### PR TITLE
Fix QB64-PE dependency list, _StartDir$ relative compile with no -o, and command line output.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,6 +175,7 @@ endif
 	DEP_ICON := y
 	DEP_ICON_RC := y
 	DEP_SOCKETS := y
+	DEP_HTTP := y
 endif
 
 include $(PATH_INTERNAL_C)/libqb/build.mk

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -1226,6 +1226,11 @@ file$ = f$
 
 fullrecompile:
 
+IF NOT QuietMode THEN
+    PRINT
+    PRINT "Beginning C++ output from QB64 code... "
+END IF
+
 BU_DEPENDENCY_CONSOLE_ONLY = DEPENDENCY(DEPENDENCY_CONSOLE_ONLY)
 FOR i = 1 TO UBOUND(DEPENDENCY): DEPENDENCY(i) = 0: NEXT
 DEPENDENCY(DEPENDENCY_CONSOLE_ONLY) = BU_DEPENDENCY_CONSOLE_ONLY AND 2 'Restore -g switch if used
@@ -1701,11 +1706,6 @@ IF iderecompile THEN
 END IF
 
 IF idemode THEN GOTO ideret1
-
-IF NOT QuietMode THEN
-    PRINT
-    PRINT "Beginning C++ output from QB64 code... "
-END IF
 
 lineinput3load sourcefile$
 

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -12315,11 +12315,15 @@ IF idemode = 0 AND No_C_Compile_Mode = 0 THEN
             PRINT "Compiling C++ code into EXE..."
         END IF
     END IF
-    IF LEN(outputfile_cmd$) THEN
-        'resolve relative path for output file
-        path.out$ = getfilepath$(outputfile_cmd$)
-        f$ = MID$(outputfile_cmd$, LEN(path.out$) + 1)
-        file$ = RemoveFileExtension$(f$)
+
+    ' Fixup the output path if either we got an `-o` argument, or we're relative to `_StartDir$`
+    IF LEN(outputfile_cmd$) Or OutputIsRelativeToStartDir THEN
+        IF LEN(outputfile_cmd$) THEN
+            'resolve relative path for output file
+            path.out$ = getfilepath$(outputfile_cmd$)
+            f$ = MID$(outputfile_cmd$, LEN(path.out$) + 1)
+            file$ = RemoveFileExtension$(f$)
+        END IF
 
         IF LEN(path.out$) OR OutputIsRelativeToStartDir THEN
             currentdir$ = _CWD$


### PR DESCRIPTION
This PR combines three relatively small fixes for #255, #256, and #257:

1. The `Makefile` was missing the `DEP_HTTP` flag which is now required for QB64-PE's help to work.
2. Use of some commands like `$NoPrefix` no longer causes the "Beginning C++ output..." to get duplicated.
3. When using `-x` with a `_SourceDir$`-relative source file, if no `-o` flag is provided the executable is now placed into `_SourceDir$` (instead of being placed at the location of QB64-PE).

Fixes: #255
Fixes: #256
Fixes: #257