### PR TITLE
Add ide compiler settings dialog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,11 @@ endif
 
 ifeq ($(OS),osx)
 	CXXLIBS += -framework OpenGL -framework IOKit -framework GLUT -framework Cocoa
+
+	# OSX doesn't strip using objcopy, so we're using `-s` instead
+	ifneq ($(STRIP_SYMBOLS),n)
+		CXXLIBS += -s
+	endif
 endif
 
 QB_QBX_OBJ := $(PATH_INTERNAL_C)/qbx$(TEMP_ID).o
@@ -344,7 +349,9 @@ clean:
 $(EXE): $(EXE_OBJS) $(EXE_LIBS)
 	$(CXX) $(CXXFLAGS) $(EXE_OBJS) -o "$@" $(EXE_LIBS) $(CXXLIBS)
 ifneq ($(filter-out osx,$(OS)),)
+ifneq ($(STRIP_SYMBOLS),n)
 	$(OBJCOPY) --only-keep-debug "$@" "$(PATH_INTERNAL_TEMP)/$(notdir $@).sym"
 	$(OBJCOPY) --strip-unneeded "$@"
+endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ all: $(EXE)
 
 CLEAN_LIST :=
 
-CXXFLAGS := -w
+CXXFLAGS += -w
 
 ifeq ($(OS),lnx)
 	CXXLIBS += -lGL -lGLU -lX11 -lpthread -ldl -lrt

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -108,6 +108,7 @@ These flags control some basic settings for how the `Makefile` can compile the p
 | `CXXFLAGS_EXTRA` | None | Collection of C++ compiler flags | No | These flags are provided to the compiler when building the C++ files. This includes the generate source files, but also files like `libqb.cpp`. |
 | `CXXLIBS_EXTRA` | None | Collection of linker flags | No | These flags are provided to the compiler (`g++` or `clang++`) when linking the final executable. Typically includes the `-l` library flags |
 | `CFLAGS_EXTRA` | None | Collection of C compiler flags | No | These flags are provided to the compiler when building C files |
+| `STRIP_SYMBOLS` | None | `n` | No | Symbols are stripped by default, if this is `n` then symbols will not be stripped from the executable |
 
 These flags controls whether certain dependencies are compiled in or not. All of them are blank by default and should be set to `y` to use them. Note that the program being built may not compile if you supply the wrong dependency settings - may of them supply functions that will not be defined if the dependency is required, and some of them (Ex. `DEP_GL`) have requirements the program being compiled must meet.
 

--- a/setup_lnx.sh
+++ b/setup_lnx.sh
@@ -110,7 +110,7 @@ fi
 
 echo "Compiling and installing QB64..."
 make clean
-make OS=lnx BUILD_QB64=y
+make OS=lnx BUILD_QB64=y -j3
 
 if [ -e "./qb64" ]; then
   echo "Done compiling!!"

--- a/setup_osx.command
+++ b/setup_osx.command
@@ -27,7 +27,7 @@ fi
 
 echo "Building 'QB64'"
 make OS=osx clean
-make OS=osx BUILD_QB64=y
+make OS=osx BUILD_QB64=y -j3
 
 echo ""
 if [ -f ./qb64 ]; then

--- a/source/global/IDEsettings.bas
+++ b/source/global/IDEsettings.bas
@@ -18,8 +18,13 @@ DIM SHARED WatchListToConsole AS _BYTE
 DIM SHARED windowSettingsSection$, colorSettingsSection$, customDictionarySection$
 DIM SHARED mouseSettingsSection$, generalSettingsSection$, displaySettingsSection$
 DIM SHARED colorSchemesSection$, debugSettingsSection$, iniFolderIndex$, DebugInfoIniWarning$, ConfigFile$
+DIM SHARED compilerSettingsSection$
 DIM SHARED idebaseTcpPort AS LONG, AutoAddDebugCommand AS _BYTE
 DIM SHARED wikiBaseAddress$
+DIM SHARED MaxParallelProcesses AS _UNSIGNED LONG
+DIM SHARED ExtraCppFlags AS STRING, ExtraLinkerFlags AS STRING
+DIM SHARED StripDebugSymbols AS _UNSIGNED LONG
+DIM SHARED OptimizeCppProgram AS _UNSIGNED LONG
 
 ConfigFile$ = "internal/config.ini"
 iniFolderIndex$ = STR$(tempfolderindex)
@@ -33,6 +38,7 @@ mouseSettingsSection$ = "MOUSE SETTINGS"
 generalSettingsSection$ = "GENERAL SETTINGS"
 displaySettingsSection$ = "IDE DISPLAY SETTINGS"
 debugSettingsSection$ = "DEBUG SETTINGS"
+compilerSettingsSection$ = "COMPILER SETTINGS"
 
 IniSetAddQuotes 0
 IniSetForceReload -1
@@ -520,6 +526,15 @@ IF ReadConfigSetting(colorSettingsSection$, "BackgroundColor2", value$) THEN
     IDEBackgroundColor2 = VRGBS(value$, IDEBackgroundColor2)
 ELSE WriteConfigSetting colorSettingsSection$, "BackgroundColor2", rgbs$(IDEBackgroundColor2)
 END IF
+
+'Compiler Settings ------------------------------------------------------------
+OptimizeCppProgram = ReadWriteBooleanSettingValue%(compilerSettingsSection$, "OptimizeCppProgram", 0)
+StripDebugSymbols = ReadWriteBooleanSettingValue%(compilerSettingsSection$, "StripDebugSymbols", -1)
+
+MaxParallelProcesses = ReadWriteLongSettingValue&(compilerSettingsSection$, "MaxParallelProcesses", 3)
+
+ExtraCppFlags = ReadWriteStringSettingValue$(compilerSettingsSection$, "ExtraCppFlags", "")
+ExtraLinkerFlags = ReadWriteStringSettingValue$(compilerSettingsSection$, "ExtraLinkerFlags", "")
 
 'End of initial settings ------------------------------------------------------
 

--- a/source/global/IDEsettings.bas
+++ b/source/global/IDEsettings.bas
@@ -17,7 +17,7 @@ DIM SHARED WhiteListQB64FirstTimeMsg AS _BYTE, ideautolayoutkwcapitals AS _BYTE
 DIM SHARED WatchListToConsole AS _BYTE
 DIM SHARED windowSettingsSection$, colorSettingsSection$, customDictionarySection$
 DIM SHARED mouseSettingsSection$, generalSettingsSection$, displaySettingsSection$
-DIM SHARED colorSchemesSection$, debugSettingsSection$, iniFolderIndex$, DebugInfoIniWarning$, ConfigFile$
+DIM SHARED colorSchemesSection$, debugSettingsSection$, iniFolderIndex$, ConfigFile$
 DIM SHARED compilerSettingsSection$
 DIM SHARED idebaseTcpPort AS LONG, AutoAddDebugCommand AS _BYTE
 DIM SHARED wikiBaseAddress$
@@ -28,7 +28,6 @@ DIM SHARED OptimizeCppProgram AS _UNSIGNED LONG
 
 ConfigFile$ = "internal/config.ini"
 iniFolderIndex$ = STR$(tempfolderindex)
-DebugInfoIniWarning$ = " 'Do not change manually. Use 'qb64 -s', or Debug->Advanced in the IDE"
 
 windowSettingsSection$ = "IDE WINDOW" + iniFolderIndex$
 colorSettingsSection$ = "IDE COLOR SETTINGS" + iniFolderIndex$
@@ -217,9 +216,9 @@ IF idebackupsize < 10 OR idebackupsize > 2000 THEN idebackupsize = 100: WriteCon
 
 result = ReadConfigSetting(generalSettingsSection$, "DebugInfo", value$)
 idedebuginfo = VAL(value$)
-IF UCASE$(LEFT$(value$, 4)) = "TRUE" THEN idedebuginfo = 1
-IF result = 0 OR idedebuginfo <> 1 THEN
-    WriteConfigSetting generalSettingsSection$, "DebugInfo", "False" + DebugInfoIniWarning$
+IF UCASE$(LEFT$(value$, 4)) = "TRUE" THEN idedebuginfo = -1
+IF result = 0 OR idedebuginfo <> -1 THEN
+    WriteConfigSetting generalSettingsSection$, "DebugInfo", "False"
     idedebuginfo = 0
 END IF
 Include_GDB_Debugging_Info = idedebuginfo

--- a/source/qb64.bas
+++ b/source/qb64.bas
@@ -12505,19 +12505,33 @@ IF ExeIconSet OR VersionInfoSet THEN makedeps$ = makedeps$ + " DEP_ICON_RC=y"
 
 IF tempfolderindex > 1 THEN makedeps$ = makedeps$ + " TEMP_ID=" + str2$(tempfolderindex)
 
-CxxFlagsExtra$ = ""
-CxxLibsExtra$ = ""
+CxxFlagsExtra$ = ExtraCppFlags
+CxxLibsExtra$ = ExtraLinkerFlags
 
-IF Include_GDB_Debugging_Info THEN
-    CxxFlagsExtra$ = "-g"
+' If debugging then use `-Og` rather than `-O2`
+IF OptimizeCppProgram THEN
+    IF Include_GDB_Debugging_Info THEN
+        CxxFlagsExtra$ = CxxFlagsExtra$ + " -Og"
+    ELSE
+        CxxFlagsExtra$ = CxxFlagsExtra$ + " -O2"
+    END IF
+ELSE
+    IF Include_GDB_Debugging_Info THEN
+        CxxFlagsExtra$ = CxxFlagsExtra$ + " -g"
+    END IF
 END IF
 
-CxxLibsExtra$ = mylib$ + " " + mylibopt$
+CxxLibsExtra$ = CxxLibsExtra$ + " " + mylib$ + " " + mylibopt$
 
 makeline$ = make$ + makedeps$ + " EXE=" + AddQuotes$(StrReplace$(path.exe$ + file$ + extension$, " ", "\ "))
-makeline$ = makeline$ + " CXXFLAGS_EXTRA=" + AddQuotes$(CxxFlagsExtra$)
-makeline$ = makeline$ + " CFLAGS_EXTRA=" + AddQuotes$(CxxFlagsExtra$) ' Just the -O flag, use for C files as well
-makeline$ = makeline$ + " CXXLIBS_EXTRA=" + AddQuotes$(CxxLibsExtra$)
+makeline$ = makeline$ + " " + AddQuotes$("CXXFLAGS_EXTRA=" + CxxFlagsExtra$)
+makeline$ = makeline$ + " " + AddQuotes$("CFLAGS_EXTRA=" + CxxFlagsExtra$)
+makeline$ = makeline$ + " " + AddQuotes$("CXXLIBS_EXTRA=" + CxxLibsExtra$)
+makeline$ = makeline$ + " -j" + AddQuotes$(str2$(MaxParallelProcesses))
+
+IF NOT StripDebugSymbols THEN
+    makeline$ = makeline$ + " STRIP_SYMBOLS=n"
+END IF
 
 IF os$ = "WIN" THEN
 
@@ -13156,7 +13170,7 @@ FUNCTION ParseCMDLineArgs$ ()
                     CASE ":debuginfo=true"
                         PRINT "debuginfo = true"
                         WriteConfigSetting generalSettingsSection$, "DebugInfo", "True" + DebugInfoIniWarning$
-                        idedebuginfo = 1
+                        idedebuginfo = -1
                         Include_GDB_Debugging_Info = idedebuginfo
                         PurgeTemporaryBuildFiles (os$), (MacOSX)
                     CASE ":debuginfo=false"

--- a/source/utilities/strings.bas
+++ b/source/utilities/strings.bas
@@ -35,3 +35,91 @@ END FUNCTION
 FUNCTION AddQuotes$ (s$)
     AddQuotes$ = CHR$(34) + s$ + CHR$(34)
 END FUNCTION
+
+'
+' Convert a boolean value to 'True' or 'False'
+'
+FUNCTION BoolToTFString$ (b AS LONG)
+    IF b THEN
+        BoolToTFString$ = "True"
+    ELSE
+        BoolToTFString$ = "False"
+    END IF
+END FUNCTION
+
+'
+' Convert 'True' or 'False' to a boolean value
+'
+' Any string not 'True' or 'False' is returned as -2
+'
+FUNCTION TFStringToBool% (s AS STRING)
+    DIM s2 AS STRING
+    s2 = _TRIM$(UCASE$(s))
+
+    IF s2 = "TRUE" THEN
+        TFStringToBool% = -1
+    ELSEIF s2 = "FALSE" THEN
+        TFStringToBool% = 0
+    ELSE
+        TFStringToBool% = -2
+    END IF
+END FUNCTION
+
+'
+' Reads the bool setting at section:setting. If it is not there or invalid, writes the default value to it
+'
+FUNCTION ReadWriteBooleanSettingValue% (section AS STRING, setting AS STRING, default AS INTEGER)
+    DIM checkResult AS INTEGER
+    DIM value AS STRING
+    DIM result AS INTEGER
+
+    result = ReadConfigSetting(section, setting, value)
+
+    checkResult = TFStringToBool%(value)
+
+    IF checkResult = -2 THEN
+        WriteConfigSetting section, setting, BoolToTFString$(default)
+        ReadWriteBooleanSettingValue% = default
+    ELSE
+        ReadWriteBooleanSettingValue% = checkResult
+    END IF
+END FUNCTION
+
+'
+' Reads the string setting at section:setting. If it is not there or invalid, writes the default value to it
+'
+FUNCTION ReadWriteStringSettingValue$ (section AS STRING, setting AS STRING, default AS STRING)
+    DIM value AS STRING
+    DIM result AS INTEGER
+
+    result = ReadConfigSetting(section, setting, value)
+
+    IF result = 0 THEN
+        WriteConfigSetting section, setting, default
+        ReadWriteStringSettingValue$ = default
+    ELSE
+        ReadWriteStringSettingValue$ = value
+    END IF
+END FUNCTION
+
+'
+' Reads the integer setting at section:setting. If it is not there or invalid, writes the default value to it
+'
+' Verfies the value is positive and non-zero
+'
+FUNCTION ReadWriteLongSettingValue& (section AS STRING, setting AS STRING, default AS LONG)
+    DIM value AS STRING
+    DIM result AS INTEGER
+    DIM checkResult AS LONG
+
+    result = ReadConfigSetting(section, setting, value)
+
+    checkResult = VAL(value)
+
+    IF result = 0 OR checkResult <= 0 THEN
+        WriteConfigSetting section, setting, str2$(default)
+        ReadWriteLongSettingValue& = default
+    ELSE
+        ReadWriteLongSettingValue& = checkResult
+    END IF
+END FUNCTION


### PR DESCRIPTION
The new dialogs includes 5 settings:

1. Flag to turn on Optimization (off by default)
2. Flag to strip symbols (On by default)
3. String for extra compiler flags
4. String for extra linker flags
5. Setting for max compiler processes (default of 3)

The "Advanced (C++)" dialog was removed, putting the single setting into
the new C++ Compiler Settings dialog.

Fixes: #65
Fixes: #40 