### PR TITLE
Split up workflows

### DIFF
--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -1,0 +1,121 @@
+name: QB64-PE Build Process
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: x64
+            prefix: lnx
+          - os: macos-latest
+            platform: x64
+            prefix: osx
+          - os: windows-latest
+            platform: x64
+            prefix: win
+          - os: windows-latest
+            platform: x86
+            prefix: win
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      PLATFORM: ${{ matrix.platform }}
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+      # A deploy key is setup so that the potential push of ./internal/source can
+      # trigger a new build. Care is taken to make sure loops cannot happen.
+    - uses: webfactory/ssh-agent@v0.5.4
+      if: ${{ github.event_name == 'push' && matrix.os == 'ubuntu-latest' }}
+      with:
+        ssh-private-key: ${{ secrets.ACTION_DEPLOY_KEY }}
+
+    - name: Install dependencies
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: sudo apt update && sudo apt install build-essential x11-utils mesa-common-dev libglu1-mesa-dev libasound2-dev zlib1g-dev
+
+    - name: Calculate Version
+      shell: bash
+      run: .ci/calculate_version.sh
+
+    - name: Read version for artifacts
+      shell: bash
+      run: echo "version=$(.ci/read-version.sh)" >> $GITHUB_ENV
+
+    - name: Bootstrap compiler Linux/OSX
+      if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
+      run: .ci/bootstrap.sh ${{ matrix.prefix }}
+
+    - name: Bootstrap compiler Windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: .ci/bootstrap.bat
+
+    - name: Compile Linux/OSX
+      if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest' }}
+      run: .ci/compile.sh ${{ matrix.prefix }}
+
+    - name: Compile Windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: .ci/compile.bat
+
+    - name: Test libqb
+      shell: bash
+      run: tests/run_c_tests.sh
+
+    - name: Print QB64-PE Version
+      run: ./qb64pe -?
+
+    - name: Test
+      shell: bash
+      run: tests/run_tests.sh
+
+    - name: Create QB64-PE Artifact
+      shell: bash
+      run: .ci/make-dist.sh ${{ matrix.os }} "${{ env.version }}"
+
+      # Note that compiling programs in dist does modify the ./dist and make it
+      # dirty, but that's ok because we've already create the .7z or .tar.gz
+      # artifacts in the previous step
+    - name: Test QB64-PE Artifact
+      shell: bash
+      run: tests/run_dist_tests.sh ./dist/qb64pe ${{ matrix.prefix }}
+
+      # Only update ./internal/source if we're building on Linux, building on
+      # the main branch, and building a Pull request merge. Otherwise the repo
+      # is left alone.
+    - name: Update ./internal/source
+      if: ${{ github.event_name == 'push' &&  matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'Merge pull request') }}
+      run: .ci/push-internal-source.sh
+
+    - uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: qb64pe-${{ matrix.prefix }}${{ matrix.prefix == 'win' && format('-{0}', matrix.platform) || '' }}-${{ env.version }}
+        path: |
+          tests/results/
+          qb64pe_win-x86*.7z
+          qb64pe_win-x64*.7z
+          qb64pe_lnx*.tar.gz
+          qb64pe_osx*.tar.gz
+
+    - name: Create release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v1
+      with:
+        draft: true
+        files: |
+          qb64pe_win-x86*.7z
+          qb64pe_win-x64*.7z
+          qb64pe_lnx*.tar.gz
+          qb64pe_osx*.tar.gz
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,7 +1,7 @@
-name: CI
+name: PR
 
 on:
-  push:
+  pull_request:
     branches:
       - 'main'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
-name: CI
+name: Release
 
 on:
   push:
-    branches:
-      - 'main'
+    tags:
+      - 'v*'
 
 jobs:
   build:


### PR DESCRIPTION
Splitting up the build process into separate workflows makes it easier
to differentiate the builds for each, since each Workflow will get a
different name and history of builds. The actual build process remains
the same.

A screenshot of the result is below:
![image](https://user-images.githubusercontent.com/3310024/187117196-77bc83ec-9c1e-4d37-bff1-3a86bac8f14c.png)

`CI` only contains builds of `main`. `PR` contains every `PR` build. `Release` contains tagged release builds. `QB64-PE Build Process` doesn't get any builds under it, but I couldn't see an obvious way to not make it get listed. The big win here is that the build history for each of these is separate.

Edit: Note that I tested all of the workflows individually in my fork to verify this works :)