### PR TITLE
Fix various identified Makefile issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,7 @@ clean:
 	$(RM) $(call FIXPATH,$(CLEAN_LIST))
 
 $(EXE): $(EXE_OBJS) $(EXE_LIBS)
-	$(CXX) $(CXXFLAGS) $(EXE_OBJS) -o $@ $(EXE_LIBS) $(CXXLIBS)
+	$(CXX) $(CXXFLAGS) $(EXE_OBJS) -o "$@" $(EXE_LIBS) $(CXXLIBS)
 ifneq ($(filter-out osx,$(OS)),)
 	$(OBJCOPY) --only-keep-debug "$@" "$(PATH_INTERNAL_TEMP)/$(notdir $@).sym"
 	$(OBJCOPY) --strip-unneeded "$@"

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ endif
 
 QB_QBX_OBJ := $(PATH_INTERNAL_C)/qbx$(TEMP_ID).o
 
-$(QB_QBX_OBJ): $(wildcard $(PATH_INTERNAL)/temp/*.txt)
+$(QB_QBX_OBJ): $(wildcard $(PATH_INTERNAL)/temp$(TEMP_ID)/*.txt)
 
 EXE_OBJS += $(QB_QBX_OBJ)
 

--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ clean:
 $(EXE): $(EXE_OBJS) $(EXE_LIBS)
 	$(CXX) $(CXXFLAGS) $(EXE_OBJS) -o $@ $(EXE_LIBS) $(CXXLIBS)
 ifneq ($(filter-out osx,$(OS)),)
-	$(OBJCOPY) --only-keep-debug $@ $(PATH_INTERNAL_TEMP)/$@.sym
-	$(OBJCOPY) --strip-unneeded $@
+	$(OBJCOPY) --only-keep-debug "$@" "$(PATH_INTERNAL_TEMP)/$(notdir $@).sym"
+	$(OBJCOPY) --strip-unneeded "$@"
 endif
 

--- a/source/global/version.bas
+++ b/source/global/version.bas
@@ -1,9 +1,9 @@
 DIM SHARED Version AS STRING
 DIM SHARED IsCiVersion AS _BYTE
 
-Version$ = "0.6.0"
-$VERSIONINFO:FileVersion#=0,6,0,0
-$VERSIONINFO:ProductVersion#=0,6,0,0
+Version$ = "0.7.1"
+$VERSIONINFO:FileVersion#=0,7,1,0
+$VERSIONINFO:ProductVersion#=0,7,1,0
 
 ' If ./internal/version.txt exist, then this is some kind of CI build with a label
 If _FILEEXISTS("internal/version.txt") THEN

--- a/source/qb64.bas
+++ b/source/qb64.bas
@@ -12514,7 +12514,7 @@ END IF
 
 CxxLibsExtra$ = mylib$ + " " + mylibopt$
 
-makeline$ = make$ + makedeps$ + " EXE=" + AddQuotes$(path.exe$ + file$ + extension$)
+makeline$ = make$ + makedeps$ + " EXE=" + AddQuotes$(StrReplace$(path.exe$ + file$ + extension$, " ", "\ "))
 makeline$ = makeline$ + " CXXFLAGS_EXTRA=" + AddQuotes$(CxxFlagsExtra$)
 makeline$ = makeline$ + " CFLAGS_EXTRA=" + AddQuotes$(CxxFlagsExtra$) ' Just the -O flag, use for C files as well
 makeline$ = makeline$ + " CXXLIBS_EXTRA=" + AddQuotes$(CxxLibsExtra$)

--- a/tests/compile_tests.sh
+++ b/tests/compile_tests.sh
@@ -21,29 +21,31 @@ show_incorrect_result()
     printf "GOT:      '%s'\n" "$2"
 }
 
-for test in $(ls ./tests/compile_tests)
+for test in ./tests/compile_tests/*
 do 
-    TESTCASE=$test
-    EXE="$RESULTS_DIR/$test-output"
+    test=$(basename "$test")
+
+    TESTCASE="$test"
+    EXE="$RESULTS_DIR/$test - output"
 
     # Clear out temp folder before next compile, avoids stale compilelog files
     rm -fr ./internal/temp/*
 
-    "$QB64" -x  "./tests/compile_tests/$test/test.bas" -o "$EXE" 1>$RESULTS_DIR/$test-compile_result.txt
+    "$QB64" -x  "./tests/compile_tests/$test/test.bas" -o "$EXE" 1>"$RESULTS_DIR/$test-compile_result.txt"
     ERR=$?
-    cp_if_exists ./internal/temp/compilelog.txt $RESULTS_DIR/$test-compilelog.txt
+    cp_if_exists ./internal/temp/compilelog.txt "$RESULTS_DIR/$test-compilelog.txt"
 
     (exit $ERR)
-    assert_success_named "Compile" "Compilation Error:" show_failure $test
+    assert_success_named "Compile" "Compilation Error:" show_failure "$test"
 
     test -f "$EXE"
-    assert_success_named "exe exists" "$test-output executable does not exist!" show_failure $test
+    assert_success_named "exe exists" "$test-output executable does not exist!" show_failure "$test"
 
     if [ ! -f "./tests/compile_tests/$test/test.output" ]; then
         continue
     fi
 
-    expectedResult="$(cat ./tests/compile_tests/$test/test.output)"
+    expectedResult="$(cat "./tests/compile_tests/$test/test.output")"
 
     pushd . > /dev/null
     cd "./tests/compile_tests/$test"


### PR DESCRIPTION
The commits include more detail descriptions, but brief descriptions of the fixes

1. qbx.o always listed `./internal/temp/*.txt` as the dependencies, rather than using the proper `temp*` directory depending upon the ID being used. This meant `qbx.o` would not always get recompiled when it should.
2. The `.sym` files was not getting correctly generated because the directory was left in the name, producing an invalid path. The fix is to just strip the leading path off, which is what I intended when I put it in.
3. Compiling executables with spaces in their name or path would not work. This is an issue with Make, but I was able to work around it since the executable name is not a list and is the only thing that's a path we don't control. I added testing for this as well.

I also bumped the next version to `0.7.1`. It's probably worth getting a patch release out after this is merged since these will probably be messy issues for people. It would also fix the versioning of `0.7.0`.

Fixes: #80 
Fixes: #81 

---

As a general note, there is not yet automated testing of multiple qb64 instances running at the same time. I'd like to add this but it will get a bit messy so I'm skipping it for the moment. It should definitely be possible though, with a little bit of work.