### PR TITLE
Version 3.4.1

### DIFF
--- a/source/global/version.bas
+++ b/source/global/version.bas
@@ -1,9 +1,9 @@
 DIM SHARED Version AS STRING
 DIM SHARED IsCiVersion AS _BYTE
 
-Version$ = "3.4.0"
-$VERSIONINFO:FileVersion#=3,4,0,0
-$VERSIONINFO:ProductVersion#=3,4,0,0
+Version$ = "3.4.1"
+$VERSIONINFO:FileVersion#=3,4,1,0
+$VERSIONINFO:ProductVersion#=3,4,1,0
 
 ' If ./internal/version.txt exist, then this is some kind of CI build with a label
 If _FILEEXISTS("internal/version.txt") THEN


### PR DESCRIPTION
Bumping to version 3.4.1. This includes the PAINT fixes in #241, several fixes to the dialog functions, a bump of the MinGW version, and also the new `GUI Dialogs` option @SteveMcNeill added which uses the new dialog functionality for the IDE `Open` menu option. The last one is not exactly a bug fix, but I think it's close enough :shrug: To me it doesn't really seem to justify a `3.5.0`.