### PR TITLE
Fix High-DPI awareness on Windows

### DIFF
--- a/internal/c/libqb/include/libqb-common.h
+++ b/internal/c/libqb/include/libqb-common.h
@@ -20,6 +20,7 @@
 #    define QB64_WINDOWS
 // This supports Windows Vista and up
 #    define _WIN32_WINNT 0x0600
+#    define WINVER       0x0600
 
 #    define QB64_BACKSLASH_FILESYSTEM
 #    ifdef _MSC_VER


### PR DESCRIPTION
We started defining `_WIN32_WINNT` a little while ago to express that we
require Windows Vista or above for support. This enables us to access
some Windows Vista-only APIs. The fact that `WINVER` also needs to be
defined was missed, and it seems that defining one means the other no
longer gets defined automatically as it did before. Thus we're simplying
now also defining `WINVER` the same as `_WIN32_WINNT`.

This fixes High-DPI awareness and a few other things that were gated
behind WINVER checks.