### PR TITLE
Fix compiling bas files relative to the CWD

### DIFF
--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -380,6 +380,9 @@ DIM SHARED compilelog$
 '$INCLUDE:'global\IDEsettings.bas'
 
 CMDLineFile = ParseCMDLineArgs$
+IF CMDLineFile <> "" AND _FILEEXISTS(_STARTDIR$ + "/" + CMDLineFile) THEN
+    CMDLineFile = _STARTDIR$ + "/" + CMDLineFile
+END IF
 
 IF ConsoleMode THEN
     _DEST _CONSOLE

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -379,9 +379,12 @@ DIM SHARED compilelog$
 
 '$INCLUDE:'global\IDEsettings.bas'
 
+DIM OutputIsRelativeToStartDir AS LONG
+
 CMDLineFile = ParseCMDLineArgs$
 IF CMDLineFile <> "" AND _FILEEXISTS(_STARTDIR$ + "/" + CMDLineFile) THEN
     CMDLineFile = _STARTDIR$ + "/" + CMDLineFile
+    OutputIsRelativeToStartDir = -1
 END IF
 
 IF ConsoleMode THEN
@@ -12319,19 +12322,38 @@ IF idemode = 0 AND No_C_Compile_Mode = 0 THEN
         path.out$ = getfilepath$(outputfile_cmd$)
         f$ = MID$(outputfile_cmd$, LEN(path.out$) + 1)
         file$ = RemoveFileExtension$(f$)
-        IF LEN(path.out$) THEN
+
+        IF LEN(path.out$) OR OutputIsRelativeToStartDir THEN
+            currentdir$ = _CWD$
+
+            IF OutputIsRelativeToStartDir THEN
+                ' This CHDIR makes the next CHDIR relative to _STARTDIR$
+                ' We do this if the provided source file was also relative to _STARTDIR$
+                CHDIR _STARTDIR$
+
+                ' If there was no provided path then that is the same as the
+                ' output file being directly in _STARTDIR$. Assigning it here
+                ' is perfectly fine and avoids failing the error check below
+                ' with a blank string.
+                IF LEN(path.out$) = 0 THEN
+                    path.out$ = _STARTDIR$
+                END IF
+            END IF
+
             IF _DIREXISTS(path.out$) = 0 THEN
                 PRINT
                 PRINT "Can't create output executable - path not found: " + path.out$
                 IF ConsoleMode THEN SYSTEM 1
                 END 1
             END IF
-            currentdir$ = _CWD$
+
             CHDIR path.out$
             path.out$ = _CWD$
             CHDIR currentdir$
+
             IF RIGHT$(path.out$, 1) <> pathsep$ THEN path.out$ = path.out$ + pathsep$
             path.exe$ = path.out$
+
             SaveExeWithSource = -1 'Override the global setting if an output file was specified
         END IF
     END IF

--- a/tests/compile_tests.sh
+++ b/tests/compile_tests.sh
@@ -60,7 +60,7 @@ do
     cd "./tests/compile_tests/$category"
 
     # -m and -q make sure that we get predictable results
-    "../../../$QB64" $compilerFlags -m -q -x "$testName.bas" -o "$EXE" 1>"../../../$compileResultOutput"
+    "../../../$QB64" $compilerFlags -q -m -x "$testName.bas" -o "../../../$EXE" 1>"../../../$compileResultOutput"
     ERR=$?
 
     popd >/dev/null

--- a/tests/compile_tests.sh
+++ b/tests/compile_tests.sh
@@ -56,9 +56,14 @@ do
         compilerFlags=$(cat "./tests/compile_tests/$category/$testName.flags")
     fi
 
+    pushd . >/dev/null
+    cd "./tests/compile_tests/$category"
+
     # -m and -q make sure that we get predictable results
-    "$QB64" $compilerFlags -m -q -x "./tests/compile_tests/$category/$testName.bas" -o "$EXE" 1>"$compileResultOutput"
+    "../../../$QB64" $compilerFlags -m -q -x "$testName.bas" -o "$EXE" 1>"../../../$compileResultOutput"
     ERR=$?
+
+    popd >/dev/null
     cp_if_exists ./internal/temp/compilelog.txt "$RESULTS_DIR/$category-$testName-compilelog.txt"
 
     if [ "$testType" == "success" ]; then

--- a/tests/compile_tests/extra/include_extra.bi
+++ b/tests/compile_tests/extra/include_extra.bi
@@ -1,0 +1,2 @@
+
+PRINT "include_extra.bi was included!"

--- a/tests/compile_tests/extra/include_extra_include.bi
+++ b/tests/compile_tests/extra/include_extra_include.bi
@@ -1,0 +1,12 @@
+
+' Include a file relative to the location of this file (which itself is included from elsewhere)
+
+' Both relative formats should work
+
+'$include:'./include_extra_target.bi'
+'$include:'include_extra_target.bi'
+
+' Absolute position relative to the compiler should work too
+
+'$include:'./tests/compile_tests/extra/include_extra_target.bi'
+'$include:'tests/compile_tests/extra/include_extra_target.bi'

--- a/tests/compile_tests/extra/include_extra_target.bi
+++ b/tests/compile_tests/extra/include_extra_target.bi
@@ -1,0 +1,4 @@
+
+includeCount = includeCount + 1
+
+PRINT "include_extra_target.bi was included! Include count:"; includeCount

--- a/tests/compile_tests/include_paths/include_fixed_compile_location.bas
+++ b/tests/compile_tests/include_paths/include_fixed_compile_location.bas
@@ -1,0 +1,10 @@
+$CONSOLE:ONLY
+
+' This include path is relative to the location of QB64-PE
+
+' Both relative path formats should work
+
+'$include:'./tests/compile_tests/extra/include_extra.bi'
+'$include:'tests/compile_tests/extra/include_extra.bi'
+
+SYSTEM

--- a/tests/compile_tests/include_paths/include_fixed_compile_location.output
+++ b/tests/compile_tests/include_paths/include_fixed_compile_location.output
@@ -1,0 +1,2 @@
+include_extra.bi was included!
+include_extra.bi was included!

--- a/tests/compile_tests/include_paths/include_multiple.bas
+++ b/tests/compile_tests/include_paths/include_multiple.bas
@@ -1,0 +1,12 @@
+$CONSOLE:ONLY
+
+' Include a file that itself includes another file. It does so in a relative
+' fashion
+
+Dim includeCount As Long
+
+'$include:'../extra/include_extra_include.bi'
+'$include:'./tests/compile_tests/extra/include_extra_include.bi'
+'$include:'tests/compile_tests/extra/include_extra_include.bi'
+
+SYSTEM

--- a/tests/compile_tests/include_paths/include_multiple.output
+++ b/tests/compile_tests/include_paths/include_multiple.output
@@ -1,0 +1,12 @@
+include_extra_target.bi was included! Include count: 1 
+include_extra_target.bi was included! Include count: 2 
+include_extra_target.bi was included! Include count: 3 
+include_extra_target.bi was included! Include count: 4 
+include_extra_target.bi was included! Include count: 5 
+include_extra_target.bi was included! Include count: 6 
+include_extra_target.bi was included! Include count: 7 
+include_extra_target.bi was included! Include count: 8 
+include_extra_target.bi was included! Include count: 9 
+include_extra_target.bi was included! Include count: 10 
+include_extra_target.bi was included! Include count: 11 
+include_extra_target.bi was included! Include count: 12 

--- a/tests/compile_tests/include_paths/include_relative.bas
+++ b/tests/compile_tests/include_paths/include_relative.bas
@@ -1,0 +1,7 @@
+$CONSOLE:ONLY
+
+' This include path is specified relative to the location of the current source file
+
+'$include:'../extra/include_extra.bi'
+
+SYSTEM

--- a/tests/compile_tests/include_paths/include_relative.output
+++ b/tests/compile_tests/include_paths/include_relative.output
@@ -1,0 +1,1 @@
+include_extra.bi was included!


### PR DESCRIPTION
Fix was pulled from QB64Official/qb64#17 by @DualBrain, I just added tests around it.

Most (all?) compilers allow you to run the compiler from a separate directory than the compiler itself is located in and compile source files relative to that directory. QB64-PE however does not allow that, for a variety of reasons it always search for the provided source file relative to the location of the QB64-PE compiler rather than the CWD it was run from. This is pretty unexpected behavior in a lot of cases, and also doesn't give very helpful error messages either.

This change has us check if the source file exists at the given CWD location, and if it does we will prepend the CWD to produce the correct path to the file.

To test that this behavior works as expected I modified `compile_test.sh` to compile from within the test directories using a relative path directly to the test file, this fails with current QB64-PE versions because it can't find the source file.

Additionally, I was unsure of whether this would impact the behavior of `'$include`, so I added some tests around include that uses various combinations of paths relative to QB64-PE and relative to the source file being compiled, and they all find the files as expected so I think it's fine.