### PR TITLE
Add back internal MessageBox function

### DIFF
--- a/internal/c/parts/gui/gui.cpp
+++ b/internal/c/parts/gui/gui.cpp
@@ -433,5 +433,57 @@ bool gui_alert(const char *fmt, ...) {
 
     return true;
 }
+
+#ifndef QB64_WINDOWS
+
+#    define IDOK 1
+#    define IDCANCEL 2
+#    define IDABORT 3
+#    define IDRETRY 4
+#    define IDIGNORE 5
+#    define IDYES 6
+#    define IDNO 7
+#    define MB_OK 0x00000000L
+#    define MB_OKCANCEL 0x00000001L
+#    define MB_ABORTRETRYIGNORE 0x00000002L
+#    define MB_YESNOCANCEL 0x00000003L
+#    define MB_YESNO 0x00000004L
+#    define MB_RETRYCANCEL 0x00000005L
+#    define MB_SYSTEMMODAL 0x00001000L
+
+// This exists because InForm calls it directly.
+// It only supports the "MB_OK" and "MB_YESNO" options
+int MessageBox(int ignore, char *message, char *title, int type) {
+    const char *msgType;
+    const char *icon;
+    int yesret;
+
+    switch (type & 0b00000111) {
+    case MB_YESNO:
+        msgType = "yesno";
+        icon = "question";
+        yesret = IDYES;
+        break;
+
+    case MB_OK:
+    default:
+        msgType = "ok";
+        icon = "info";
+        yesret = IDOK;
+        break;
+    }
+
+    int result = tinyfd_messageBox(title, message, msgType, icon, 1 /* OK/Yes */);
+
+    switch (result) {
+    case 1:
+        return yesret;
+
+    case 0:
+    default:
+        return IDNO;
+    }
+}
+#endif
 //-----------------------------------------------------------------------------------------------------
 //-----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Unfortunately InForm code calls this function directly via `DECLARE LIBRARY`. For the moment we're adding it back in to keep those programs functioning, in the future it may be removed.

Note that this implementation just matches the functionality of the previous Linux and OSX versions, so it only supports the `MB_OK` and `MB_YESNO` options. To that end `InForm` only ever calls it with those settings when using this implementation (For Windows it calls the win32 `MessageBox` function directly).