### PR TITLE
The C++ settings menu reuses existing shortcut key

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -399,7 +399,7 @@ FUNCTION ide2 (ignore)
         menuDesc$(m, i - 1) = "Changes or customizes IDE color scheme"
         menu$(m, i) = "#Code Layout...": i = i + 1
         menuDesc$(m, i - 1) = "Changes auto-format features"
-        menu$(m, i) = "C++ C#ompiler Settings...": i = i + 1
+        menu$(m, i) = "C++ Co#mpiler Settings...": i = i + 1
         menuDesc$(m, i - 1) = "Change settings for compiling the C++ code"
         menu$(m, i) = "-": i = i + 1
         menu$(m, i) = "#Language...": i = i + 1


### PR DESCRIPTION
The C++ compiler Settings menu uses the shortcut key 'o', but that's
actually already in use and thus creates a conflict. We're switching it
to use the option 'm', which does not conflict.

Fixes: #105