### PR TITLE
Use -no-pie on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ ifeq ($(OS),lnx)
 	PLATFORM := posix
 	EXTENSION :=
 
+	# Compiling with -no-pie lets some file explorers know we're an executable,
+	# not a shared object
+	CXXFLAGS += -no-pie
+
 	# Check bitness by getting length of `long
 	# 64 bits on x86_64, 32 bits on x86
 	BITS := $(shell getconf LONG_BIT)


### PR DESCRIPTION
The -no-pie flag tells the compiler not to make a Position Independent
Executable. We don't really care which it chooses to make, but some file
explorers consider PIE executables to be shared objects and won't allow
you to run them directly. To avoid this, we're compiling with -no-pie.

Fixes: #142