### PR TITLE
Add missing test for directory with spaces

### DIFF
--- a/tests/compile_tests/name with spaces/test.bas
+++ b/tests/compile_tests/name with spaces/test.bas
@@ -1,0 +1,4 @@
+$CONSOLE:ONLY
+
+Print "Hello, World!";
+SYSTEM

--- a/tests/compile_tests/name with spaces/test.output
+++ b/tests/compile_tests/name with spaces/test.output
@@ -1,0 +1,1 @@
+Hello, World!


### PR DESCRIPTION
I meant to add this test in my previous PR but it got missed. It's not extremely important because I put a space in all of the test executable names, but this adds a test that includes a space in the directory name for the executable as well.