### PR TITLE
Remove DPI Awareness on Windows

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -24356,24 +24356,6 @@ void call_int(int32 i) {
 // Creating/destroying an image surface:
 
 int32 func__newimage(int32 x, int32 y, int32 bpp, int32 passed) {
-#ifdef QB64_WINDOWS
-#    if WINVER >= 0x0600 // this block is not compatible with XP
-    static bool j;
-    if (j != 1) {
-        FARPROC dpiaware;
-        HMODULE user32 = LoadLibrary(TEXT("user32.dll"));
-        if (user32 != NULL) {
-            dpiaware = GetProcAddress(user32, "SetProcessDPIAware");
-            if (NULL != dpiaware) {
-                (dpiaware)();
-                j = 1;
-                FreeLibrary(user32);
-            }
-            FreeLibrary(user32);
-        }
-    }
-#    endif
-#endif
     static int32 i;
     if (new_error)
         return 0;


### PR DESCRIPTION
DPI Awareness allows a program to tell Windows that it will handle
properly scaling itself for the screen's DPI. Thus when a program is DPI
Aware, it will always see the actual screen size. When a program is not
DPI Aware, then Windows will scale the program according to the
selection by the user, and the reported screen size will match the
scaled size rather than the actual screen size.

Commit 189cdb8e added logic to enable DPI Awareness on Windows, but it
was hidden behind a `WINVER` check. This meant it was not actually in
use because at the time QB64 did not set a `WINVER` high enough to
actually enable that code. As such all Windows versions of QB64
including v2.0.2 were not DPI Aware.

Much later-on, Commit 869e361e declared a `_WIN32_WINNT` of `0x0600`,
which seems to have also declared `WINVER` as the same and thus enabled
the DPI Awareness logic. As a consequence, QB64-PE programs no longer
get scaled even though they don't have a way to acquire the current DPI
to do proper scaling themselves.

Since the behavior change was unintentional and proper language support
is not there, we're considering the addition of DPI Awareness a bug. It
will be added back some time later with more language support to allow
it to be properly used.