### PR TITLE
Fix the 'Beginning C++' message to stop being printed when using the IDE

### DIFF
--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -1226,7 +1226,7 @@ file$ = f$
 
 fullrecompile:
 
-IF NOT QuietMode THEN
+IF idemode = 0 AND NOT QuietMode THEN
     PRINT
     PRINT "Beginning C++ output from QB64 code... "
 END IF


### PR DESCRIPTION
This was overlooked in #258, previously this printing was being skipped over via a check of idemode, but after changing where it was located so it only prints once it now runs when using the IDE, which screwed up the drawing of the IDE screen.

The simple fix is to check for idemode before doing the printing, which is effectively what it was doing before.

Fixes: #266