### PR TITLE
Fix usage of `mem_block` `type` in `_MEMSOUND`

### DIFF
--- a/internal/c/common.h
+++ b/internal/c/common.h
@@ -255,18 +255,12 @@ struct mem_block {
     ptrszint size;
     int64 lock_id;        // 64-bit key, must be present at lock's offset or memory region is invalid
     ptrszint lock_offset; // pointer to lock
-    ptrszint type;
-    /*
-        memorytype (4 bytes, but only the first used, for flags):
-        1 integer values
-        2 unsigned (set in conjunction with integer)
-        4 floating point values
-        8 char string(s) 'element-size is the memory size of 1 string
-    */
+    ptrszint type;        // https://qb64phoenix.com/qb64wiki/index.php/MEM
     ptrszint elementsize;
     int32 image;
     int32 sound;
 };
+
 struct mem_lock {
     uint64 id;
     int32 type; // required to know what action to take (if any) when a request is made to free the block

--- a/internal/c/parts/audio/audio.cpp
+++ b/internal/c/parts/audio/audio.cpp
@@ -1962,11 +1962,13 @@ mem_block func__memsound(int32_t handle, int32_t targetChannel) {
     // Setup type: This was not done in the old code
     // But we are doing it here. By examing the type the user can now figure out if they have to use FP32 or integers
     if (maFormat == ma_format::ma_format_f32)
-        mb.type = 4; // FP32
-    else
-        mb.type = 1; // Integer
-    if (maFormat == ma_format::ma_format_u8)
-        mb.type |= 2; // Unsigned
+        mb.type = 4 + 256; // FP32
+    else if (maFormat == ma_format::ma_format_s32)
+        mb.type = 4 + 128; // Int32
+    else if (maFormat == ma_format::ma_format_s16)
+        mb.type = 2 + 128; // Int16
+    else if (maFormat == ma_format::ma_format_u8)
+        mb.type = 1 + 128 + 1024; // Int8
 
     mb.elementsize = ma_get_bytes_per_frame(maFormat, channels); // Set the element size. This is the size of each PCM frame in bytes
     mb.offset = (ptrszint)ds->pNode->data.backend.decoded.pData; // Setup offset


### PR DESCRIPTION
This corrects an issue with `_MEMSOUND`, where it was using the older .TYPE values (prior to 1.000) instead of values for version 1.000 and up. This also lets users easily detect more sample formats when using `_MEMSOUND` in their code.