### PR TITLE
Fix compilation of files with $ in the name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,11 +347,11 @@ clean:
 	$(RM) $(call FIXPATH,$(CLEAN_LIST))
 
 $(EXE): $(EXE_OBJS) $(EXE_LIBS)
-	$(CXX) $(CXXFLAGS) $(EXE_OBJS) -o "$@" $(EXE_LIBS) $(CXXLIBS)
+	$(CXX) $(CXXFLAGS) $(EXE_OBJS) -o '$@' $(EXE_LIBS) $(CXXLIBS)
 ifneq ($(filter-out osx,$(OS)),)
 ifneq ($(STRIP_SYMBOLS),n)
-	$(OBJCOPY) --only-keep-debug "$@" "$(PATH_INTERNAL_TEMP)/$(notdir $@).sym"
-	$(OBJCOPY) --strip-unneeded "$@"
+	$(OBJCOPY) --only-keep-debug '$@' '$(PATH_INTERNAL_TEMP)/$(notdir $@).sym'
+	$(OBJCOPY) --strip-unneeded '$@'
 endif
 endif
 

--- a/source/qb64.bas
+++ b/source/qb64.bas
@@ -12523,7 +12523,12 @@ END IF
 
 CxxLibsExtra$ = CxxLibsExtra$ + " " + mylib$ + " " + mylibopt$
 
-makeline$ = make$ + makedeps$ + " EXE=" + AddQuotes$(StrReplace$(path.exe$ + file$ + extension$, " ", "\ "))
+' Make and the shell don't like certain characters in the file name, so we
+' escape them to get them to handle them properly
+escapedExe$ = StrReplace$(path.exe$ + file$ + extension$, " ", "\ ")
+escapedExe$ = StrReplace$(escapedExe$, "$", "$$")
+
+makeline$ = make$ + makedeps$ + " EXE=" + AddQuotes$(escapedExe$)
 makeline$ = makeline$ + " " + AddQuotes$("CXXFLAGS_EXTRA=" + CxxFlagsExtra$)
 makeline$ = makeline$ + " " + AddQuotes$("CFLAGS_EXTRA=" + CxxFlagsExtra$)
 makeline$ = makeline$ + " " + AddQuotes$("CXXLIBS_EXTRA=" + CxxLibsExtra$)


### PR DESCRIPTION
This is a bit of an odd one, but files with $ in the name don't compile
correctly due to expansion being done on the $.

The culprit here is `make`, as the syntax '$x' is interpreted to mean to
insert the expansion of the variable 'x'. To avoid this behavior we have
to replace every single $ with `$$`. Make will interpret the `$$` to mean it
should insert a single $ and not do any expansion, which is what we
want.

Fixes: #96