### PR TITLE
Fix compiling source files with single quotes in name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,11 +386,11 @@ clean: $(CLEAN_DEP_LIST)
 	$(RM) $(call FIXPATH,$(CLEAN_LIST))
 
 $(EXE): $(EXE_OBJS) $(EXE_LIBS)
-	$(CXX) $(CXXFLAGS) $(EXE_OBJS) -o '$@' $(EXE_LIBS) $(CXXLIBS)
+	$(CXX) $(CXXFLAGS) $(EXE_OBJS) -o "$@" $(EXE_LIBS) $(CXXLIBS)
 ifneq ($(filter-out osx,$(OS)),)
 ifneq ($(STRIP_SYMBOLS),n)
-	$(OBJCOPY) --only-keep-debug '$@' '$(PATH_INTERNAL_TEMP)/$(notdir $@).sym'
-	$(OBJCOPY) --strip-unneeded '$@'
+	$(OBJCOPY) --only-keep-debug "$@" "$(PATH_INTERNAL_TEMP)/$(notdir $@).sym"
+	$(OBJCOPY) --strip-unneeded "$@"
 endif
 endif
 

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -12525,6 +12525,7 @@ CxxLibsExtra$ = CxxLibsExtra$ + " " + mylib$ + " " + mylibopt$
 ' Make and the shell don't like certain characters in the file name, so we
 ' escape them to get them to handle them properly
 escapedExe$ = StrReplace$(path.exe$ + file$ + extension$, " ", "\ ")
+escapedExe$ = StrReplace$(escapedExe$, CHR$(34), "\" + CHR$(34))
 escapedExe$ = StrReplace$(escapedExe$, "$", "$$")
 
 makeline$ = make$ + makedeps$ + " EXE=" + AddQuotes$(escapedExe$)

--- a/tests/compile_tests/single'quote'test/single'quote'test.bas
+++ b/tests/compile_tests/single'quote'test/single'quote'test.bas
@@ -1,0 +1,4 @@
+$CONSOLE:ONLY
+
+Print "Hello, World!";
+SYSTEM

--- a/tests/compile_tests/single'quote'test/single'quote'test.output
+++ b/tests/compile_tests/single'quote'test/single'quote'test.output
@@ -1,0 +1,1 @@
+Hello, World!


### PR DESCRIPTION
Using single quotes in a file name wasn't working because the Makefile
was using single quotes itself to quote the filename when providing it
to the compiler. The Makefile was switched to use double quotes instead,
which work just as well but are allowed to contain single quotes inside
of them.

Since double quotes are a legal character to have in a file name on
Linux and Mac OS, I added extra logic to start escaping double quote
characters.

I added a test to verify that we can compile source files with single
quotes in the name. I could not add a test for double quotes since such
files cannot exist on Windows and thus cannot easily be added to the
repository.