### PR TITLE
Update setup_win.bat

### DIFF
--- a/setup_win.bat
+++ b/setup_win.bat
@@ -4,9 +4,21 @@ echo QB64-PE Setup
 echo.
 
 mkdir internal\c\c_compiler
+echo.
 
 if exist internal\c\c_compiler\bin\c++.exe goto skipccompsetup
-reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && set MINGW=mingw32.exe || set MINGW=mingw64.exe
+reg Query "HKLM\Hardware\Description\System\CentralProcessor\0" | find /i "x86" > NUL && goto download32 || goto download64choice
+
+:download32
+set MINGW=mingw32.exe
+goto downloadfinished
+
+:download64choice
+choice /C 12 /M "Do you prefer to download 1)32-bit QB64-PE or 2)64-bit QB64-PE"
+if errorlevel == 1 goto download32
+set MINGW=mingw64.exe
+
+:downloadfinished
 
 set url="https://www.qb64phoenix.com/qb64_files/%MINGW%"
 
@@ -16,7 +28,6 @@ curl %url% -o %MINGW%
 echo Extracting %MINGW% as C++ Compiler
 @echo off
 %MINGW% -y -o"./internal/c/c_compiler/"
-del %MINGW%
 
 :skipccompsetup
 


### PR DESCRIPTION
Removed the DEL command which was taking 5-7 minutes to execute and appeared to lock up and freeze the process.

Added option for users on 64-bit OSes to be able to choose if they want to download the 64-bit or the 32-bit compiler.