### PR TITLE
Fix _MOUSEMOVE when window is resized

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -6605,7 +6605,6 @@ int32 selectfont(int32 f, img_struct *im) {
 int32 nmodes = 0;
 int32 anymode = 0;
 
-float x_scale = 1, y_scale = 1;
 int32 x_offset = 0, y_offset = 0;
 int32 x_limit = 0, y_limit = 0;
 
@@ -23959,17 +23958,20 @@ void sub__mousemove(float x, float y) {
         if (y2 > sy - 1)
             goto error;
     }
+
     // x2,y2 are pixel co-ordinates
     // adjust for fullscreen position as necessary:
-    x2 *= x_scale;
-    y2 *= y_scale;
-    x2 += x_offset;
-    y2 += y_offset;
+    x2 *= environment_2d__screen_x_scale;
+    y2 *= environment_2d__screen_y_scale;
+    x2 += environment_2d__screen_x1;
+    y2 += environment_2d__screen_y1;
+
     while (!window_exists) {
         Sleep(100);
     }
     glutWarpPointer(x2, y2);
     return;
+
 error:
     error(5);
 #endif


### PR DESCRIPTION
`sub__mousemove` is trying to use `x_scale`, `y_scale`, `x_offset`, and
`y_offset` to calculate where the mouse should be in the event the
window coordinates are different from the screen coordinates.

Unfortunately, all four of those variables are actually never set in the
program. The real scale values and offsets (in the event of
letterboxing) are stored in `environment_2d__` values. This change
switches `sub__mousemove` to simply use the correct values when
calculating the mouse position.

Because `x_scale` and `y_scale` are not used anywhere else I just
removed them completely. I wanted to remove `x_offset` and `y_offset` as
well but there are a few spots that make use of it. It must be a bug,
since they are never assigned values other than zero, but I'm not sure
if the correct fix for the other locations is to use the
`environment_2d__` value or do nothing, so I'm leaving them for now and
we can address them later.

I tested the fix with `_FULLSCREEN`, `_FULLSCREEN _STRETCH`,
`$RESIZE:ON`, `$RESIZE:STRETCH`, `$RESIZE:SMOOTH`, and
`_FULLSCREEN _SQUAREPIXELS`, and in all cases `_MOUSEMOVE` sends
the mouse to the correct location for the current `SCREEN`.