### PR TITLE
Fix _InputBox$ on Windows to use DialogBoxIndirect, and a few other changes

### DIFF
--- a/internal/c/parts/gui/tinyfiledialogs.c
+++ b/internal/c/parts/gui/tinyfiledialogs.c
@@ -1100,9 +1100,6 @@ int tinyfd_messageBoxW(
 
         if (aTitle&&!wcscmp(aTitle, L"tinyfd_query")){ strcpy(tinyfd_response, "windows_wchar"); return 1; }
 
-		if (quoteDetectedW(aTitle)) return tinyfd_messageBoxW(L"INVALID TITLE WITH QUOTES", aMessage, aDialogType, aIconType, aDefaultButton);
-		if (quoteDetectedW(aMessage)) return tinyfd_messageBoxW(aTitle, L"INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
-
         if (aIconType && !wcscmp(L"warning", aIconType))
         {
                 aCode = MB_ICONWARNING;
@@ -1534,14 +1531,6 @@ wchar_t * tinyfd_saveFileDialogW(
 
         if (aTitle&&!wcscmp(aTitle, L"tinyfd_query")){ strcpy(tinyfd_response, "windows_wchar"); return (wchar_t *)1; }
 
-		if (quoteDetectedW(aTitle)) return tinyfd_saveFileDialogW(L"INVALID TITLE WITH QUOTES", aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription);
-		if (quoteDetectedW(aDefaultPathAndFile)) return tinyfd_saveFileDialogW(aTitle, L"INVALID DEFAULT_PATH WITH QUOTES", aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription);
-		if (quoteDetectedW(aSingleFilterDescription)) return tinyfd_saveFileDialogW(aTitle, aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, L"INVALID FILTER_DESCRIPTION WITH QUOTES");
-		for (i = 0; i < aNumOfFilterPatterns; i++)
-		{
-			if (quoteDetectedW(aFilterPatterns[i])) return tinyfd_saveFileDialogW(L"INVALID FILTER_PATTERN WITH QUOTES", aDefaultPathAndFile, 0, NULL, NULL);
-		}
-
         lHResult = CoInitializeEx(NULL, 0);
 
         getPathWithoutFinalSlashW(lDirname, aDefaultPathAndFile);
@@ -1642,14 +1631,6 @@ wchar_t * tinyfd_openFileDialogW(
 		if (aAllowMultipleSelects < 0) return (wchar_t *)0;
 
 		if (aTitle&&!wcscmp(aTitle, L"tinyfd_query")){ strcpy(tinyfd_response, "windows_wchar"); return (wchar_t *)1; }
-
-		if (quoteDetectedW(aTitle)) return tinyfd_openFileDialogW(L"INVALID TITLE WITH QUOTES", aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription, aAllowMultipleSelects);
-		if (quoteDetectedW(aDefaultPathAndFile)) return tinyfd_openFileDialogW(aTitle, L"INVALID DEFAULT_PATH WITH QUOTES", aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription, aAllowMultipleSelects);
-		if (quoteDetectedW(aSingleFilterDescription)) return tinyfd_openFileDialogW(aTitle, aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, L"INVALID FILTER_DESCRIPTION WITH QUOTES", aAllowMultipleSelects);
-		for (i = 0; i < aNumOfFilterPatterns; i++)
-		{
-			if (quoteDetectedW(aFilterPatterns[i])) return tinyfd_openFileDialogW(L"INVALID FILTER_PATTERN WITH QUOTES", aDefaultPathAndFile, 0, NULL, NULL, aAllowMultipleSelects);
-		}
 
 		if (aAllowMultipleSelects)
 		{
@@ -1820,9 +1801,6 @@ wchar_t * tinyfd_selectFolderDialogW(
 
         if (aTitle&&!wcscmp(aTitle, L"tinyfd_query")){ strcpy(tinyfd_response, "windows_wchar"); return (wchar_t *)1; }
 
-		if (quoteDetectedW(aTitle)) return tinyfd_selectFolderDialogW(L"INVALID TITLE WITH QUOTES", aDefaultPath);
-		if (quoteDetectedW(aDefaultPath)) return tinyfd_selectFolderDialogW(aTitle, L"INVALID DEFAULT_PATH WITH QUOTES");
-
         lHResult = CoInitializeEx(NULL, COINIT_APARTMENTTHREADED);
 
         bInfo.hwndOwner = GetForegroundWindow();
@@ -1871,9 +1849,6 @@ wchar_t * tinyfd_colorChooserW(
         HRESULT lHResult;
 
         if (aTitle&&!wcscmp(aTitle, L"tinyfd_query")){ strcpy(tinyfd_response, "windows_wchar"); return (wchar_t *)1; }
-
-		if (quoteDetectedW(aTitle)) return tinyfd_colorChooserW(L"INVALID TITLE WITH QUOTES", aDefaultHexRGB, aDefaultRGB, aoResultRGB);
-		if (quoteDetectedW(aDefaultHexRGB)) return tinyfd_colorChooserW(aTitle, L"INVALID DEFAULT_HEX_RGB WITH QUOTES", aDefaultRGB, aoResultRGB);
 
         lHResult = CoInitializeEx(NULL, 0);
 
@@ -2734,9 +2709,6 @@ int tinyfd_messageBox(
 	UINT lOriginalCP = 0;
 	UINT lOriginalOutputCP = 0;
 
-	if (tfd_quoteDetected(aTitle)) return tinyfd_messageBox("INVALID TITLE WITH QUOTES", aMessage, aDialogType, aIconType, aDefaultButton);
-	if (tfd_quoteDetected(aMessage)) return tinyfd_messageBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDialogType, aIconType, aDefaultButton);
-
 	if ((!tinyfd_forceConsole || !(GetConsoleWindow() || dialogPresent()))
 		&& (!getenv("SSH_CLIENT") || getenvDISPLAY()))
 	{
@@ -2884,10 +2856,6 @@ char * tinyfd_inputBox(
 
 	if (!aTitle && !aMessage && !aDefaultInput) return lBuff; /* now I can fill lBuff from outside */
 
-	if (tfd_quoteDetected(aTitle)) return tinyfd_inputBox("INVALID TITLE WITH QUOTES", aMessage, aDefaultInput);
-	if (tfd_quoteDetected(aMessage)) return tinyfd_inputBox(aTitle, "INVALID MESSAGE WITH QUOTES", aDefaultInput);
-	if (tfd_quoteDetected(aDefaultInput)) return tinyfd_inputBox(aTitle, aMessage, "INVALID DEFAULT_INPUT WITH QUOTES");
-
     mode = 0;
     hStdin = GetStdHandle(STD_INPUT_HANDLE);
 
@@ -3016,15 +2984,6 @@ char * tinyfd_saveFileDialog(
 
         lBuff[0]='\0';
 
-		if (tfd_quoteDetected(aTitle)) return tinyfd_saveFileDialog("INVALID TITLE WITH QUOTES", aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription);
-		if (tfd_quoteDetected(aDefaultPathAndFile)) return tinyfd_saveFileDialog(aTitle, "INVALID DEFAULT_PATH WITH QUOTES", aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription);
-		if (tfd_quoteDetected(aSingleFilterDescription)) return tinyfd_saveFileDialog(aTitle, aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, "INVALID FILTER_DESCRIPTION WITH QUOTES");
-		for (i = 0; i < aNumOfFilterPatterns; i++)
-		{
-			if (tfd_quoteDetected(aFilterPatterns[i])) return tinyfd_saveFileDialog("INVALID FILTER_PATTERN WITH QUOTES", aDefaultPathAndFile, 0, NULL, NULL);
-		}
-
-
 		if ( ( !tinyfd_forceConsole || !( GetConsoleWindow() || dialogPresent() ) )
 			&& (!getenv("SSH_CLIENT") || getenvDISPLAY()))
         {
@@ -3084,14 +3043,6 @@ char * tinyfd_openFileDialog(
 	char * lPointerInputBox;
 	int i;
 
-	if (tfd_quoteDetected(aTitle)) return tinyfd_openFileDialog("INVALID TITLE WITH QUOTES", aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription, aAllowMultipleSelects);
-	if (tfd_quoteDetected(aDefaultPathAndFile)) return tinyfd_openFileDialog(aTitle, "INVALID DEFAULT_PATH WITH QUOTES", aNumOfFilterPatterns, aFilterPatterns, aSingleFilterDescription, aAllowMultipleSelects);
-	if (tfd_quoteDetected(aSingleFilterDescription)) return tinyfd_openFileDialog(aTitle, aDefaultPathAndFile, aNumOfFilterPatterns, aFilterPatterns, "INVALID FILTER_DESCRIPTION WITH QUOTES", aAllowMultipleSelects);
-	for (i = 0; i < aNumOfFilterPatterns; i++)
-	{
-		if (tfd_quoteDetected(aFilterPatterns[i])) return tinyfd_openFileDialog("INVALID FILTER_PATTERN WITH QUOTES", aDefaultPathAndFile, 0, NULL, NULL, aAllowMultipleSelects);
-	}
-
     if ( ( !tinyfd_forceConsole || !( GetConsoleWindow() || dialogPresent() ) )
 		&& (!getenv("SSH_CLIENT") || getenvDISPLAY()))
         {
@@ -3143,9 +3094,6 @@ char * tinyfd_selectFolderDialog(
 	char * lPointerInputBox;
 	char lString[MAX_PATH_OR_CMD];
 
-	if (tfd_quoteDetected(aTitle)) return tinyfd_selectFolderDialog("INVALID TITLE WITH QUOTES", aDefaultPath);
-	if (tfd_quoteDetected(aDefaultPath)) return tinyfd_selectFolderDialog(aTitle, "INVALID DEFAULT_PATH WITH QUOTES");
-
     if ( ( !tinyfd_forceConsole || !( GetConsoleWindow() || dialogPresent() ) )
 		&& (!getenv("SSH_CLIENT") || getenvDISPLAY()))
         {
@@ -3196,9 +3144,6 @@ char * tinyfd_colorChooser(
 	char lString[MAX_PATH_OR_CMD];
 
 	lDefaultHexRGB[0] = '\0';
-
-	if (tfd_quoteDetected(aTitle)) return tinyfd_colorChooser("INVALID TITLE WITH QUOTES", aDefaultHexRGB, aDefaultRGB, aoResultRGB);
-	if (tfd_quoteDetected(aDefaultHexRGB)) return tinyfd_colorChooser(aTitle, "INVALID DEFAULT_HEX_RGB WITH QUOTES", aDefaultRGB, aoResultRGB);
 
     if ( (!tinyfd_forceConsole || !( GetConsoleWindow() || dialogPresent()) )
 		&& (!getenv("SSH_CLIENT") || getenvDISPLAY()))

--- a/internal/c/parts/gui/tinyfiledialogs.c
+++ b/internal/c/parts/gui/tinyfiledialogs.c
@@ -3078,8 +3078,8 @@ char * tinyfd_openFileDialog(
 	char const * aSingleFilterDescription, /* NULL or "image files" */
     int aAllowMultipleSelects ) /* 0 or 1 */
 {
+	static char lBuff[MAX_PATH_OR_CMD];
 	char lString[MAX_PATH_OR_CMD];
-	char lBuff[MAX_PATH_OR_CMD];
 	char * p;
 	char * lPointerInputBox;
 	int i;

--- a/internal/c/parts/gui/tinyfiledialogs.c
+++ b/internal/c/parts/gui/tinyfiledialogs.c
@@ -1229,12 +1229,12 @@ static BOOL CALLBACK dialogBoxCallback(HWND hwndDlg, UINT message, WPARAM wParam
         {
         case IDOK:
             GetDlgItemText(hwndDlg, ID_TEXT, dialogContents, MAX_PATH_OR_CMD);
-            DestroyWindow(hwndDlg);
+            EndDialog(hwndDlg, 0);
             return TRUE;
 
         case IDCANCEL:
             memset(dialogContents, 0, sizeof(dialogContents));
-            DestroyWindow(hwndDlg);
+            EndDialog(hwndDlg, 0);
             return TRUE;
         }
     }
@@ -1331,6 +1331,9 @@ static LRESULT DisplayMyMessage(HINSTANCE hinst, HWND hwndOwner, const wchar_t *
     lpdit->cx = 190; lpdit->cy = 12;
     lpdit->id = ID_TEXT;    // Text identifier
     lpdit->style = WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL | ES_LEFT;
+
+    if (wcslen(defaultText) == 0)
+        lpdit->style |= ES_PASSWORD;
 
     lpw = (LPWORD)(lpdit + 1);
     *lpw++ = 0xFFFF;

--- a/internal/c/parts/gui/tinyfiledialogs.c
+++ b/internal/c/parts/gui/tinyfiledialogs.c
@@ -968,19 +968,6 @@ static char * ensureFilesExist(char * aDestination,
 
 #ifdef _WIN32
 
-static int __stdcall EnumThreadWndProc(HWND hwnd, LPARAM lParam)
-{
-        wchar_t lTitleName[MAX_PATH];
-        GetWindowTextW(hwnd, lTitleName, MAX_PATH);
-        /* wprintf(L"lTitleName %ls \n", lTitleName);  */
-        if (wcscmp(L"tinyfiledialogsTopWindow", lTitleName) == 0)
-        {
-                SetWindowPos(hwnd, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE);
-                return 0;
-        }
-        return 1;
-}
-
 int tinyfd_messageBoxW(
         wchar_t const * aTitle, /* NULL or "" */
         wchar_t const * aMessage, /* NULL or ""  may contain \n and \t */
@@ -1274,14 +1261,14 @@ static LRESULT DisplayMyMessage(HINSTANCE hinst, HWND hwndOwner, const wchar_t *
     *lpw++ = 0;             // No menu
     *lpw++ = 0;             // Predefined dialog box class (by default)
 
-    for (lpwsz = (LPWSTR)lpw; (*lpwsz++) = *title++;);
+    for (lpwsz = (LPWSTR)lpw; ((*lpwsz++) = *title++););
     lpw = (LPWORD)lpwsz;
 
     // Add font information
     const wchar_t *font = L"Arial";
 
     *lpw++ = 9; // Point size
-    for (lpwsz = (LPWSTR)lpw; (*lpwsz++) = *font++;); // Font name
+    for (lpwsz = (LPWSTR)lpw; ((*lpwsz++) = *font++);); // Font name
     lpw = (LPWORD)lpwsz;
 
     //-----------------------
@@ -1339,7 +1326,7 @@ static LRESULT DisplayMyMessage(HINSTANCE hinst, HWND hwndOwner, const wchar_t *
     *lpw++ = 0xFFFF;
     *lpw++ = 0x0081;        // Edit class
 
-    for (lpwsz = (LPWSTR)lpw; (*lpwsz++) = *defaultText++;);
+    for (lpwsz = (LPWSTR)lpw; ((*lpwsz++) = *defaultText++););
     lpw = (LPWORD)lpwsz;
     *lpw++ = 0;             // No creation data
 
@@ -1357,7 +1344,7 @@ static LRESULT DisplayMyMessage(HINSTANCE hinst, HWND hwndOwner, const wchar_t *
     *lpw++ = 0xFFFF;
     *lpw++ = 0x0082;        // Static class
 
-    for (lpwsz = (LPWSTR)lpw; (*lpwsz++) = *lpszMessage++;);
+    for (lpwsz = (LPWSTR)lpw; ((*lpwsz++) = *lpszMessage++););
     lpw = (LPWORD)lpwsz;
     *lpw++ = 0;             // No creation data
 


### PR DESCRIPTION
This removes the VBS based InputBox for Windows and replaces it with a
version that uses DialogBoxIndirect to create the dialog. While it is a
bit more complicated in some respects, it removes any concerns about the
contents of the strings as they're no longer being inserted into the
generated script. It also has the advantage that it doesn't spawn
another process (which then shows up in the task bar in some situations).

With this changes quote characters are allowed in all of the parameters.
Additionally this is the last set of changes for Windows, Mac OS is the only
platform left.

This additionally contains the change caught by @a740g to mark the `lBuff`
array `static` in `tinyfd_openFileDialog()`. I also went ahead and removed
the last of the quote checks (which weren't doing anything on Windows
beyond keeping parity with the functionality for other platforms).