### PR TITLE
Allow numerical $VERSIONINFO values to set corresponding string values

### DIFF
--- a/source/qb64.bas
+++ b/source/qb64.bas
@@ -3286,10 +3286,12 @@ DO
                 CASE "FILEVERSION#"
                     GOSUB ValidateVersion
                     viFileVersionNum$ = VersionInfoValue$
+                    if viFileVersion$ = "" THEN viFileVersion$ = viFileVersionNum$
                     layout$ = SCase$("$VersionInfo:FILEVERSION#=") + VersionInfoValue$
                 CASE "PRODUCTVERSION#"
                     GOSUB ValidateVersion
                     viProductVersionNum$ = VersionInfoValue$
+                    if viProductVersion$ = "" THEN viProductVersion$ = viProductVersionNum$
                     layout$ = SCase$("$VersionInfo:PRODUCTVERSION#=") + VersionInfoValue$
                 CASE "COMPANYNAME"
                     viCompanyName$ = VersionInfoValue$

--- a/tests/compile_tests/versioninfo2/test.bas
+++ b/tests/compile_tests/versioninfo2/test.bas
@@ -1,0 +1,2 @@
+
+$VERSIONINFO:ProductVersion#=1,2,3,4

--- a/tests/compile_tests/versioninfo3/test.bas
+++ b/tests/compile_tests/versioninfo3/test.bas
@@ -1,0 +1,3 @@
+
+$VERSIONINFO:ProductVersion#=1,2,3,4
+$VERSIONINFO:ProductVersion=1,2,3,4


### PR DESCRIPTION
The Windows resource file we create contains two separate values for FileVersion and ProductVersion. Currently, they are actually represented by two separate values in $VERSIONINFO and effectively require duplicating the information between them.

My understanding is that the string values should always be the same as the numerical versions, so to make $VERSIONINFO easier to use this changes the logic so that setting the numerical version will automatically also set the string version if values for them are not provided.

Ex. This change makes it so this:
```
$VERSIONINFO:ProductVersion#=1,2,3,4
```

Is equivalent to this:

```
$VERSIONINFO:ProductVersion#=1,2,3,4
$VERSIONINFO:ProductVerison=1,2,3,4
```

The previous version is still allowed