### PR TITLE
Fix text wrapping on last column with variable width fonts

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -14609,7 +14609,7 @@ void qbs_print(qbs *str, int32 finish_on_new_line) {
         //(only applies to non-fixed width fonts)
         if (!fontwidth[write_page->font]) { // unpredictable width
             w = chrwidth(character);
-            if ((write_page->cursor_x + w) > write_page->width) {
+            if ((write_page->cursor_x - 1 + w) > write_page->width) {
                 newline();
                 // entered_new_line not set, a character will follow
             }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 !*.bas
 results/
+exes/

--- a/tests/qbasic_tests.sh
+++ b/tests/qbasic_tests.sh
@@ -4,8 +4,10 @@
 PREFIX="QBasic"
 
 RESULTS_DIR="./tests/results/$PREFIX"
+EXES_DIR="./tests/exes/$PREFIX"
 
 mkdir -p $RESULTS_DIR
+mkdir -p $EXES_DIR
 
 QB64=$1
 
@@ -26,7 +28,7 @@ do
 
     TESTCASE=$test
 
-    "$QB64" -x  "$sourceFile" -o "./$RESULTS_DIR/$test-output.exe" 1>$RESULTS_DIR/$test-compile_result.txt
+    "$QB64" -x  "$sourceFile" -o "./$EXES_DIR/$test-output.exe" 1>$RESULTS_DIR/$test-compile_result.txt
     ERR=$?
     cp ./internal/temp/compilelog.txt $RESULTS_DIR/$test-compilelog.txt
 


### PR DESCRIPTION
Currently there is a bug where if a variable width font is in use and
text printed would exactly fit to the end of the row, it is instead
wrapped and printed on the next line.

Ex. You're printing a character that is 10 pixels wide, starting
from position 90 on an image that is 100 pixels wide. This should fit,
but instead your character will be printed on the next line.

The reason this happens is an off by one error, cursor_x (effectively
the X value passed to LOCATE) is one based even when using a variable
width font where cursor_x represents a pixel location. The location that
check if the next character can fit on the screen never handles the base
one, so it ends up treating the ending Y coordinate as one past where it
will actually end, which makes the code thing the print will go past the
edge of the screen.

To fix we simply subtract one before doing the comparison to give us the
actual ending pixel column.

I also tacked on a simple fix to stop publishing all the qbasic test exe's
into the archives on each build. It turns out each one is around 2MB
in size, so we end up archiving a few hundred MBs worth of exes.