### PR TITLE
Remove 32-bit/64-bit distinction from Linux and OSX artifact name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: qb64-${{ matrix.prefix }}-${{ matrix.platform }}
+        name: qb64-${{ matrix.prefix }}${{ matrix.prefix == 'win' && format('-{0}', matrix.platform) || '' }}
         path: |
           tests/results/
           qb64_win-x86.7z


### PR DESCRIPTION
The OSX and Linux build artifacts have `x64` in the name even though they're both 32-bit and 64-bit compatible. It's causes some confusion.

Fixes: #78