### PR TITLE
Add and fix options listed in manpage

### DIFF
--- a/qb64pe.1
+++ b/qb64pe.1
@@ -11,7 +11,7 @@ USAGE: qb64pe [switches] <file>
 Source file to load
 .TP
 \fB\-v\fR
-Verbose mode (detailed warnings)
+Print version number and exit
 .TP
 \fB\-c\fR
 Compile instead of edit
@@ -29,6 +29,15 @@ Generate C code without compiling to executable
 \fB\-o\fR <output file>
 Write output executable to <output file>
 .TP
+\fB\-w\fR
+Show warnings when compiling
+.TP
+\fB\-q\fR
+Quiet mode (suppresses most output other than warnings and errors)
+.TP
+\fB\-m\fR
+Suppress colors in output
+.TP
 \fB\-e\fR
 Enables OPTION _EXPLICIT, making variable declaration
 mandatory (per\-compilation; doesn't affect the
@@ -36,6 +45,9 @@ source file or global settings)
 .TP
 \fB\-s[\fR:switch=true/false]
 View/edit compiler settings
+.TP
+\fB\-f[\fR:setting=value]
+Configure compiler settings for this run of the compiler
 .TP
 \fB\-l\fR:<line number>
 Starts the IDE at the specified line number


### PR DESCRIPTION
Fairly simple, the man page was missing some of the switches (the new one I added, and also some older ones). The `-v` also had the wrong documentation.

Fixes: #199