### PR TITLE
Implement `_SNDPLAYCOPY` enhancement #185

### DIFF
--- a/internal/c/libqb/include/audio.h
+++ b/internal/c/libqb/include/audio.h
@@ -66,7 +66,7 @@ int32_t func__sndopen(qbs *fileName, qbs *requirements, int32_t passed);
 void sub__sndclose(int32_t handle);
 int32_t func__sndcopy(int32_t src_handle);
 void sub__sndplay(int32_t handle);
-void sub__sndplaycopy(int32_t src_handle, double volume, int32_t passed);
+void sub__sndplaycopy(int32_t src_handle, double volume, double x, double y, double z, int32_t passed);
 void sub__sndplayfile(qbs *fileName, int32_t sync, double volume, int32_t passed);
 void sub__sndpause(int32_t handle);
 int32_t func__sndplaying(int32_t handle);

--- a/internal/c/parts/audio/audio.cpp
+++ b/internal/c/parts/audio/audio.cpp
@@ -1540,16 +1540,7 @@ void sub__sndplaycopy(int32_t src_handle, double volume, double x, double y, dou
 
         if (passed & 4 || passed & 8) {                                                                   // If y or z or both are passed
             ma_sound_set_spatialization_enabled(&audioEngine.soundHandles[dst_handle]->maSound, MA_TRUE); // Enable 3D spatialization
-
-            // Set values of x, y, z to 0 if these were not passed
-            if (!(passed & 2))
-                x = 0.0;
-            if (!(passed & 4))
-                y = 0.0;
-            if (!(passed & 8))
-                z = 0.0;
-
-            ma_sound_set_position(&audioEngine.soundHandles[dst_handle]->maSound, x, y, z); // Use full 3D positioning
+            ma_sound_set_position(&audioEngine.soundHandles[dst_handle]->maSound, x, y, z);               // Use full 3D positioning
         } else if (passed & 2) {
             ma_sound_set_spatialization_enabled(&audioEngine.soundHandles[dst_handle]->maSound, MA_FALSE); // Disable spatialization for better stereo sound
             ma_sound_set_pan_mode(&audioEngine.soundHandles[dst_handle]->maSound, ma_pan_mode_pan);        // Set true panning
@@ -1559,6 +1550,8 @@ void sub__sndplaycopy(int32_t src_handle, double volume, double x, double y, dou
         sub__sndplay(dst_handle);                              // Play the sound
         audioEngine.soundHandles[dst_handle]->autoKill = true; // Set to auto kill
     }
+
+    AUDIO_DEBUG_PRINT("Playing sound copy %i: volume %lf, 3D (%lf, %lf, %lf)", dst_handle, volume, x, y, z);
 }
 
 /// <summary>

--- a/internal/c/parts/audio/audio.cpp
+++ b/internal/c/parts/audio/audio.cpp
@@ -1538,10 +1538,10 @@ void sub__sndplaycopy(int32_t src_handle, double volume, double x, double y, dou
         if (passed & 1)
             ma_sound_set_volume(&audioEngine.soundHandles[dst_handle]->maSound, volume);
 
-        if (passed & 4 || passed & 8) {                                                                   // If y or z or both are passed
-            ma_sound_set_spatialization_enabled(&audioEngine.soundHandles[dst_handle]->maSound, MA_TRUE); // Enable 3D spatialization
-            ma_sound_set_position(&audioEngine.soundHandles[dst_handle]->maSound, x, y, z);               // Use full 3D positioning
-        } else if (passed & 2) {
+        if (passed & 4 || passed & 8) {                                                                    // If y or z or both are passed
+            ma_sound_set_spatialization_enabled(&audioEngine.soundHandles[dst_handle]->maSound, MA_TRUE);  // Enable 3D spatialization
+            ma_sound_set_position(&audioEngine.soundHandles[dst_handle]->maSound, x, y, z);                // Use full 3D positioning
+        } else if (passed & 2) {                                                                           // If x is passed
             ma_sound_set_spatialization_enabled(&audioEngine.soundHandles[dst_handle]->maSound, MA_FALSE); // Disable spatialization for better stereo sound
             ma_sound_set_pan_mode(&audioEngine.soundHandles[dst_handle]->maSound, ma_pan_mode_pan);        // Set true panning
             ma_sound_set_pan(&audioEngine.soundHandles[dst_handle]->maSound, x);                           // Just use stereo panning
@@ -1693,8 +1693,8 @@ void sub__sndbal(int32_t handle, double x, double y, double z, int32_t channel, 
             if (!(passed & 4))
                 z = v.z;
 
-            ma_sound_set_position(&audioEngine.soundHandles[handle]->maSound, x, y, z); // Use full 3D positioning
-        } else {
+            ma_sound_set_position(&audioEngine.soundHandles[handle]->maSound, x, y, z);                // Use full 3D positioning
+        } else if (passed & 1) {                                                                       // Only bother if x is passed
             ma_sound_set_spatialization_enabled(&audioEngine.soundHandles[handle]->maSound, MA_FALSE); // Disable spatialization for better stereo sound
             ma_sound_set_pan_mode(&audioEngine.soundHandles[handle]->maSound, ma_pan_mode_pan);        // Set true panning
             ma_sound_set_pan(&audioEngine.soundHandles[handle]->maSound, x);                           // Just use stereo panning

--- a/internal/c/parts/audio/out/src.c
+++ b/internal/c/parts/audio/out/src.c
@@ -1149,7 +1149,7 @@ void sub__sndclose(int32 handle) {
 
 //"macros"
 
-void sub__sndplaycopy(int32 handle, double volume, int32 passed) {
+void sub__sndplaycopy(int32 handle, double volume, double x, double y, double z, int32 passed) {
     if (new_error)
         return;
     sndsetup();
@@ -1157,7 +1157,7 @@ void sub__sndplaycopy(int32 handle, double volume, int32 passed) {
     handle2 = func__sndcopy(handle);
     if (!handle2)
         return; // an error has already happened
-    if (passed) {
+    if (passed & 1) {
         sub__sndvol(handle2, volume);
         if (sub__sndvol_error) {
             sub__sndclose(handle2);

--- a/internal/c/qbx.cpp
+++ b/internal/c/qbx.cpp
@@ -1,4 +1,5 @@
 #include "common.h"
+#include "audio.h"
 
 extern int32 func__cinp(int32 toggle,
                         int32 passed); // Console INP scan code reader
@@ -216,11 +217,6 @@ extern void sub__maptriangle(int32 cull_options, float sx1, float sy1,
                              int32 smooth_options, int32 passed);
 extern void sub__depthbuffer(int32 options, int32 dst, int32 passed);
 extern int32 func_play(int32 ignore);
-extern int32 func__sndrate();
-extern int32 func__sndopenraw();
-extern void sub__sndrawdone(int32 handle, int32 passed);
-extern void sub__sndraw(float left, float right, int32 handle, int32 passed);
-extern double func__sndrawlen(int32 handle, int32 passed);
 extern void sub_paletteusing(void *element, int32 bits);
 extern int64 func_read_int64(uint8 *data, ptrszint *data_offset,
                              ptrszint data_size);
@@ -581,26 +577,6 @@ extern qbs *func_input(int32 n, int32 i, int32 passed);
 extern double func_sqr(double value);
 extern void sub_beep();
 extern void snd_check();
-extern int32 func__sndraw(uint8 *data, uint32 bytes);
-extern int32 func__sndopen(qbs *filename, qbs *requirements, int32 passed);
-extern double func__sndlen(int32 handle);
-extern void sub__sndlimit(int32 handle, double limit);
-extern void sub__sndstop(int32 handle);
-extern void sub__sndsetpos(int32 handle, double sec);
-extern double func__sndgetpos(int32 handle);
-extern void sub__sndbal(int32 handle, double x, double y, double z,
-                        int32 channel, int32 passed);
-extern void sub__sndplay(int32 handle);
-extern void sub__sndloop(int32 handle);
-extern int32 func__sndcopy(int32 handle);
-extern void sub__sndvol(int32 handle, float volume);
-extern void sub__sndpause(int32 handle);
-extern int32 func__sndpaused(int32 handle);
-extern int32 func__sndplaying(int32 handle);
-extern void sub__sndclose(int32 handle);
-extern void sub__sndplayfile(qbs *filename, int32 sync, double volume,
-                             int32 passed);
-extern void sub__sndplaycopy(int32 handle, double volume, int32 passed);
 extern qbs *func_command(int32 index, int32 passed);
 extern int32 func__commandcount();
 extern void sub_kill(qbs *str);

--- a/source/subs_functions/subs_functions.bas
+++ b/source/subs_functions/subs_functions.bas
@@ -1929,10 +1929,10 @@ clearid
 id.n = qb64prefix$ + "SndPlayCopy": id.Dependency = DEPENDENCY_AUDIO_OUT
 id.subfunc = 2
 id.callname = "sub__sndplaycopy"
-id.args = 2
-id.arg = MKL$(ULONGTYPE - ISPOINTER) + MKL$(FLOATTYPE - ISPOINTER)
-id.specialformat = "?[,?]"
-id.hr_syntax = "_SNDPLAYCOPY handle&[, volume!]"
+id.args = 5
+id.arg = MKL$(ULONGTYPE - ISPOINTER) + MKL$(FLOATTYPE - ISPOINTER) + MKL$(FLOATTYPE - ISPOINTER) + MKL$(FLOATTYPE - ISPOINTER) + MKL$(FLOATTYPE - ISPOINTER)
+id.specialformat = "?[,[?][,[?][,[?][,[?]]]]]"
+id.hr_syntax = "_SNDPLAYCOPY handle&[, volume!][, x!][, y!][, z!]"
 regid
 
 clearid
@@ -2018,9 +2018,8 @@ id.callname = "sub__sndbal"
 id.args = 5
 id.arg = MKL$(ULONGTYPE - ISPOINTER) + MKL$(FLOATTYPE - ISPOINTER) + MKL$(FLOATTYPE - ISPOINTER) + MKL$(FLOATTYPE - ISPOINTER) + MKL$(ULONGTYPE - ISPOINTER)
 id.specialformat = "?,[?][,[?][,[?][,[?]]]]"
-id.hr_syntax = "_SNDBAL handle&[, x!][, y!][, z!][, channel&]]"
+id.hr_syntax = "_SNDBAL handle&[, x!][, y!][, z!][, channel&]"
 regid
-
 
 clearid
 id.n = qb64prefix$ + "SndVol": id.Dependency = DEPENDENCY_AUDIO_OUT


### PR DESCRIPTION
This implements enhancements to `_SNDPLAYCOPY` as described in #185.

The extra `[, x!][, y!][, z!]` parameters are optional and hence this does not have any breaking changes.
The extra parameters can also be used with the old OpenAL audio backend. However, it does not change the properties of the sound.

We could have backported this feature to the OpenAL backend. However, considering that it is on life-support and may be removed it the future, I do not see any incentive.

This also corrects a minor typo in the help text for `_SNDBAL` that I discovered while implementing the changes in `subs_functions.bas`.