### PR TITLE
Add separate libqb folder with new APIs, along with C++ automated testing.

### DIFF
--- a/.ci/compile.bat
+++ b/.ci/compile.bat
@@ -8,4 +8,8 @@ del qb64_bootstrap.exe
 del /q /s internal\source\*
 move internal\temp\* internal\source\
 
+REM Build libqb test executables
+internal\c\c_compiler\bin\mingw32-make.exe -j8 OS=win build-tests
+
 internal\c\c_compiler\bin\mingw32-make.exe OS=win clean
+

--- a/.ci/compile.sh
+++ b/.ci/compile.sh
@@ -13,6 +13,10 @@ rm internal/temp/qb64_bootstrap.sym
 
 mv internal/temp/* internal/source/
 
+
+# Build libqb test executables
+make -j8 OS=$os build-tests
+
 make clean OS=$os
 
 exit $SUCCESS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,10 @@ jobs:
       if: ${{ matrix.os == 'windows-latest' }}
       run: .ci/compile.bat
 
+    - name: Test libqb
+      shell: bash
+      run: tests/run_c_tests.sh
+
     - name: Print QB64 Version
       run: ./qb64 -?
 

--- a/Makefile
+++ b/Makefile
@@ -379,3 +379,5 @@ ifneq ($(STRIP_SYMBOLS),n)
 endif
 endif
 
+-include ./tests/build.mk
+

--- a/internal/c/libqb/build.mk
+++ b/internal/c/libqb/build.mk
@@ -1,0 +1,2 @@
+
+CLEAN_LIST += $(libqb-objs-y)

--- a/internal/c/libqb/build.mk
+++ b/internal/c/libqb/build.mk
@@ -1,4 +1,6 @@
 
+libqb-objs-y += $(PATH_LIBQB)/src/threading.o
+
 libqb-objs-y += $(PATH_LIBQB)/src/threading-$(PLATFORM).o
 
 CLEAN_LIST += $(libqb-objs-y)

--- a/internal/c/libqb/build.mk
+++ b/internal/c/libqb/build.mk
@@ -1,5 +1,6 @@
 
 libqb-objs-y += $(PATH_LIBQB)/src/threading.o
+libqb-objs-y += $(PATH_LIBQB)/src/buffer.o
 
 libqb-objs-y += $(PATH_LIBQB)/src/threading-$(PLATFORM).o
 

--- a/internal/c/libqb/build.mk
+++ b/internal/c/libqb/build.mk
@@ -1,2 +1,4 @@
 
+libqb-objs-y += $(PATH_LIBQB)/src/threading-$(PLATFORM).o
+
 CLEAN_LIST += $(libqb-objs-y)

--- a/internal/c/libqb/include/buffer.h
+++ b/internal/c/libqb/include/buffer.h
@@ -1,0 +1,34 @@
+#ifndef INCLUDE_LIBQB_BUFFER_H
+#define INCLUDE_LIBQB_BUFFER_H
+
+struct libqb_buffer_entry {
+    size_t length;
+    char *data;
+    struct libqb_buffer_entry *next;
+};
+
+struct libqb_buffer {
+    size_t total_length;
+    size_t cur_entry_offset;
+
+    struct libqb_buffer_entry *head;
+    struct libqb_buffer_entry **tail;
+};
+
+void libqb_buffer_init(struct libqb_buffer *);
+
+// Free's all data used by the buffer.
+void libqb_buffer_clear(struct libqb_buffer *);
+
+// Returns the current length of the buffer.
+size_t libqb_buffer_length(struct libqb_buffer *);
+
+// Reads data from the buffer. The data read is removed from the buffer
+//
+// Returns the number of bytes actually read
+size_t libqb_buffer_read(struct libqb_buffer *, char *, size_t length);
+
+// Writes data into the buffer
+void libqb_buffer_write(struct libqb_buffer *, const char *, size_t length);
+
+#endif

--- a/internal/c/libqb/include/completion.h
+++ b/internal/c/libqb/include/completion.h
@@ -1,0 +1,26 @@
+#ifndef INCLUDE_LIBQB_COMPLETION_H
+#define INCLUDE_LIBQB_COMPLETION_H
+
+#include "mutex.h"
+#include "condvar.h"
+
+// A completion is a oneshot signal - it waits until finish is called and
+// then never blocks again.
+//
+// Due to the oneshot nature the order wait() and finish() are called does not matter.
+struct completion {
+    int finished;
+    struct libqb_mutex *mutex;
+    struct libqb_condvar *var;
+};
+
+void completion_init(struct completion *);
+void completion_clear(struct completion *);
+
+// Blocks until the completion is finished
+void completion_wait(struct completion *);
+
+// Finishes the completion, unblocks all waiters
+void completion_finish(struct completion *);
+
+#endif

--- a/internal/c/libqb/include/condvar.h
+++ b/internal/c/libqb/include/condvar.h
@@ -1,0 +1,23 @@
+#ifndef INCLUDE_LIBQB_CONDVAR_H
+#define INCLUDE_LIBQB_CONDVAR_H
+
+#include "mutex.h"
+
+// Condition Variable
+struct libqb_condvar;
+
+// Allocates and frees a Condition Variable
+struct libqb_condvar *libqb_condvar_new();
+void libqb_condvar_free(struct libqb_condvar *);
+
+// Waits until the Condition Variable is signalled, atomically dropping the
+// Mutex while checking the Condition Variable
+void libqb_condvar_wait(struct libqb_condvar *, struct libqb_mutex *);
+
+// Singals a single thread waiting on the Condition Variable
+void libqb_condvar_signal(struct libqb_condvar *);
+
+// Signals all threads waiting on the Condtiion Variable
+void libqb_condvar_broadcast(struct libqb_condvar *);
+
+#endif

--- a/internal/c/libqb/include/libqb-common.h
+++ b/internal/c/libqb/include/libqb-common.h
@@ -1,0 +1,54 @@
+#ifndef INCLUDE_LIBQB_LIBQB_COMMON_H
+#define INCLUDE_LIBQB_LIBQB_COMMON_H
+// Should be included at the top of every .cpp file
+
+/* Provide some OS/compiler macros.
+ * QB64_WINDOWS: Is this a Windows system?
+ * QB64_LINUX: Is this a Linux system?
+ * QB64_MACOSX: Is this MacOSX, or MacOS or whatever Apple calls it now?
+ * QB64_UNIX: Is this a Unix-flavoured system?
+ *
+ * QB64_BACKSLASH_FILESYSTEM: Does this system use \ for file paths (as opposed to /)?
+ * QB64_MICROSOFT: Are we compiling with Visual Studio?
+ * QB64_GCC: Are we compiling with gcc?
+ * QB64_MINGW: Are we compiling with MinGW, specifically? (Set in addition to QB64_GCC)
+ *
+ * QB64_32: A 32bit system (the default)
+ * QB64_64: A 64bit system (assumes all Macs are 64 bit)
+ */
+#ifdef WIN32
+#    define QB64_WINDOWS
+// This supports Windows Vista and up
+#    define _WIN32_WINNT 0x0600
+
+#    define QB64_BACKSLASH_FILESYSTEM
+#    ifdef _MSC_VER
+// Do we even support non-mingw compilers on Windows?
+#        define QB64_MICROSOFT
+#    else
+#        define QB64_GCC
+#        define QB64_MINGW
+#    endif
+#elif defined(__APPLE__)
+#    define QB64_MACOSX
+#    define QB64_UNIX
+#    define QB64_GCC
+#elif defined(__linux__)
+#    define QB64_LINUX
+#    define QB64_UNIX
+#    define QB64_GCC
+#else
+#    error "Unknown system; refusing to build. Edit os.h if needed"
+#endif
+
+#if defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined(QB64_MACOSX) || defined(__aarch64__)
+#    define QB64_64
+#else
+#    define QB64_32
+#endif
+
+#if !defined(i386) && !defined(__x86_64__)
+#    define QB64_NOT_X86
+#endif
+
+#endif

--- a/internal/c/libqb/include/mutex.h
+++ b/internal/c/libqb/include/mutex.h
@@ -1,0 +1,29 @@
+#ifndef INCLUDE_LIBQB_MUTEX_H
+#define INCLUDE_LIBQB_MUTEX_H
+
+struct libqb_mutex;
+
+// Allocates and frees a Mutex. Mutex is created unlocked.
+struct libqb_mutex *libqb_mutex_new();
+void libqb_mutex_free(struct libqb_mutex *);
+
+// Lock and unlock the Mutex
+void libqb_mutex_lock(struct libqb_mutex *);
+void libqb_mutex_unlock(struct libqb_mutex *);
+
+// Locks a mutex when created, and unlocks when the guard goes out of scope
+class libqb_mutex_guard {
+  public:
+    libqb_mutex_guard(struct libqb_mutex *mtx) : lock(mtx) {
+        libqb_mutex_lock(lock);
+    }
+
+    ~libqb_mutex_guard() {
+        libqb_mutex_unlock(lock);
+    }
+
+  private:
+    struct libqb_mutex *lock;
+};
+
+#endif

--- a/internal/c/libqb/include/thread.h
+++ b/internal/c/libqb/include/thread.h
@@ -1,0 +1,18 @@
+#ifndef INCLUDE_LIBQB_THREAD_H
+#define INCLUDE_LIBQB_THREAD_H
+
+// Thread
+struct libqb_thread;
+
+// Allocates a new thread, note that it is not running when this returns
+// Thread should already be stopped/joined when free is called
+struct libqb_thread *libqb_thread_new();
+void libqb_thread_free(struct libqb_thread *);
+
+// Configures and starts a thread to begin it's execution.
+void libqb_thread_start(struct libqb_thread *, void (*start_func) (void *), void *arg);
+
+// Joins a thread to end its execution
+void libqb_thread_join(struct libqb_thread *);
+
+#endif

--- a/internal/c/libqb/src/buffer.cpp
+++ b/internal/c/libqb/src/buffer.cpp
@@ -1,0 +1,86 @@
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "buffer.h"
+
+void libqb_buffer_init(struct libqb_buffer *buffer) {
+    memset(buffer, 0, sizeof(*buffer));
+
+    buffer->tail = &buffer->head;
+}
+
+static void libqb_buffer_entry_free(struct libqb_buffer_entry *ent) {
+    free(ent->data);
+    free(ent);
+}
+
+void libqb_buffer_clear(struct libqb_buffer *buffer) {
+    struct libqb_buffer_entry *entry = buffer->head;
+
+    while (entry) {
+        struct libqb_buffer_entry *nxt = entry->next;
+
+        libqb_buffer_entry_free(entry);
+
+        entry = nxt;
+    }
+
+    libqb_buffer_init(buffer);
+}
+
+size_t libqb_buffer_length(struct libqb_buffer *buffer) {
+    return buffer->total_length;
+}
+
+size_t libqb_buffer_read(struct libqb_buffer *buffer, char *out, size_t length) {
+    size_t actual_length = 0;
+
+    while (buffer->head && length) {
+        struct libqb_buffer_entry *entry = buffer->head;
+        size_t offset = buffer->cur_entry_offset;
+
+        size_t len = entry->length - offset;
+        if (len > length)
+            len = length;
+
+        memcpy(out, entry->data + offset, len);
+
+        out += len;
+        length -= len;
+        actual_length += len;
+
+        if (len == entry->length - offset) {
+            // This buffer is done, drop it
+            libqb_buffer_entry_free(entry);
+            buffer->head = buffer->head->next;
+            buffer->cur_entry_offset = 0;
+        } else {
+            // We didn't use the whole buffer, length == 0, loop will end
+            buffer->cur_entry_offset = offset + len;
+        }
+    }
+
+    // If the list is now empty, we need to reset the tail pointer
+    if (!buffer->head)
+        buffer->tail = &buffer->head;
+
+    buffer->total_length -= actual_length;
+
+    return actual_length;
+}
+
+void libqb_buffer_write(struct libqb_buffer *buffer, const char *in, size_t length) {
+    struct libqb_buffer_entry *new_ent = (struct libqb_buffer_entry *)malloc(sizeof(*new_ent));
+
+    new_ent->length = length;
+    new_ent->next = NULL;
+    new_ent->data = (char *)malloc(length);
+
+    memcpy(new_ent->data, in, length);
+
+    *buffer->tail = new_ent;
+    buffer->tail = &new_ent->next;
+    buffer->total_length += length;
+}

--- a/internal/c/libqb/src/buffer.cpp
+++ b/internal/c/libqb/src/buffer.cpp
@@ -1,4 +1,6 @@
 
+#include "libqb-common.h"
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/internal/c/libqb/src/threading-posix.cpp
+++ b/internal/c/libqb/src/threading-posix.cpp
@@ -1,0 +1,103 @@
+
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#include "mutex.h"
+
+struct libqb_thread {
+    pthread_t thread;
+};
+
+struct libqb_mutex {
+    pthread_mutex_t mtx;
+};
+
+struct libqb_condvar {
+    pthread_cond_t var;
+};
+
+struct libqb_mutex *libqb_mutex_new() {
+    struct libqb_mutex *m = (struct libqb_mutex *)malloc(sizeof(*m));
+    pthread_mutex_init(&m->mtx, NULL);
+    return m;
+}
+
+void libqb_mutex_free(struct libqb_mutex *mutex) {
+    pthread_mutex_destroy(&mutex->mtx);
+    free(mutex);
+}
+
+void libqb_mutex_lock(struct libqb_mutex *m) {
+    if (m == NULL)
+        return;
+
+    pthread_mutex_lock(&m->mtx);
+}
+
+void libqb_mutex_unlock(struct libqb_mutex *m) {
+    if (m == NULL)
+        return;
+
+    pthread_mutex_unlock(&m->mtx);
+}
+
+struct libqb_condvar *libqb_condvar_new() {
+    struct libqb_condvar *c = (struct libqb_condvar *)malloc(sizeof(*c));
+    pthread_cond_init(&c->var, NULL);
+    return c;
+}
+
+void libqb_condvar_free(struct libqb_condvar *c) {
+    pthread_cond_destroy(&c->var);
+    free(c);
+}
+
+void libqb_condvar_wait(struct libqb_condvar *condvar, struct libqb_mutex *mutex) {
+    pthread_cond_wait(&condvar->var, &mutex->mtx);
+}
+
+void libqb_condvar_signal(struct libqb_condvar *condvar) {
+    pthread_cond_signal(&condvar->var);
+}
+
+void libqb_condvar_broadcast(struct libqb_condvar *condvar) {
+    pthread_cond_broadcast(&condvar->var);
+}
+
+struct libqb_thread *libqb_thread_new() {
+    struct libqb_thread *t = (struct libqb_thread *)malloc(sizeof(*t));
+    memset(t, 0, sizeof(*t));
+
+    return t;
+}
+
+void libqb_thread_free(struct libqb_thread *t) {
+    // The thread should have already have been joined.
+    free(t);
+}
+
+struct thread_wrapper_args {
+    void (*wrapper) (void *);
+    void *arg;
+};
+
+static void *thread_wrapper(void *varg) {
+    struct thread_wrapper_args *arg = (struct thread_wrapper_args *)varg;
+    (arg->wrapper) (arg->arg);
+    free(arg);
+
+    return NULL;
+}
+
+void libqb_thread_start(struct libqb_thread *t, void (*start_func) (void *), void *start_func_arg) {
+    struct thread_wrapper_args *arg = (struct thread_wrapper_args *)malloc(sizeof(*arg));
+    arg->wrapper = start_func;
+    arg->arg = start_func_arg;
+
+    pthread_create(&t->thread, NULL, thread_wrapper, (void *)arg);
+}
+
+void libqb_thread_join(struct libqb_thread *t) {
+    pthread_join(t->thread, NULL);
+}

--- a/internal/c/libqb/src/threading-posix.cpp
+++ b/internal/c/libqb/src/threading-posix.cpp
@@ -31,16 +31,10 @@ void libqb_mutex_free(struct libqb_mutex *mutex) {
 }
 
 void libqb_mutex_lock(struct libqb_mutex *m) {
-    if (m == NULL)
-        return;
-
     pthread_mutex_lock(&m->mtx);
 }
 
 void libqb_mutex_unlock(struct libqb_mutex *m) {
-    if (m == NULL)
-        return;
-
     pthread_mutex_unlock(&m->mtx);
 }
 

--- a/internal/c/libqb/src/threading-posix.cpp
+++ b/internal/c/libqb/src/threading-posix.cpp
@@ -1,4 +1,6 @@
 
+#include "libqb-common.h"
+
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>

--- a/internal/c/libqb/src/threading-windows.cpp
+++ b/internal/c/libqb/src/threading-windows.cpp
@@ -1,0 +1,104 @@
+
+// FIXME: Move this to some kind of global header
+#define _WIN32_WINNT 0x0600
+
+#include <windows.h>
+#include <synchapi.h>
+#include <process.h>
+
+#include "thread.h"
+#include "mutex.h"
+#include "condvar.h"
+
+struct libqb_thread {
+    HANDLE thread_handle;
+};
+
+struct libqb_mutex {
+    CRITICAL_SECTION crit_section;
+};
+
+struct libqb_condvar {
+    CONDITION_VARIABLE var;
+};
+
+struct libqb_mutex *libqb_mutex_new() {
+    struct libqb_mutex *m = (struct libqb_mutex *)malloc(sizeof(*m));
+
+    InitializeCriticalSectionAndSpinCount(&m->crit_section, 200);
+    return m;
+}
+
+void libqb_mutex_free(struct libqb_mutex *mutex) {
+    DeleteCriticalSection(&mutex->crit_section);
+    free(mutex);
+}
+
+void libqb_mutex_lock(struct libqb_mutex *m) {
+    EnterCriticalSection(&m->crit_section);
+}
+
+void libqb_mutex_unlock(struct libqb_mutex *m) {
+    LeaveCriticalSection(&m->crit_section);
+}
+
+struct libqb_condvar *libqb_condvar_new() {
+    struct libqb_condvar *condvar = (struct libqb_condvar *)malloc(sizeof(*condvar));
+
+    InitializeConditionVariable(&condvar->var);
+    return condvar;
+}
+
+void libqb_condvar_free(struct libqb_condvar *condvar) {
+    free(condvar);
+}
+
+void libqb_condvar_wait(struct libqb_condvar *condvar, struct libqb_mutex *mutex) {
+    SleepConditionVariableCS(&condvar->var, &mutex->crit_section, INFINITE);
+}
+
+void libqb_condvar_signal(struct libqb_condvar *condvar) {
+    WakeConditionVariable(&condvar->var);
+}
+
+void libqb_condvar_broadcast(struct libqb_condvar *condvar) {
+    WakeAllConditionVariable(&condvar->var);
+}
+
+struct libqb_thread *libqb_thread_new() {
+    struct libqb_thread *t = (struct libqb_thread *)malloc(sizeof(*t));
+    t->thread_handle = 0;
+
+    return t;
+}
+
+void libqb_thread_free(struct libqb_thread *t) {
+    // The handle is closed automatically when using _beginthreadex
+    free(t);
+}
+
+struct thread_wrapper_args {
+    void (*wrapper) (void *);
+    void *arg;
+};
+
+// This wrapper is so that the caller doesn't need to provide a __stdcall function, which is not portable
+static unsigned int __stdcall stdcall_thread_wrapper(void *varg) {
+    struct thread_wrapper_args *arg = (struct thread_wrapper_args *)varg;
+    (arg->wrapper) (arg->arg);
+    free(arg);
+
+    return 0;
+}
+
+void libqb_thread_start(struct libqb_thread *t, void (*start_func) (void *), void *start_func_arg) {
+    struct thread_wrapper_args *arg = (struct thread_wrapper_args *)malloc(sizeof(*arg));
+    arg->wrapper = start_func;
+    arg->arg = start_func_arg;
+
+    t->thread_handle = (HANDLE)_beginthreadex(NULL, 0, stdcall_thread_wrapper, arg, 0, NULL);
+}
+
+void libqb_thread_join(struct libqb_thread *t) {
+    WaitForSingleObject(t->thread_handle, INFINITE);
+}

--- a/internal/c/libqb/src/threading-windows.cpp
+++ b/internal/c/libqb/src/threading-windows.cpp
@@ -1,6 +1,5 @@
 
-// FIXME: Move this to some kind of global header
-#define _WIN32_WINNT 0x0600
+#include "libqb-common.h"
 
 #include <windows.h>
 #include <synchapi.h>

--- a/internal/c/libqb/src/threading.cpp
+++ b/internal/c/libqb/src/threading.cpp
@@ -1,0 +1,31 @@
+
+#include "mutex.h"
+#include "condvar.h"
+#include "completion.h"
+
+void completion_init(struct completion *comp) {
+    comp->finished = 0;
+    comp->mutex = libqb_mutex_new();
+    comp->var = libqb_condvar_new();
+}
+
+void completion_clear(struct completion *comp) {
+    libqb_mutex_free(comp->mutex);
+    libqb_condvar_free(comp->var);
+}
+
+void completion_wait(struct completion *comp) {
+    libqb_mutex_lock(comp->mutex);
+
+    while (!comp->finished)
+        libqb_condvar_wait(comp->var, comp->mutex);
+
+    libqb_mutex_unlock(comp->mutex);
+}
+
+void completion_finish(struct completion *comp) {
+    libqb_mutex_lock(comp->mutex);
+    comp->finished = 1;
+    libqb_condvar_broadcast(comp->var);
+    libqb_mutex_unlock(comp->mutex);
+}

--- a/internal/c/libqb/src/threading.cpp
+++ b/internal/c/libqb/src/threading.cpp
@@ -17,17 +17,15 @@ void completion_clear(struct completion *comp) {
 }
 
 void completion_wait(struct completion *comp) {
-    libqb_mutex_lock(comp->mutex);
+    libqb_mutex_guard guard(comp->mutex);
 
     while (!comp->finished)
         libqb_condvar_wait(comp->var, comp->mutex);
-
-    libqb_mutex_unlock(comp->mutex);
 }
 
 void completion_finish(struct completion *comp) {
-    libqb_mutex_lock(comp->mutex);
+    libqb_mutex_guard guard(comp->mutex);
+
     comp->finished = 1;
     libqb_condvar_broadcast(comp->var);
-    libqb_mutex_unlock(comp->mutex);
 }

--- a/internal/c/libqb/src/threading.cpp
+++ b/internal/c/libqb/src/threading.cpp
@@ -1,4 +1,6 @@
 
+#include "libqb-common.h"
+
 #include "mutex.h"
 #include "condvar.h"
 #include "completion.h"

--- a/internal/c/os.h
+++ b/internal/c/os.h
@@ -1,48 +1,5 @@
-/* Provide some OS/compiler macros.
- * QB64_WINDOWS: Is this a Windows system?
- * QB64_LINUX: Is this a Linux system?
- * QB64_MACOSX: Is this MacOSX, or MacOS or whatever Apple calls it now?
- * QB64_UNIX: Is this a Unix-flavoured system?
- *
- * QB64_BACKSLASH_FILESYSTEM: Does this system use \ for file paths (as opposed to /)?
- * QB64_MICROSOFT: Are we compiling with Visual Studio?
- * QB64_GCC: Are we compiling with gcc?
- * QB64_MINGW: Are we compiling with MinGW, specifically? (Set in addition to QB64_GCC)
- *
- * QB64_32: A 32bit system (the default)
- * QB64_64: A 64bit system (assumes all Macs are 64 bit)
- */
-#ifdef WIN32
-#    define QB64_WINDOWS
-#    define QB64_BACKSLASH_FILESYSTEM
-#    ifdef _MSC_VER
-// Do we even support non-mingw compilers on Windows?
-#        define QB64_MICROSOFT
-#    else
-#        define QB64_GCC
-#        define QB64_MINGW
-#    endif
-#elif defined(__APPLE__)
-#    define QB64_MACOSX
-#    define QB64_UNIX
-#    define QB64_GCC
-#elif defined(__linux__)
-#    define QB64_LINUX
-#    define QB64_UNIX
-#    define QB64_GCC
-#else
-#    error "Unknown system; refusing to build. Edit os.h if needed"
-#endif
 
-#if defined(_WIN64) || defined(__x86_64__) || defined(__ppc64__) || defined(QB64_MACOSX) || defined(__aarch64__)
-#    define QB64_64
-#else
-#    define QB64_32
-#endif
-
-#if !defined(i386) && !defined(__x86_64__)
-#    define QB64_NOT_X86
-#endif
+#include "libqb-common.h"
 
 /* common types (not quite an include guard, but allows an including
  * file to not have these included.

--- a/internal/c/parts/audio/out/src/config.h
+++ b/internal/c/parts/audio/out/src/config.h
@@ -1,9 +1,4 @@
-#define QB64_OS_H_NO_TYPES
-#ifdef WIN32
- #include "..\..\..\..\os.h"
-#else
- #include "../../../../os.h"
-#endif
+#include "../../../../libqb/include/libqb-common.h"
 
 #ifndef CONFIG_H
 #define CONFIG_H

--- a/tests/build.mk
+++ b/tests/build.mk
@@ -7,7 +7,7 @@ TEST_CFLAGS-y := -I'./tests/c/include' \
 
 TEST_CFLAGS-$(win) += -mconsole
 
-TEST_DEF_OBJS :=
+TEST_DEF_OBJS := tests/c/test.o
 
 # Defines the list of test sets
 

--- a/tests/build.mk
+++ b/tests/build.mk
@@ -10,6 +10,12 @@ TEST_CFLAGS-$(win) += -mconsole
 TEST_DEF_OBJS := tests/c/test.o
 
 # Defines the list of test sets
+TESTS += buffer
+
+# Describe how to build each test
+buffer.src-y := ./tests/c/buffer.cpp \
+				$(PATH_LIBQB)/src/buffer.cpp
+
 
 TEST_OBJS := $(TEST_DEF_OBJS)
 TEST_OBJS += $(foreach test,$(TESTS),$(filter ./tests/c/%,$($(test)).objs-y))

--- a/tests/build.mk
+++ b/tests/build.mk
@@ -1,0 +1,36 @@
+
+TESTS :=
+
+TEST_CFLAGS-y := -I'./tests/c/include' \
+			   -I$(PATH_LIBQB)/include \
+			   -g -std=gnu++11
+
+TEST_CFLAGS-$(win) += -mconsole
+
+TEST_DEF_OBJS :=
+
+# Defines the list of test sets
+
+TEST_OBJS := $(TEST_DEF_OBJS)
+TEST_OBJS += $(foreach test,$(TESTS),$(filter ./tests/c/%,$($(test)).objs-y))
+
+TEST_TESTS :=
+
+define TEST_template
+TEST_TESTS += ./tests/exes/cpp/$(1)_test$(EXTENSION)
+tests/exes/cpp/$(1)_test$(EXTENSION): $$(TEST_DEF_OBJS) $$($(1).src-y) $$($(1).exe-libs-y) | tests/exes/cpp
+	$$(CXX) $$(TEST_CFLAGS-y) $$($(1).cflags-y) $$^ -o $$@ $$($(1).exe-libs-y) $$($(1).libs-y)
+endef
+
+$(foreach test,$(TESTS),$(eval $(call TEST_template,$(test))))
+
+CLEAN_LIST += $(TEST_OBJS)
+
+tests/exes:
+	$(MKDIR) $(call FIXPATH,$@)
+
+tests/exes/cpp: | tests/exes
+	$(MKDIR) $(call FIXPATH,$@)
+
+PHONY += build-tests
+build-tests: $(TEST_DEF_OBJS) $(TEST_TESTS)

--- a/tests/c/buffer.cpp
+++ b/tests/c/buffer.cpp
@@ -1,0 +1,318 @@
+
+#include <stddef.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "test.h"
+#include "buffer.h"
+
+// A single read and write of the same size from the buffer
+void test_single_rw() {
+    struct libqb_buffer buffer;
+
+    libqb_buffer_init(&buffer);
+    const char str[] = "FOOBAR";
+
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    libqb_buffer_write(&buffer, str, sizeof(str));
+
+    test_assert_ints(sizeof(str), libqb_buffer_length(&buffer));
+
+    char read_buf[sizeof(str)];
+    size_t read_len = libqb_buffer_read(&buffer, read_buf, sizeof(str));
+
+    test_assert_ints(sizeof(str), read_len);
+    test_assert_buffers(str, read_buf, sizeof(str));
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    libqb_buffer_clear(&buffer);
+}
+
+// Multple writes and reads of the same size from the buffer
+void test_multiple_rw() {
+    int count = 10;
+    struct libqb_buffer buffer;
+
+    libqb_buffer_init(&buffer);
+    const char str[] = "FOOBAR";
+    int length = 0;
+
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    for (int i = 0; i < count; i++) {
+        char id[20];
+        snprintf(id, sizeof(id), "%d", i);
+
+        libqb_buffer_write(&buffer, str, sizeof(str));
+
+        length += sizeof(str);
+        test_assert_ints_with_name(id, length, libqb_buffer_length(&buffer));
+    }
+
+    for (int i = 0; i < count; i++) {
+        char id[20];
+        snprintf(id, sizeof(id), "%d", i);
+
+        char read_buf[sizeof(str)];
+        size_t read_len = libqb_buffer_read(&buffer, read_buf, sizeof(str));
+
+        length -= sizeof(str);
+
+        test_assert_ints_with_name(id, sizeof(str), read_len);
+        test_assert_buffers_with_name(id, str, read_buf, sizeof(str));
+        test_assert_ints_with_name(id, length, libqb_buffer_length(&buffer));
+    }
+
+    libqb_buffer_clear(&buffer);
+}
+
+// Single write, multiple reads
+void test_partial_read() {
+    struct libqb_buffer buffer;
+
+    libqb_buffer_init(&buffer);
+    const char str[] = "FOOBAR1" "FOOBAR2" "FOOBAR3" "FOOBAR4" "FOOBAR5" "FOOBAR6";
+    const int str_len = 7;
+    const int length = sizeof(str) - 1;
+
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    libqb_buffer_write(&buffer, str, length);
+
+    int length_left = length;
+    for (int i = 0; i < length / str_len; i++) {
+        char id[20];
+        snprintf(id, sizeof(id), "%d", i);
+
+        char read_buf[str_len];
+        size_t read_len = libqb_buffer_read(&buffer, read_buf, sizeof(read_buf));
+
+        length_left -= str_len;
+
+        test_assert_ints_with_name(id, str_len, read_len);
+
+        // Check the prefix, without the number
+        test_assert_buffers_with_name(id, "FOOBAR", read_buf, str_len - 1);
+
+        // Check the number at the end
+        test_assert_ints_with_name(id, '1' + i, read_buf[6]);
+
+        test_assert_ints_with_name(id, length_left, libqb_buffer_length(&buffer));
+    }
+
+    libqb_buffer_clear(&buffer);
+}
+
+void test_full_read() {
+    int count = 6;
+    struct libqb_buffer buffer;
+
+    libqb_buffer_init(&buffer);
+    const char str[] = "FOOBAR";
+    const int str_len = sizeof(str) - 1;
+    int length = 0;
+
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    for (int i = 0; i < count; i++) {
+        char id[20];
+        snprintf(id, sizeof(id), "%d", i);
+
+        libqb_buffer_write(&buffer, str, str_len);
+
+        length += str_len;
+        test_assert_ints_with_name(id, length, libqb_buffer_length(&buffer));
+    }
+
+    char full_buf[str_len * count];
+
+    size_t read_len = libqb_buffer_read(&buffer, full_buf, sizeof(full_buf));
+
+    test_assert_ints(sizeof(full_buf), read_len);
+    test_assert_buffers("FOOBAR" "FOOBAR" "FOOBAR" "FOOBAR" "FOOBAR" "FOOBAR", full_buf, sizeof(full_buf));
+
+    libqb_buffer_clear(&buffer);
+}
+
+void test_read_past_end() {
+    struct libqb_buffer buffer;
+
+    libqb_buffer_init(&buffer);
+    const char str[] = "FOOBAR1" "FOOBAR2";
+    int str_len = sizeof(str);
+
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    libqb_buffer_write(&buffer, str, str_len);
+
+    test_assert_ints(str_len, libqb_buffer_length(&buffer));
+
+    char read_buf[200];
+    size_t read_len = libqb_buffer_read(&buffer, read_buf, sizeof(read_buf));
+
+    test_assert_ints(str_len, read_len);
+    test_assert_buffers(str, read_buf, str_len);
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    read_len = libqb_buffer_read(&buffer, read_buf, sizeof(read_buf));
+
+    test_assert_ints(0, read_len);
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    libqb_buffer_clear(&buffer);
+}
+
+void test_read_write_multiple_partial() {
+    struct libqb_buffer buffer;
+
+    libqb_buffer_init(&buffer);
+    const char *strs[] = {
+        "FOOBAR1",
+        "FOOBAR2",
+        "FOOBAR3",
+        "FOOBAR4",
+        "FOOBAR5",
+        "FOOBAR6",
+        "FOOBAR7",
+        "FOOBAR8",
+        "FOOBAR9",
+    };
+    int str_len = 7;
+    int length = 0;
+
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    for (int i = 0; i < sizeof(strs) / sizeof(*strs); i++) {
+        libqb_buffer_write(&buffer, strs[i], str_len);
+
+        length += str_len;
+        test_assert_ints(length, libqb_buffer_length(&buffer));
+    }
+
+    char temp_buf[50];
+    size_t read_len;
+
+    read_len = libqb_buffer_read(&buffer, temp_buf, 12);
+    length -= 12;
+
+    test_assert_ints(12, read_len);
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+    test_assert_buffers("FOOBAR1FOOBA", temp_buf, 12);
+
+    read_len = libqb_buffer_read(&buffer, temp_buf, 20);
+    length -= 20;
+
+    test_assert_ints(20, read_len);
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+    test_assert_buffers("R2FOOBAR3FOOBAR4FOOB", temp_buf, 20);
+
+    read_len = libqb_buffer_read(&buffer, temp_buf, 25);
+    length -= 25;
+
+    test_assert_ints(25, read_len);
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+    test_assert_buffers("AR5FOOBAR6FOOBAR7FOOBAR8F", temp_buf, 25);
+
+    // Read past the end, should only read the 6 characters left
+    read_len = libqb_buffer_read(&buffer, temp_buf, 20);
+    length -= 6;
+
+    test_assert_ints(6, read_len);
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+    test_assert_buffers("OOBAR9", temp_buf, 6);
+
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    libqb_buffer_clear(&buffer);
+}
+
+void test_read_write_interweaved() {
+    struct libqb_buffer buffer;
+
+    libqb_buffer_init(&buffer);
+    const char *strs[] = {
+        "FOOBAR1",
+        "FOOBAR2",
+        "FOOBAR3",
+        "FOOBAR4",
+        "FOOBAR5",
+        "FOOBAR6",
+        "FOOBAR7",
+        "FOOBAR8",
+        "FOOBAR9",
+    };
+    int str_len = 7;
+    int length = 0;
+    char temp_buf[50];
+    size_t read_len;
+
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    // WRITE
+    libqb_buffer_write(&buffer, "FOOBAR1", 7);
+    length += 7;
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+
+    // WRITE
+    libqb_buffer_write(&buffer, "FOOBAR2", 7);
+    length += 7;
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+
+    // READ
+    read_len = libqb_buffer_read(&buffer, temp_buf, 12);
+    length -= 12;
+
+    test_assert_ints(12, read_len);
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+    test_assert_buffers("FOOBAR1FOOBA", temp_buf, 12);
+
+    // WRITE
+    libqb_buffer_write(&buffer, "FOOBAR3", 7);
+    length += 7;
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+
+    // READ
+    read_len = libqb_buffer_read(&buffer, temp_buf, 50);
+    length -= 9;
+
+    test_assert_ints(9, read_len);
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+    test_assert_buffers("R2FOOBAR3", temp_buf, 9);
+
+    // WRITE
+    libqb_buffer_write(&buffer, "FOOBAR4", 7);
+    length += 7;
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+
+    // WRITE
+    libqb_buffer_write(&buffer, "FOOBAR5", 7);
+    length += 7;
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+
+    // READ
+    read_len = libqb_buffer_read(&buffer, temp_buf, 50);
+    length -= 14;
+
+    test_assert_ints(14, read_len);
+    test_assert_ints(length, libqb_buffer_length(&buffer));
+    test_assert_buffers("FOOBAR4FOOBAR5", temp_buf, 14);
+
+    test_assert_ints(0, libqb_buffer_length(&buffer));
+
+    libqb_buffer_clear(&buffer);
+}
+
+int main() {
+    struct unit_test tests[] = {
+        { test_single_rw, "test-single-read-write" },
+        { test_multiple_rw, "test-multiple-read-write" },
+        { test_partial_read, "test-partial-read" },
+        { test_full_read, "test-full-read" },
+        { test_read_past_end, "test-read-past-end" },
+        { test_read_write_multiple_partial, "test-read-write-multiple-partial" },
+        { test_read_write_interweaved, "test-read-write-interweaved" },
+    };
+
+    return run_tests("buffer", tests, sizeof(tests) / sizeof(*tests));
+}

--- a/tests/c/test.cpp
+++ b/tests/c/test.cpp
@@ -1,0 +1,186 @@
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "test.h"
+
+static int cur_test_count;
+static int total_test_count = 0;
+static const char *current_test;
+static const char *current_mod;
+static int cur_failed_tests;
+
+int run_tests(const char *mod_name, struct unit_test *tests, int test_count)
+{
+    int i;
+    int error_count = 0;
+    int errs;
+    current_mod = mod_name;
+
+    printf("==== Starting tests for %s ====\n", mod_name);
+
+    for (i = 0; i < test_count; i++) {
+        total_test_count++;
+
+        cur_test_count = 0;
+        current_test = tests[i].name;
+
+        printf("== #%d: %s ==\n", total_test_count, tests[i].name);
+
+        cur_failed_tests = 0;
+        (tests + i)->test ();
+        errs = cur_failed_tests;
+
+        printf("== Result: ");
+        if (errs != 0)
+            printf(COLOR_RED "FAIL -> %d" COLOR_RESET, errs);
+        else
+            printf(COLOR_GREEN "PASS" COLOR_RESET);
+
+        printf(" ==\n");
+
+        error_count += errs;
+    }
+
+    printf("==== Finished tests for %s ====\n", mod_name);
+    printf("==== Result: ");
+    if (error_count == 0)
+        printf(COLOR_GREEN "PASS " COLOR_RESET);
+    else
+        printf(COLOR_RED "FAIL -> %d " COLOR_RESET, error_count);
+
+    printf("====\n");
+
+    return error_count;
+}
+
+void assert_true(const char *arg, const char *func, int cond)
+{
+    cur_test_count++;
+    printf(" [%02d:%03d] %s: %s: ", total_test_count, cur_test_count, func, arg);
+    if (cond)
+        printf(COLOR_GREEN "PASS" COLOR_RESET);
+    else
+        printf(COLOR_RED "FAIL" COLOR_RESET);
+
+    printf("\n");
+
+    cur_failed_tests += !cond;
+}
+
+void assert_with_name(const char *name, const char *arg, const char *func, int cond)
+{
+    char buf[256];
+    snprintf(buf, sizeof(buf), "%s: \"%s\"", name, arg);
+    assert_true(buf, func, cond);
+}
+
+// Displays a buffer of memory in a readable format
+static void dump_mem(const char *buf, size_t len, uintptr_t base_addr)
+{
+    char strbuf[200], strbuf2[200] = { 0 };
+    char *cur_b, *start, *bufend, *to_print;
+    const unsigned char *b = (const unsigned char *)buf;
+    int i = 0, j, skipping = 0;
+
+    cur_b = strbuf;
+    start = strbuf;
+
+    for (; i < len; i += 16) {
+        bufend = cur_b + sizeof(strbuf);
+        cur_b += snprintf(cur_b, bufend - cur_b,  "%08x  ", (i) + base_addr);
+
+        for (j = i; j < i + 16; j++) {
+            if (j < len)
+                cur_b += snprintf(cur_b, bufend - cur_b, "%02x ", (const unsigned int)b[j]);
+            else
+                cur_b += snprintf(cur_b, bufend - cur_b, "   ");
+
+            if (j - i == 7)
+                *(cur_b++) = ' ';
+        }
+
+        cur_b += snprintf(cur_b, bufend - cur_b, " |");
+        for (j = i; j < i + 16 && j < len; j++)
+            if (b[j] > 31 && b[j] <= 127)
+                cur_b += sprintf(cur_b, "%c", b[j]);
+            else
+                *(cur_b++) = '.';
+
+        cur_b += sprintf(cur_b, "|\n");
+
+        to_print = start;
+
+        if (start == strbuf)
+            start = strbuf2;
+        else
+            start = strbuf;
+
+        cur_b = start;
+
+        /* This logic skips duplicate lines, printing '...' instead
+         *
+         * The 12 magic number is just so we don't compare the printed address,
+         * which is in '0x00000000' format at the beginning of the string */
+        if (strcmp(strbuf + 12, strbuf2 + 12) != 0) {
+            if (skipping == 1)
+                printf("%s", start);
+            else if (skipping == 2)
+                printf("...\n");
+            skipping = 0;
+            printf("%s", to_print);
+        } else if (skipping >= 1) {
+            skipping = 2;
+        } else {
+            skipping = 1;
+        }
+    }
+
+    if (skipping) {
+        printf("...\n");
+        printf("%s", to_print);
+    }
+}
+
+void assert_buffers_equal_with_name(const char *name, const char *func, const char *arg1, const char *buf1, const char *arg2, const char *buf2, size_t length)
+{
+    int result = memcmp(buf1, buf2, length);
+    char buf[256];
+    if (name)
+        snprintf(buf, sizeof(buf), "%s: \"memcmp(%s, %s, %zd) == 0\"", name, arg1, arg2, length);
+    else
+        snprintf(buf, sizeof(buf), "\"memcmp(%s, %s, %zd) == 0\"", arg1, arg2, length);
+
+    assert_true(buf, func, result == 0);
+
+    if (result == 0)
+        return;
+
+    // Print differences
+    printf("    Expected: %s:\n", arg1);
+    dump_mem(buf1, length, 0);
+
+    printf("    Actual: %s:\n", arg2);
+    dump_mem(buf2, length, 0);
+}
+
+void assert_ints_equal_with_name(const char *name, const char *func, const char *arg1, uint64_t int1, const char *arg2, uint64_t int2)
+{
+    int result = int1 == int2;
+    char buf[256];
+
+    if (name)
+        snprintf(buf, sizeof(buf), "%s: \"%s == %s\"", name, arg1, arg2);
+    else
+        snprintf(buf, sizeof(buf), "\"%s == %s\"", arg1, arg2);
+
+    assert_true(buf, func, result);
+
+    if (result)
+        return;
+
+    // Print differences
+    printf("    Expected: %s = %lld\n", arg1, int1);
+    printf("    Actual:   %s = %lld\n", arg2, int2);
+}

--- a/tests/c/test.h
+++ b/tests/c/test.h
@@ -1,0 +1,49 @@
+#ifndef _TEST_H_
+#define _TEST_H_
+
+#include <stdint.h>
+
+struct unit_test {
+    void (*test)();
+    const char *name;
+};
+
+#define COLOR_DEFAULT      ""
+#define COLOR_RESET        "\033[m"
+#define COLOR_BOLD         "\033[1m"
+#define COLOR_RED          "\033[31m"
+#define COLOR_GREEN        "\033[32m"
+#define COLOR_YELLOW       "\033[33m"
+#define COLOR_BLUE         "\033[34m"
+#define COLOR_MAGENTA      "\033[35m"
+#define COLOR_CYAN         "\033[36m"
+#define COLOR_BOLD_RED     "\033[1;31m"
+#define COLOR_BOLD_GREEN   "\033[1;32m"
+#define COLOR_BOLD_YELLOW  "\033[1;33m"
+#define COLOR_BOLD_BLUE    "\033[1;34m"
+#define COLOR_BOLD_MAGENTA "\033[1;35m"
+#define COLOR_BOLD_CYAN    "\033[1;36m"
+#define COLOR_BG_RED       "\033[41m"
+#define COLOR_BG_GREEN     "\033[42m"
+#define COLOR_BG_YELLOW    "\033[43m"
+#define COLOR_BG_BLUE      "\033[44m"
+#define COLOR_BG_MAGENTA   "\033[45m"
+#define COLOR_BG_CYAN      "\033[46m"
+
+#define test_assert(cond) assert_true(#cond, __func__, !!(cond))
+#define test_assert_with_name(name, cond) assert_with_name(name, #cond, __func__, !!(cond))
+
+#define test_assert_ints(int1, int2) assert_ints_equal_with_name(NULL, __func__, #int1, (int1), #int2, (int2))
+#define test_assert_ints_with_name(name, int1, int2) assert_ints_equal_with_name((name), __func__, #int1, (int1), #int2, (int2))
+
+#define test_assert_buffers(buf1, buf2, len) assert_buffers_equal_with_name(NULL, __func__, #buf1, (buf1), #buf2, (buf2), (len))
+#define test_assert_buffers_with_name(name, buf1, buf2, len) assert_buffers_equal_with_name((name), __func__, #buf1, (buf1), #buf2, (buf2), (len))
+
+int run_tests(const char *test_mod_name, struct unit_test *, int test_count);
+
+void assert_true(const char *arg, const char *func, int cond);
+void assert_with_name(const char *name, const char *arg, const char *func, int cond);
+void assert_buffers_equal_with_name(const char *name, const char *func, const char *arg1, const char *buf1, const char *arg2, const char *buf2, size_t length);
+void assert_ints_equal_with_name(const char *name, const char *func, const char *arg1, uint64_t int1, const char *arg2, uint64_t int2);
+
+#endif

--- a/tests/run_c_tests.sh
+++ b/tests/run_c_tests.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+. ./tests/colors.sh
+
+result=0
+
+for test in buffer
+do
+    ./tests/exes/cpp/${test}_test || result=1
+done
+
+if [ "$result" != "1" ]; then
+    echo "====== FINAL RESULT: ${GREEN}PASS${RESET} ======"
+else
+    echo "====== FINAL RESULT: ${RED}FAIL${RESET} ======"
+fi
+
+exit $result


### PR DESCRIPTION
This is a reasonably big one but I didn't see a better way to split it up, this is the next step after #102. If you have any questions please ask :)

The `./internal/c/libqb/` folder now has two new folders `./internal/c/libqb/src/` and `./internal/c/libqb/include` for headers and C++ source files contributing to libqb. These source files are all compiled independently into `.o` files, and then linked into the final application. Which of these files gets built and linked is determined by the logic in `./internal/c/libqb/build.mk`.

The `threading-*.cpp` files show the general approach for platform-specific implementations.  Depending on exactly how different the implementations for Windows/POSIX/x64/x86/etc... are we can avoid all the `#ifdef` logic everywhere by simply providing completely different source files and building the necessary ones for that platform. This can work for dependencies too, so Ex. We can check if `DEP_SOCKETS` is true and the compile/link the necessary source files if that's the case.

---

The C++ automated testing is fairly simple and something I wrote a while back for a different project. All the logic is just a single file `test.cpp`, which takes in a list of functions and calls them one at a time, logging information as it goes. There's various `test_assert*` functions that check if a condition is true, and if not mark that test as failed and output some information on why it failed. The script `./run_c_tests.sh` can run all the C++ tests in a row and checks if any of them report failures. There's various improvements that could probably be made, but I think it's a good starting point for us.

The building of the C++ tests is a little complicated and located in `./tests/build.mk`, but think once I get a few more examples in there it will start to make sense. Ignoring the `make` magic, you basically just define the name of a test suite, and then what source files should be used to build that test suite. You can also provide any compiler flags for that test, if they are needed.

---

A notable detail that might get lost is that `CONDITION_VARIABLE` (which I need for the HTTP/HTTPS stuff that's coming up) on Windows is Vista and up, so while I think we were already not XP compatible this makes us more-so incompatible.