### PR TITLE
Fix quoting in Windows-specific files in ./internal/source

### DIFF
--- a/internal/source/icon.rc
+++ b/internal/source/icon.rc
@@ -1,32 +1,32 @@
-0 ICON 'icon.ico'
+0 ICON "icon.ico"
 
-#include 'manifest.h'
+#include "manifest.h"
 
-CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST 'qb64.manifest'
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "qb64.manifest"
 
 1 VERSIONINFO
 FILEVERSION     0,6,0,0
 PRODUCTVERSION  0,6,0,0
 BEGIN
-    BLOCK 'StringFileInfo'
+    BLOCK "StringFileInfo"
     BEGIN
-        BLOCK '040904E4'
+        BLOCK "040904E4"
         BEGIN
-            VALUE 'CompanyName','QB64\0'
-            VALUE 'FileDescription','QB64 Compiler\0'
-            VALUE 'FileVersion','0,6,0,0\0'
-            VALUE 'InternalName','qb64.bas\0'
-            VALUE 'LegalCopyright','MIT\0'
-            VALUE 'LegalTrademarks','\0'
-            VALUE 'OriginalFilename','qb64.exe\0'
-            VALUE 'ProductName','QB64\0'
-            VALUE 'ProductVersion','0,6,0,0\0'
-            VALUE 'Comments','QB64 is a modern extended BASIC programming language that retains QB4.5/QBasic compatibility and compiles native binaries for Windows, Linux and macOS.\0'
-            VALUE 'Web','\0'
+            VALUE "CompanyName","QB64\0"
+            VALUE "FileDescription","QB64 Compiler\0"
+            VALUE "FileVersion","0,6,0,0\0"
+            VALUE "InternalName","qb64.bas\0"
+            VALUE "LegalCopyright","MIT\0"
+            VALUE "LegalTrademarks","\0"
+            VALUE "OriginalFilename","qb64.exe\0"
+            VALUE "ProductName","QB64\0"
+            VALUE "ProductVersion","0,6,0,0\0"
+            VALUE "Comments","QB64 is a modern extended BASIC programming language that retains QB4.5/QBasic compatibility and compiles native binaries for Windows, Linux and macOS.\0"
+            VALUE "Web","\0"
         END
     END
-    BLOCK 'VarFileInfo'
+    BLOCK "VarFileInfo"
     BEGIN
-            VALUE 'Translation', 0x409, 0x04E4
+            VALUE "Translation", 0x409, 0x04E4
     END
 END

--- a/internal/source/manifest.h
+++ b/internal/source/manifest.h
@@ -1,7 +1,7 @@
 #ifndef RESOURCE_H
 #define   RESOURCE_H
 #ifdef    __cplusplus
-extern 'C' {
+extern "C" {
 #endif
 #ifdef    __cplusplus
 }

--- a/internal/source/qb64.manifest
+++ b/internal/source/qb64.manifest
@@ -1,21 +1,21 @@
-<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
-<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
 <assemblyIdentity
-    version='1.0.0.0'
-    processorArchitecture='*'
-    name='QB64.QB64.QB64'
-    type='win32'
+    version="1.0.0.0"
+    processorArchitecture="*"
+    name="QB64.QB64.QB64"
+    type="win32"
 />
 <description>QB64 Compiler</description>
 <dependency>
     <dependentAssembly>
         <assemblyIdentity
-            type='win32'
-            name='Microsoft.Windows.Common-Controls'
-            version='6.0.0.0'
-            processorArchitecture='*'
-            publicKeyToken='6595b64144ccf1df'
-            language='*'
+            type="win32"
+            name="Microsoft.Windows.Common-Controls"
+            version="6.0.0.0"
+            processorArchitecture="*"
+            publicKeyToken="6595b64144ccf1df"
+            language="*"
         />
     </dependentAssembly>
 </dependency>


### PR DESCRIPTION
This issue was fixed in 4d61ff79, but due to how ./internal/source is
updated the new ./internal/source files were compiled using a QB64
without the fix, producing files with the wrong quoting. Previously this
was worked around because the build process overwrote these files, but
the `Makefile` build requires them to be fixed.

./internal/source itself is fine, so it's easy enough to simply fix the
files by hand. Since ./internal/source now contains a compiled QB64 that
contains the fix from 4d61ff79 it's generated files will have proper
quoting and won't need to be manually updated.