### PR TITLE
Fix C++ compiler settings menu

### DIFF
--- a/source/global/version.bas
+++ b/source/global/version.bas
@@ -1,9 +1,9 @@
 DIM SHARED Version AS STRING
 DIM SHARED IsCiVersion AS _BYTE
 
-Version$ = "0.8.1"
-$VERSIONINFO:FileVersion#=0,8,1,0
-$VERSIONINFO:ProductVersion#=0,8,1,0
+Version$ = "0.8.2"
+$VERSIONINFO:FileVersion#=0,8,2,0
+$VERSIONINFO:ProductVersion#=0,8,2,0
 
 ' If ./internal/version.txt exist, then this is some kind of CI build with a label
 If _FILEEXISTS("internal/version.txt") THEN

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -5100,7 +5100,7 @@ FUNCTION ide2 (ignore)
                 GOTO ideloop
             END IF
 
-            IF menu$(m, s) = "C++ C#ompiler Settings..." THEN
+            IF menu$(m, s) = "C++ Co#mpiler Settings..." THEN
                 PCOPY 2, 0
                 retval = ideCompilerSettingsBox
                 IF retval THEN idechangemade = 1: idelayoutallow = 2: startPausedPending = 0 'recompile if options changed


### PR DESCRIPTION
#107 broke the C++ Compiler Settings menu because I forgot to update the string where we check of menu was clicked :-/

This also bumps to v0.8.2, so we can make a release with this fix.

I made sure to test it with the correct compiled copy of QB64 this time 🤦 ...