### PR TITLE
Math evaluator: values that round to zero can crash QB64pe

### DIFF
--- a/source/qb64.bas
+++ b/source/qb64.bas
@@ -24434,19 +24434,20 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
                         EXIT FUNCTION
                     END IF
                 CASE "\"
-                    IF VAL(num(2)) <> 0 THEN
-                        n1 = VAL(num(1)) \ VAL(num(2))
-                    ELSE
+                    IF FIX(VAL(num(2))) = 0 THEN
                         EvaluateNumbers$ = "ERROR - Division By Zero"
                         EXIT FUNCTION
                     END IF
+
+                    n1 = VAL(num(1)) \ FIX(VAL(num(2)))
                 CASE "MOD"
-                    IF VAL(num(2)) <> 0 THEN
-                        n1 = VAL(num(1)) MOD VAL(num(2))
-                    ELSE
+                    IF FIX(VAL(num(2))) = 0 THEN
                         EvaluateNumbers$ = "ERROR - Division By Zero"
                         EXIT FUNCTION
                     END IF
+
+                    n1 = VAL(num(1)) MOD FIX(VAL(num(2)))
+
                 CASE "+": n1 = VAL(num(1)) + VAL(num(2))
                 CASE "-":
                     n1 = VAL(num(1)) - VAL(num(2))


### PR DESCRIPTION
The math evaluator already contains a few checks for zero when we're
executing operations that could cause a `Divide By Zero` error, but the
actual value input is floating point and can get rounded to zero when
the operation happens. This effectively allows zero values to bypass the
checks to prevent them from being evaluated.

To avoid the error completely we need to check that the rounded value is
not zero, rather than the initial value. FIX() is used to make sure
values such a `-.1` round to zero and are avoided. I also applied FIX()
when we actually execute the operation, just to ensure the same
behavior.

---

This issue was originally reported for qb64official/qb64#4, and we experience the
same issue. Also, oddly, like stated in the title it does not actually trigger
a `Divide By Zero` error but rather actually crashes QB64pe with a floating
point error.

I attempted to recreate this with a small program but wasn't able. We do
receive a `SIGFPE` as expected, but I was unable to tell if our signal handler
actually got called and right after that the program gets a `SIGSEGV` which
crashes the whole thing. This fix does avoid the entire issue, but we might
want to look into the underlying issue sometime later since you ideally
shouldn't be able to segfault the program like this :-/