### PR TITLE
Add version to artifact name

### DIFF
--- a/.ci/common-exclusion.list
+++ b/.ci/common-exclusion.list
@@ -1,9 +1,0 @@
-.ci
-.travis
-.travis.yml
-appveyor.yml
-.git
-.gitignore
-.github
-setup_win.bat
-internal\c\mingw

--- a/.ci/lnx-exclusion.list
+++ b/.ci/lnx-exclusion.list
@@ -1,3 +1,0 @@
-setup_macos.command
-internal/c/c_compiler
-qb64_start_osx.command

--- a/.ci/make-dist.sh
+++ b/.ci/make-dist.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 buildPlatform=$1
+version=$2
 format=
 
 ARCHIVE_ROOT=qb64
@@ -44,7 +45,7 @@ cp -p ./internal/c/*      $DIST_ROOT/internal/c/
 
 case "$buildPlatform" in
     windows-latest)
-        filename="qb64_win-$PLATFORM.7z"
+        filename="qb64_win-$PLATFORM-$version.7z"
 
         format=7zip
 
@@ -53,7 +54,7 @@ case "$buildPlatform" in
         ;;
 
     ubuntu-latest)
-        filename="qb64_lnx.tar.gz"
+        filename="qb64_lnx-$version.tar.gz"
         format=tar
 
         # Not sure if we should distribute this
@@ -62,7 +63,7 @@ case "$buildPlatform" in
         ;;
 
     macos-latest)
-        filename="qb64_osx.tar.gz"
+        filename="qb64_osx-$version.tar.gz"
         format=tar
 
         cp -p ./qb64_start.command $DIST_ROOT

--- a/.ci/osx-exclusion.list
+++ b/.ci/osx-exclusion.list
@@ -1,2 +1,0 @@
-setup_lnx.sh
-internal/c/c_compiler

--- a/.ci/read-version.sh
+++ b/.ci/read-version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Pull the version out of the QB64 source. A little ugly but we're match for the first assignment line
+versionLine=$(cat ./source/global/version.bas | grep "Version\$ = " | head -n 1 | tr -d '\n' | tr -d '\r')
+
+# This uses a regular expression to pull the X.Y.Z version out of the assignment line
+version=$(echo "$versionLine" | sed -r 's/^Version\$ = "([0-9]*\.[0-9]*\.[0-9]*)"/\1/' | tr -d '\n')
+
+# if ./internal/version.txt exists, then we have a tag at the end of our version number
+# (IE. non-release version)
+if [ -f "./internal/version.txt" ]
+then
+    version="$version$(cat ./internal/version.txt | tr -d '\n' | tr -d '\r')"
+fi
+
+printf "$version"

--- a/.ci/win-exclusion.list
+++ b/.ci/win-exclusion.list
@@ -1,4 +1,0 @@
-setup_lnx.sh
-setup_osx.command
-qb64_start_osx.command
-secure-file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
       shell: bash
       run: .ci/calculate_version.sh
 
+    - name: Read version for artifacts
+      shell: bash
+      run: echo "version=$(.ci/read-version.sh)" >> $GITHUB_ENV
+
     - name: Bootstrap compiler Linux/OSX
       if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
       run: .ci/bootstrap.sh ${{ matrix.prefix }}
@@ -79,7 +83,7 @@ jobs:
 
     - name: Create QB64 Artifact
       shell: bash
-      run: .ci/make-dist.sh ${{ matrix.os }}
+      run: .ci/make-dist.sh ${{ matrix.os }} "${{ env.version }}"
 
       # Note that compiling programs in dist does modify the ./dist and make it
       # dirty, but that's ok because we've already create the .7z or .tar.gz
@@ -98,13 +102,13 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: always()
       with:
-        name: qb64-${{ matrix.prefix }}${{ matrix.prefix == 'win' && format('-{0}', matrix.platform) || '' }}
+        name: qb64-${{ matrix.prefix }}${{ matrix.prefix == 'win' && format('-{0}', matrix.platform) || '' }}-${{ env.version }}
         path: |
           tests/results/
-          qb64_win-x86.7z
-          qb64_win-x64.7z
-          qb64_lnx.tar.gz
-          qb64_osx.tar.gz
+          qb64_win-x86*.7z
+          qb64_win-x64*.7z
+          qb64_lnx*.tar.gz
+          qb64_osx*.tar.gz
 
     - name: Create release
       if: startsWith(github.ref, 'refs/tags/v')
@@ -112,9 +116,9 @@ jobs:
       with:
         draft: true
         files: |
-          qb64_win-x86.7z
-          qb64_win-x64.7z
-          qb64_lnx.tar.gz
-          qb64_osx.tar.gz
+          qb64_win-x86*.7z
+          qb64_win-x64*.7z
+          qb64_lnx*.tar.gz
+          qb64_osx*.tar.gz
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The artifacts like `qb64-lnx.tar.gz` will now also include the version
in their name, making them `qb64-lnx-X.Y.Z.tar.gz` instead.

Fixes: #104 