### PR TITLE
Add error handling to setup_win.bat, fix objcopy command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ ifdef BUILD_QB64
 	else
 		EXE ?= qb64
 	endif
-else
+endif
 
 ifneq ($(filter clean,$(MAKECMDGOALS)),)
 	# We have to define this for the Makefile to work,
@@ -99,8 +99,6 @@ endif
 
 ifndef EXE
 $(error Please provide executable name as 'EXE=executable')
-endif
-
 endif
 
 all: $(EXE)

--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,8 @@ clean:
 
 $(EXE): $(EXE_OBJS) $(EXE_LIBS)
 	$(CXX) $(CXXFLAGS) $(EXE_OBJS) -o $@ $(EXE_LIBS) $(CXXLIBS)
+ifneq ($(filter-out osx,$(OS)),)
 	$(OBJCOPY) --only-keep-debug $@ $(PATH_INTERNAL_TEMP)/$@.sym
 	$(OBJCOPY) --strip-unneeded $@
+endif
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,11 @@ else
 endif
 
 ifdef BUILD_QB64
-	EXE ?= qb64
+	ifeq ($(OS),win)
+		EXE ?= qb64.exe
+	else
+		EXE ?= qb64
+	endif
 else
 
 ifneq ($(filter clean,$(MAKECMDGOALS)),)

--- a/setup_win.bat
+++ b/setup_win.bat
@@ -20,7 +20,7 @@ echo Extracting %MINGW% as C++ Compiler
 :skipccompsetup
 
 internal\c\c_compiler\bin\mingw32-make.exe OS=win clean
-internal\c\c_compiler\bin\mingw32-make.exe OS=win BUILD_QB64=y
+internal\c\c_compiler\bin\mingw32-make.exe OS=win BUILD_QB64=y || goto report_error
 
 echo.
 echo Launching 'QB64'
@@ -28,3 +28,10 @@ qb64
 
 echo.
 pause
+
+exit 0
+
+report_error:
+echo "Error compiling QB64."
+echo "Please review above steps and report to https://github.com/QB64-Phoenix-Edition/QB64pe/issues if you can't get it to work"
+exit 1

--- a/setup_win.bat
+++ b/setup_win.bat
@@ -20,7 +20,7 @@ echo Extracting %MINGW% as C++ Compiler
 :skipccompsetup
 
 echo Cleaning...
-internal\c\c_compiler\bin\mingw32-make.exe OS=win clean >NUL
+internal\c\c_compiler\bin\mingw32-make.exe OS=win clean >NUL 2>NUL
 
 echo Building QB64...
 internal\c\c_compiler\bin\mingw32-make.exe OS=win BUILD_QB64=y || goto report_error

--- a/setup_win.bat
+++ b/setup_win.bat
@@ -19,10 +19,10 @@ echo Extracting %MINGW% as C++ Compiler
 
 :skipccompsetup
 
-echo "Cleaning..."
+echo Cleaning...
 internal\c\c_compiler\bin\mingw32-make.exe OS=win clean >NUL
 
-echo "Building QB64..."
+echo Building QB64...
 internal\c\c_compiler\bin\mingw32-make.exe OS=win BUILD_QB64=y || goto report_error
 
 echo.

--- a/setup_win.bat
+++ b/setup_win.bat
@@ -19,7 +19,10 @@ echo Extracting %MINGW% as C++ Compiler
 
 :skipccompsetup
 
-internal\c\c_compiler\bin\mingw32-make.exe OS=win clean
+echo "Cleaning..."
+internal\c\c_compiler\bin\mingw32-make.exe OS=win clean >NUL
+
+echo "Building QB64..."
 internal\c\c_compiler\bin\mingw32-make.exe OS=win BUILD_QB64=y || goto report_error
 
 echo.


### PR DESCRIPTION
The `setup_win.bat` was not previously reporting an error if the compilation fails, so I changed it to indicate that something went wrong and report an exit code. This has the benefit that it will fail the build if there is something wrong with the `setup_win.bat` test.

Also, the `objcopy` is bugged on Windows and does not work on OSX, so I'm going to modify the logic to work on Windows and simply remove the functionality from OSX.