### PR TITLE
Fix license info

### DIFF
--- a/COPYING.txt
+++ b/COPYING.txt
@@ -1,1 +1,1 @@
-Please refer to licenses/COPYING.TXT for licensing details.
+Please refer to licenses/README.md for licensing details.

--- a/licenses/README.md
+++ b/licenses/README.md
@@ -88,7 +88,8 @@ These libraries are pulled in when using any sound-related functionality.
 | Miniaudio | MIT | license_miniaudio.txt | internal/c/parts/audio/miniaudio.h |
 | libxmp-lite  | MIT | license_libxmp-lite.txt | internal/c/parts/audio/extras/libxmp-lite/ |
 | RADv2 | Public Domain | license_radv2.txt | internal/c/parts/audio/extras/radv2/ |
-| std_vorbus | Public Domain | license_stdvorbis.txt | internal/c/parts/audio/extras/std_vorbis.c |
+| std_vorbis | Public Domain | license_stdvorbis.txt | internal/c/parts/audio/extras/std_vorbis.c |
+| HivelyTracker | BSD 3-Clause | license_hivelytracker.txt | internal/c/parts/audio/extras/hivelytracker |
 
 ## MIDI Support
 


### PR DESCRIPTION
A tiny PR that:

- Changes `licenses/COPYING.TXT` to `licenses/README.md` in `COPYING.txt`
- Fixes a typo in `licenses/README.md`
- Adds HivelyTracker license to `licenses/README.md`