### PR TITLE
Fix setup_osx.command script when run from a different directory

### DIFF
--- a/setup_osx.command
+++ b/setup_osx.command
@@ -1,8 +1,7 @@
-# Argument 1: Location of qb64pe (blank means current directory
-# Argument 2: If not blank, qb64pe will not be started after compiltaion
+# Argument 1: If not blank, qb64pe will not be started after compiltaion
 
-cd "$(dirname "$1")"
-dont_run="$2"
+cd "$(dirname "$0")"
+dont_run="$1"
 
 Pause()
 {

--- a/tests/dist_tests.sh
+++ b/tests/dist_tests.sh
@@ -35,7 +35,17 @@ case "$2" in
         ;;
 
     osx)
-        ./setup_osx.command "." "dont_run" 1>"$RESULTS_DIR/osx-setup.txt"
+        # When testing the OSX script we run it from a different directory as
+        # that is the typical way it is used.
+        pushd . > /dev/null
+        cd "$ROOT"
+
+        $1/setup_osx.command "dont_run" 1>"$RESULTS_DIR/osx-setup.txt"
+        ERR=$?
+
+        popd > /dev/null
+
+        (exit $ERR)
         assert_success_named "OSX setup" cat "$RESULTS_DIR/osx-setup.txt"
         ;;
 esac


### PR DESCRIPTION
I broke this by accident in 5031de2, likely by misreading the $0.  What the line was intended to do was change to the directory the script is located in when the script starts, this allows the script to be started from any location.

Typically this isn't necessary functionality, but for Mac OS it's important because if you double-click the script (the typical way to run it) it is started from the user's home directory. Due to this I also updated the Mac OS distribution test to run the script in this way so that it's closer to how a user will run it.

Fixes: #218