### PR TITLE
Add support for optional function arguments

### DIFF
--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -16423,27 +16423,36 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
 
     SetDependency id2.Dependency
 
+    argCount = countFunctionElements(a$)
+    ReDim providedArgs(argCount)
+
     passomit = 0
-    omitarg_first = 0: omitarg_last = 0
+    hasOptionalFirstArg = 0
+    firstOptionalArgument = 0
 
     f$ = RTRIM$(id2.specialformat)
     IF LEN(f$) THEN 'special format given
 
-        'count omittable args
-        sqb = 0
-        a = 0
-        FOR fi = 1 TO LEN(f$)
-            fa = ASC(f$, fi)
-            IF fa = ASC_QUESTIONMARK THEN
-                a = a + 1
-                IF sqb <> 0 AND omitarg_first = 0 THEN omitarg_first = a
-            END IF
-            IF fa = ASC_LEFTSQUAREBRACKET THEN sqb = 1
-            IF fa = ASC_RIGHTSQUAREBRACKET THEN sqb = 0: omitarg_last = a
-        NEXT
-        omitargs = omitarg_last - omitarg_first + 1
+        For fi = 1 to argCount
+            providedArgs(fi) = hasFunctionElement(a$, fi)
+        Next
 
-        IF args <> id2.args - omitargs AND args <> id2.args THEN
+        ' Special case for the INSTR and _INSTRREV format, which have an optional argument at the beginning
+        If f$ = "[?],?,?"  Then
+            hasOptionalFirstArg = -1
+
+            if UBOUND(providedArgs) = 2 Then
+                ReDim _Preserve providedArgs(3)
+
+                providedArgs(3) = providedArgs(2)
+                providedArgs(2) = providedArgs(1)
+                providedArgs(1) = 0 ' The first argument was not provided
+
+                skipFirstArg = -1
+            End If
+        End If
+
+        IF Not isValidArgSet(id2.specialformat, providedArgs(), firstOptionalArgument) Then
             IF LEN(id2.hr_syntax) > 0 THEN
                 Give_Error "Incorrect number of arguments - Reference: " + id2.hr_syntax
             ELSE
@@ -16454,9 +16463,11 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
 
         passomit = 1 'pass omit flags param to function
 
-        IF id2.args = args THEN omitarg_first = 0: omitarg_last = 0 'all arguments were passed!
-
     ELSE 'no special format given
+
+        For fi = 1 to argCount
+            providedArgs(fi) = -1
+        Next
 
         IF n$ = "ASC" AND args = 2 THEN GOTO skipargnumchk
         IF id2.overloaded = -1 AND (args >= id2.minargs AND args <= id2.args) THEN GOTO skipargnumchk
@@ -16482,29 +16493,28 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
         curarg = 1
         firsti = 1
 
+        ' The first optional argument is missing and not included in the
+        ' argument list
+        if skipFirstArg Then
+            r$ = r$ + "NULL,"
+            curarg = 2
+        End If
+
         n = numelements(a$)
-        IF n = 0 THEN i = 0: GOTO noargs
 
         FOR i = 1 TO n
-
-
-
-            IF curarg >= omitarg_first AND curarg <= omitarg_last THEN
-                noargs:
-                targettyp = CVL(MID$(id2.arg, curarg * 4 - 4 + 1, 4))
-
-                'IF (targettyp AND ISSTRING) THEN Give_Error "QB64 doesn't support optional string arguments for functions yet!": EXIT FUNCTION
-
-                FOR fi = 1 TO omitargs - 1: r$ = r$ + "NULL,": NEXT: r$ = r$ + "NULL"
-                curarg = curarg + omitargs
-                IF i = n THEN EXIT FOR
-                r$ = r$ + ","
-            END IF
-
             l$ = getelement(a$, i)
             IF l$ = "(" THEN b = b + 1
             IF l$ = ")" THEN b = b - 1
             IF (l$ = "," AND b = 0) OR (i = n) THEN
+                IF NOT providedArgs(curarg) THEN
+                    If i = n Then Give_Error "Last function argument cannot be empty": Exit Function
+
+                    r$ = r$ + "NULL,"
+                    firsti = i + 1
+                    curarg = curarg + 1
+                    _Continue
+                END IF
 
                 targettyp = CVL(MID$(id2.arg, curarg * 4 - 4 + 1, 4))
                 nele = ASC(MID$(id2.nele, curarg, 1))
@@ -17640,7 +17650,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                 IF targettyp AND ISSTRING THEN
                     IF (sourcetyp AND ISSTRING) = 0 THEN
                         nth = curarg
-                        IF omitarg_last <> 0 AND nth > omitarg_last THEN nth = nth - 1
+                        if skipFirstArg Then nth = nth - 1
                         IF ids(targetid).args = 1 THEN Give_Error "String required for function": EXIT FUNCTION
                         Give_Error str_nth$(nth) + " function argument requires a string": EXIT FUNCTION
                     END IF
@@ -17648,7 +17658,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                 IF (targettyp AND ISSTRING) = 0 THEN
                     IF sourcetyp AND ISSTRING THEN
                         nth = curarg
-                        IF omitarg_last <> 0 AND nth > omitarg_last THEN nth = nth - 1
+                        if skipFirstArg Then nth = nth - 1
                         IF ids(targetid).args = 1 THEN Give_Error "Number required for function": EXIT FUNCTION
                         Give_Error str_nth$(nth) + " function argument requires a number": EXIT FUNCTION
                     END IF
@@ -17663,7 +17673,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                 IF explicitreference = 0 THEN
                     IF targettyp AND ISUDT THEN
                         nth = curarg
-                        IF omitarg_last <> 0 AND nth > omitarg_last THEN nth = nth - 1
+                        if skipFirstArg Then nth = nth - 1
                         IF qb64prefix_set AND udtxcname(targettyp AND 511) = "_MEM" THEN
                             x$ = "'" + MID$(RTRIM$(udtxcname(targettyp AND 511)), 2) + "'"
                         ELSE
@@ -17770,19 +17780,18 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                 firsti = i + 1
                 curarg = curarg + 1
             END IF
-
-            IF (curarg >= omitarg_first AND curarg <= omitarg_last) AND i = n THEN
-                targettyp = CVL(MID$(id2.arg, curarg * 4 - 4 + 1, 4))
-                'IF (targettyp AND ISSTRING) THEN Give_Error "QB64 doesn't support optional string arguments for functions yet!": EXIT FUNCTION
-                FOR fi = 1 TO omitargs: r$ = r$ + ",NULL": NEXT
-                curarg = curarg + omitargs
-            END IF
-
         NEXT
+
+        ' Add on any extra optional arguments that were not provided
+        If curarg <= id2.args Then
+            For i = curarg To id2.args
+                If i = 1 Then r$ = r$ + "NULL" Else r$ = r$ + ",NULL"
+            Next
+        End If
     END IF
 
     IF n$ = "UBOUND" OR n$ = "LBOUND" THEN
-        IF r$ = ",NULL" THEN r$ = ",1"
+        IF r$ = ",NULL" THEN r$ = ",1" ' FIXME: ??????
         IF n$ = "UBOUND" THEN r2$ = "func_ubound(" ELSE r2$ = "func_lbound("
         e$ = refer$(ulboundarray$, sourcetyp, 1)
         IF Error_Happened THEN EXIT FUNCTION
@@ -17797,7 +17806,15 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
     END IF
 
     IF passomit THEN
-        IF omitarg_first THEN r$ = r$ + ",0" ELSE r$ = r$ + ",1"
+        r$ = r$ + ",0"
+
+        If hasOptionalFirstArg Then
+            If providedArgs(1) Then r$ = r$ + "|1"
+        Else
+            For i = firstOptionalArgument to UBOUND(providedArgs)
+                if providedArgs(i) Then r$ = r$ + "|" + str2$(_SHL(1, i - firstOptionalArgument))
+            Next
+        End If
     END IF
     r$ = r$ + ")"
 
@@ -19628,84 +19645,12 @@ FUNCTION getelementspecial$ (savea$, elenum)
 END FUNCTION
 
 
-
-FUNCTION getelement$ (a$, elenum)
-    IF a$ = "" THEN EXIT FUNCTION 'no elements!
-
-    n = 1
-    p = 1
-    getelementnext:
-    i = INSTR(p, a$, sp)
-
-    IF elenum = n THEN
-        IF i THEN
-            getelement$ = MID$(a$, p, i - p)
-        ELSE
-            getelement$ = RIGHT$(a$, LEN(a$) - p + 1)
-        END IF
-        EXIT FUNCTION
-    END IF
-
-    IF i = 0 THEN EXIT FUNCTION 'no more elements!
-    n = n + 1
-    p = i + 1
-    GOTO getelementnext
-END FUNCTION
-
-FUNCTION getelements$ (a$, i1, i2)
-    IF i2 < i1 THEN getelements$ = "": EXIT FUNCTION
-    n = 1
-    p = 1
-    getelementsnext:
-    i = INSTR(p, a$, sp)
-    IF n = i1 THEN
-        i1pos = p
-    END IF
-    IF n = i2 THEN
-        IF i THEN
-            getelements$ = MID$(a$, i1pos, i - i1pos)
-        ELSE
-            getelements$ = RIGHT$(a$, LEN(a$) - i1pos + 1)
-        END IF
-        EXIT FUNCTION
-    END IF
-    n = n + 1
-    p = i + 1
-    GOTO getelementsnext
-END FUNCTION
-
 SUB getid (i AS LONG)
     IF i = -1 THEN Give_Error "-1 passed to getid!": EXIT SUB
 
     id = ids(i)
 
     currentid = i
-END SUB
-
-SUB insertelements (a$, i, elements$)
-    IF i = 0 THEN
-        IF a$ = "" THEN
-            a$ = elements$
-            EXIT SUB
-        END IF
-        a$ = elements$ + sp + a$
-        EXIT SUB
-    END IF
-
-    a2$ = ""
-    n = numelements(a$)
-
-
-
-
-    FOR i2 = 1 TO n
-        IF i2 > 1 THEN a2$ = a2$ + sp
-        a2$ = a2$ + getelement$(a$, i2)
-        IF i = i2 THEN a2$ = a2$ + sp + elements$
-    NEXT
-
-    a$ = a2$
-
 END SUB
 
 FUNCTION isoperator (a2$)
@@ -20776,18 +20721,6 @@ SUB makeidrefer (ref$, typ AS LONG)
     typ = id.t + ISREFERENCE
 END SUB
 
-FUNCTION numelements (a$)
-    IF a$ = "" THEN EXIT FUNCTION
-    n = 1
-    p = 1
-    numelementsnext:
-    i = INSTR(p, a$, sp)
-    IF i = 0 THEN numelements = n: EXIT FUNCTION
-    n = n + 1
-    p = i + 1
-    GOTO numelementsnext
-END FUNCTION
-
 FUNCTION operatorusage (operator$, typ AS LONG, info$, lhs AS LONG, rhs AS LONG, result AS LONG)
     lhs = 7: rhs = 7: result = 0
     'return values
@@ -21298,49 +21231,6 @@ SUB regUnstableHttp
     END IF
 
     reginternalsubfunc = 0
-
-END SUB
-
-'this sub is faulty atm!
-'sub replacelement (a$, i, newe$)
-''note: performs no action for out of range values of i
-'e=1
-'s=1
-'do
-'x=instr(s,a$,sp)
-'if x then
-'if e=i then
-'a1$=left$(a$,s-1): a2$=right$(a$,len(a$)-x+1)
-'a$=a1$+sp+newe$+a2$ 'note: a2 includes spacer
-'exit sub
-'end if
-'s=x+1
-'e=e+1
-'end if
-'loop until x=0
-'if e=i then
-'a$=left$(a$,s-1)+sp+newe$
-'end if
-'end sub
-
-
-SUB removeelements (a$, first, last, keepindexing)
-    a2$ = ""
-    'note: first and last MUST be valid
-    '      keepindexing means the number of elements will stay the same
-    '       but some elements will be equal to ""
-
-    n = numelements(a$)
-    FOR i = 1 TO n
-        IF i < first OR i > last THEN
-            a2$ = a2$ + sp + getelement(a$, i)
-        ELSE
-            IF keepindexing THEN a2$ = a2$ + sp
-        END IF
-    NEXT
-    IF LEFT$(a2$, 1) = sp THEN a2$ = RIGHT$(a2$, LEN(a2$) - 1)
-
-    a$ = a2$
 
 END SUB
 
@@ -26113,6 +26003,7 @@ END FUNCTION
 '$INCLUDE:'utilities\strings.bas'
 '$INCLUDE:'utilities\file.bas'
 '$INCLUDE:'utilities\build.bas'
+'$INCLUDE:'utilities\elements.bas'
 '$INCLUDE:'subs_functions\extensions\opengl\opengl_methods.bas'
 '$INCLUDE:'utilities\ini-manager\ini.bm'
 '$INCLUDE:'utilities\s-buffer\simplebuffer.bm'

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -12317,7 +12317,7 @@ IF idemode = 0 AND No_C_Compile_Mode = 0 THEN
     END IF
 
     ' Fixup the output path if either we got an `-o` argument, or we're relative to `_StartDir$`
-    IF LEN(outputfile_cmd$) Or OutputIsRelativeToStartDir THEN
+    IF LEN(outputfile_cmd$) OR OutputIsRelativeToStartDir THEN
         IF LEN(outputfile_cmd$) THEN
             'resolve relative path for output file
             path.out$ = getfilepath$(outputfile_cmd$)
@@ -16424,7 +16424,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
     SetDependency id2.Dependency
 
     argCount = countFunctionElements(a$)
-    ReDim providedArgs(argCount)
+    REDIM providedArgs(argCount)
 
     passomit = 0
     hasOptionalFirstArg = 0
@@ -16433,26 +16433,26 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
     f$ = RTRIM$(id2.specialformat)
     IF LEN(f$) THEN 'special format given
 
-        For fi = 1 to argCount
+        FOR fi = 1 TO argCount
             providedArgs(fi) = hasFunctionElement(a$, fi)
-        Next
+        NEXT
 
         ' Special case for the INSTR and _INSTRREV format, which have an optional argument at the beginning
-        If f$ = "[?],?,?"  Then
+        IF f$ = "[?],?,?" THEN
             hasOptionalFirstArg = -1
 
-            if UBOUND(providedArgs) = 2 Then
-                ReDim _Preserve providedArgs(3)
+            IF UBOUND(providedArgs) = 2 THEN
+                REDIM _PRESERVE providedArgs(3)
 
                 providedArgs(3) = providedArgs(2)
                 providedArgs(2) = providedArgs(1)
                 providedArgs(1) = 0 ' The first argument was not provided
 
                 skipFirstArg = -1
-            End If
-        End If
+            END IF
+        END IF
 
-        IF Not isValidArgSet(id2.specialformat, providedArgs(), firstOptionalArgument) Then
+        IF NOT isValidArgSet(id2.specialformat, providedArgs(), firstOptionalArgument) THEN
             IF LEN(id2.hr_syntax) > 0 THEN
                 Give_Error "Incorrect number of arguments - Reference: " + id2.hr_syntax
             ELSE
@@ -16465,9 +16465,9 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
 
     ELSE 'no special format given
 
-        For fi = 1 to argCount
+        FOR fi = 1 TO argCount
             providedArgs(fi) = -1
-        Next
+        NEXT
 
         IF n$ = "ASC" AND args = 2 THEN GOTO skipargnumchk
         IF id2.overloaded = -1 AND (args >= id2.minargs AND args <= id2.args) THEN GOTO skipargnumchk
@@ -16495,10 +16495,10 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
 
         ' The first optional argument is missing and not included in the
         ' argument list
-        if skipFirstArg Then
+        IF skipFirstArg THEN
             r$ = r$ + "NULL,"
             curarg = 2
-        End If
+        END IF
 
         n = numelements(a$)
 
@@ -16508,12 +16508,12 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
             IF l$ = ")" THEN b = b - 1
             IF (l$ = "," AND b = 0) OR (i = n) THEN
                 IF NOT providedArgs(curarg) THEN
-                    If i = n Then Give_Error "Last function argument cannot be empty": Exit Function
+                    IF i = n THEN Give_Error "Last function argument cannot be empty": EXIT FUNCTION
 
                     r$ = r$ + "NULL,"
                     firsti = i + 1
                     curarg = curarg + 1
-                    _Continue
+                    _CONTINUE
                 END IF
 
                 targettyp = CVL(MID$(id2.arg, curarg * 4 - 4 + 1, 4))
@@ -17650,7 +17650,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                 IF targettyp AND ISSTRING THEN
                     IF (sourcetyp AND ISSTRING) = 0 THEN
                         nth = curarg
-                        if skipFirstArg Then nth = nth - 1
+                        IF skipFirstArg THEN nth = nth - 1
                         IF ids(targetid).args = 1 THEN Give_Error "String required for function": EXIT FUNCTION
                         Give_Error str_nth$(nth) + " function argument requires a string": EXIT FUNCTION
                     END IF
@@ -17658,7 +17658,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                 IF (targettyp AND ISSTRING) = 0 THEN
                     IF sourcetyp AND ISSTRING THEN
                         nth = curarg
-                        if skipFirstArg Then nth = nth - 1
+                        IF skipFirstArg THEN nth = nth - 1
                         IF ids(targetid).args = 1 THEN Give_Error "Number required for function": EXIT FUNCTION
                         Give_Error str_nth$(nth) + " function argument requires a number": EXIT FUNCTION
                     END IF
@@ -17673,7 +17673,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                 IF explicitreference = 0 THEN
                     IF targettyp AND ISUDT THEN
                         nth = curarg
-                        if skipFirstArg Then nth = nth - 1
+                        IF skipFirstArg THEN nth = nth - 1
                         IF qb64prefix_set AND udtxcname(targettyp AND 511) = "_MEM" THEN
                             x$ = "'" + MID$(RTRIM$(udtxcname(targettyp AND 511)), 2) + "'"
                         ELSE
@@ -17783,11 +17783,11 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
         NEXT
 
         ' Add on any extra optional arguments that were not provided
-        If curarg <= id2.args Then
-            For i = curarg To id2.args
-                If i = 1 Then r$ = r$ + "NULL" Else r$ = r$ + ",NULL"
-            Next
-        End If
+        IF curarg <= id2.args THEN
+            FOR i = curarg TO id2.args
+                IF i = 1 THEN r$ = r$ + "NULL" ELSE r$ = r$ + ",NULL"
+            NEXT
+        END IF
     END IF
 
     IF n$ = "UBOUND" OR n$ = "LBOUND" THEN
@@ -17808,13 +17808,13 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
     IF passomit THEN
         r$ = r$ + ",0"
 
-        If hasOptionalFirstArg Then
-            If providedArgs(1) Then r$ = r$ + "|1"
-        Else
-            For i = firstOptionalArgument to UBOUND(providedArgs)
-                if providedArgs(i) Then r$ = r$ + "|" + str2$(_SHL(1, i - firstOptionalArgument))
-            Next
-        End If
+        IF hasOptionalFirstArg THEN
+            IF providedArgs(1) THEN r$ = r$ + "|1"
+        ELSE
+            FOR i = firstOptionalArgument TO UBOUND(providedArgs)
+                IF providedArgs(i) THEN r$ = r$ + "|" + str2$(_SHL(1, i - firstOptionalArgument))
+            NEXT
+        END IF
     END IF
     r$ = r$ + ")"
 

--- a/source/utilities/elements.bas
+++ b/source/utilities/elements.bas
@@ -1,5 +1,7 @@
 
 FUNCTION getelement$ (a$, elenum)
+    DIM p AS LONG, n AS LONG, i AS LONG
+
     IF a$ = "" THEN EXIT FUNCTION 'no elements!
 
     n = 1
@@ -23,6 +25,8 @@ FUNCTION getelement$ (a$, elenum)
 END FUNCTION
 
 FUNCTION getelements$ (a$, i1, i2)
+    DIM p AS LONG, n AS LONG, i AS LONG, i1pos AS LONG
+
     IF i2 < i1 THEN getelements$ = "": EXIT FUNCTION
     n = 1
     p = 1
@@ -45,6 +49,8 @@ FUNCTION getelements$ (a$, i1, i2)
 END FUNCTION
 
 SUB insertelements (a$, i, elements$)
+    DIM a2 AS STRING, n AS LONG, i2 AS LONG
+
     IF i = 0 THEN
         IF a$ = "" THEN
             a$ = elements$
@@ -57,9 +63,6 @@ SUB insertelements (a$, i, elements$)
     a2$ = ""
     n = numelements(a$)
 
-
-
-
     FOR i2 = 1 TO n
         IF i2 > 1 THEN a2$ = a2$ + sp
         a2$ = a2$ + getelement$(a$, i2)
@@ -71,6 +74,8 @@ SUB insertelements (a$, i, elements$)
 END SUB
 
 FUNCTION numelements (a$)
+    DIM p AS LONG, n AS LONG, i AS LONG
+
     IF a$ = "" THEN EXIT FUNCTION
     n = 1
     p = 1
@@ -83,6 +88,8 @@ FUNCTION numelements (a$)
 END FUNCTION
 
 SUB removeelements (a$, first, last, keepindexing)
+    DIM n AS LONG, i AS LONG, a2 AS STRING
+
     a2$ = ""
     'note: first and last MUST be valid
     '      keepindexing means the number of elements will stay the same
@@ -105,38 +112,38 @@ END SUB
 ' a$ should be a function argument list
 ' Returns number of function arguments (including empty ones) in the provided list
 FUNCTION countFunctionElements (a$)
-    Dim count As Long, p As Long, lvl As Long
+    DIM count AS LONG, p AS LONG, lvl AS LONG, i AS LONG
     p = 1
     lvl = 1
     i = 0
 
-    if Len(a$) = 0 Then
+    IF LEN(a$) = 0 THEN
         countFunctionElements = 0
-        Exit Function
-    End If
+        EXIT FUNCTION
+    END IF
 
-    Do
-        Select Case Asc(a$, i + 1)
-            Case Asc("("):
+    DO
+        SELECT CASE ASC(a$, i + 1)
+            CASE ASC("("):
                 lvl = lvl + 1
 
-            Case Asc(")"):
+            CASE ASC(")"):
                 lvl = lvl - 1
 
-            Case Asc(","):
-                If lvl = 1 Then
+            CASE ASC(","):
+                IF lvl = 1 THEN
                     count = count + 1
-                End If
+                END IF
 
-        End Select
+        END SELECT
 
         i = INSTR(p, a$, sp)
-        if i = 0 Then
-            Exit Do
-        End If
+        IF i = 0 THEN
+            EXIT DO
+        END IF
 
         p = i + 1
-    Loop
+    LOOP
 
     ' Make sure to count the argument after the last comma
     countFunctionElements = count + 1
@@ -144,87 +151,87 @@ END FUNCTION
 
 ' a$ should be a function argument list
 ' Returns true if the argument was provided in the list
-FUNCTION hasFunctionElement(a$, element)
-    Dim count As Long, p As Long, lvl As Long
+FUNCTION hasFunctionElement (a$, element)
+    DIM count AS LONG, p AS LONG, lvl AS LONG, i AS LONG, start AS LONG
     start = 0
     p = 1
     lvl = 1
     i = 1
 
-    if Len(a$) = 0 Then
+    IF LEN(a$) = 0 THEN
         hasFunctionElement = 0
-        Exit Function
-    End If
+        EXIT FUNCTION
+    END IF
 
     ' Special case for a single provided argument
-    If INSTR(a$, sp) = 0 And Len(a$) <> 0 Then
+    IF INSTR(a$, sp) = 0 AND LEN(a$) <> 0 THEN
         hasFunctionElement = element = 1
-        Exit Function
-    End If
+        EXIT FUNCTION
+    END IF
 
-    Do
-        If i > Len(a$) Then
-            Exit Do
-        End If
+    DO
+        IF i > LEN(a$) THEN
+            EXIT DO
+        END IF
 
-        Select Case Asc(a$, i)
-            Case Asc("("):
+        SELECT CASE ASC(a$, i)
+            CASE ASC("("):
                 lvl = lvl + 1
 
-            Case Asc(")"):
+            CASE ASC(")"):
                 lvl = lvl - 1
 
-            Case Asc(","):
-                If lvl = 1 Then
+            CASE ASC(","):
+                IF lvl = 1 THEN
                     count = count + 1
 
-                    If element = count Then
+                    IF element = count THEN
                         ' We have a element here if there's any elements
                         ' inbetween the previous comma and this one
-                        hasFunctionElement = (i <> 1) And (i - 2 <> start)
-                        Exit Function
-                    End If
+                        hasFunctionElement = (i <> 1) AND (i - 2 <> start)
+                        EXIT FUNCTION
+                    END IF
 
                     start = i
-                End If
-        End Select
+                END IF
+        END SELECT
 
         p = i
         i = INSTR(i, a$, sp)
 
-        if i = 0 Then
-            Exit Do
-        End If
+        IF i = 0 THEN
+            EXIT DO
+        END IF
 
         i = i + 1
-    Loop
+    LOOP
 
-    If element > count + 1 Then
+    IF element > count + 1 THEN
         hasFunctionElement = 0
-        Exit Function
-    End If
+        EXIT FUNCTION
+    END IF
 
     ' Check if last argument was provided.
     '
     ' Syntax '2,3' has two arguments, the '3' argument is what gets compared here
     ' Syntax '2,' has one argument, the comma is the last element so it fails this check.
-    If p > 0 Then
-        If Asc(a$, p) <> Asc(",") Then
+    IF p > 0 THEN
+        IF ASC(a$, p) <> ASC(",") THEN
             hasFunctionElement = -1
-            Exit Function
-        End If
-    End If
+            EXIT FUNCTION
+        END IF
+    END IF
 
     hasFunctionElement = 0
 END FUNCTION
 
 ' Returns true if the provided arguments are a valid set for the given function format
 ' firstOptionalArgument returns the index of the first argument that is optional
-FUNCTION isValidArgSet(format As String, providedArgs() As Long, firstOptionalArgument As Long)
-    Dim maxArgument As Long, i As Long
-    Dim currentArg As Long, optionLvl As Long
-    Dim wasProvided(0 To 10) As Long
-    Dim As Long ArgProvided , ArgNotProvided, ArgIgnored
+FUNCTION isValidArgSet (format AS STRING, providedArgs() AS LONG, firstOptionalArgument AS LONG)
+    DIM maxArgument AS LONG, i AS LONG
+    DIM currentArg AS LONG, optionLvl AS LONG
+    DIM wasProvided(0 TO 10) AS LONG
+    DIM AS LONG ArgProvided, ArgNotProvided, ArgIgnored
 
     ArgProvided = -1
     ArgNotProvided = 0
@@ -245,61 +252,61 @@ FUNCTION isValidArgSet(format As String, providedArgs() As Long, firstOptionalAr
 
     maxArgument = UBOUND(providedArgs)
 
-    For i = 1 to Len(format)
-        Select Case Asc(format, i)
-            Case Asc("["):
+    FOR i = 1 TO LEN(format)
+        SELECT CASE ASC(format, i)
+            CASE ASC("["):
                 optionLvl = optionLvl + 1
                 wasProvided(optionLvl) = ArgIgnored
 
-            Case Asc("]"):
+            CASE ASC("]"):
                 optionLvl = optionLvl - 1
 
-                If wasProvided(optionLvl) = ArgIgnored Then
+                IF wasProvided(optionLvl) = ArgIgnored THEN
                     ' If not provided, then we stay in the ignored state
                     ' because whether this arg set was provided does not matter
                     ' for the rest of the parsing
-                    If wasProvided(optionLvl + 1) = ArgProvided Then
+                    IF wasProvided(optionLvl + 1) = ArgProvided THEN
                         wasProvided(optionLvl) = ArgProvided
-                    End If
-                Else
+                    END IF
+                ELSE
                     ' If an arg at this level was already not provided, then
                     ' this optional set can't be provided either
-                    if wasProvided(optionLvl) = ArgNotProvided And wasProvided(optionLvl + 1) = ArgProvided Then
+                    IF wasProvided(optionLvl) = ArgNotProvided AND wasProvided(optionLvl + 1) = ArgProvided THEN
                         isValidArgSet = 0
                         EXIT FUNCTION
-                    End If
-                End If
+                    END IF
+                END IF
 
-            Case Asc("?"):
+            CASE ASC("?"):
                 currentArg = currentArg + 1
-                if optionLvl >= 1 And firstOptionalArgument = 0 Then firstOptionalArgument = currentArg
+                IF optionLvl >= 1 AND firstOptionalArgument = 0 THEN firstOptionalArgument = currentArg
 
-                if wasProvided(optionLvl) = ArgIgnored Then
-                    If maxArgument >= currentArg Then
+                IF wasProvided(optionLvl) = ArgIgnored THEN
+                    IF maxArgument >= currentArg THEN
                         wasProvided(optionLvl) = providedArgs(currentArg)
-                    else
+                    ELSE
                         wasProvided(optionLvl) = 0
-                    End If
-                else
-                    if maxArgument < currentArg Then
-                        If wasProvided(optionLvl) <> ArgNotProvided Then
+                    END IF
+                ELSE
+                    IF maxArgument < currentArg THEN
+                        IF wasProvided(optionLvl) <> ArgNotProvided THEN
                             isValidArgSet = 0
-                            Exit Function
-                        End If
-                    Elseif wasProvided(optionLvl) <> providedArgs(currentArg) Then
+                            EXIT FUNCTION
+                        END IF
+                    ELSEIF wasProvided(optionLvl) <> providedArgs(currentArg) THEN
                         isValidArgSet = 0
                         EXIT FUNCTION
-                    End If
-                End If
-        End Select
-    Next
+                    END IF
+                END IF
+        END SELECT
+    NEXT
 
     ' The base level of arguments are required. They can be in the
     ' 'ignored' state though if all arguments are within brackets
-    if currentArg < maxArgument Or wasProvided(0) = ArgNotProvided then
+    IF currentArg < maxArgument OR wasProvided(0) = ArgNotProvided THEN
         isValidArgSet = 0
-        Exit Function
-    End If
+        EXIT FUNCTION
+    END IF
 
     isValidArgSet = -1
 END FUNCTION

--- a/source/utilities/elements.bas
+++ b/source/utilities/elements.bas
@@ -1,0 +1,305 @@
+
+FUNCTION getelement$ (a$, elenum)
+    IF a$ = "" THEN EXIT FUNCTION 'no elements!
+
+    n = 1
+    p = 1
+    getelementnext:
+    i = INSTR(p, a$, sp)
+
+    IF elenum = n THEN
+        IF i THEN
+            getelement$ = MID$(a$, p, i - p)
+        ELSE
+            getelement$ = RIGHT$(a$, LEN(a$) - p + 1)
+        END IF
+        EXIT FUNCTION
+    END IF
+
+    IF i = 0 THEN EXIT FUNCTION 'no more elements!
+    n = n + 1
+    p = i + 1
+    GOTO getelementnext
+END FUNCTION
+
+FUNCTION getelements$ (a$, i1, i2)
+    IF i2 < i1 THEN getelements$ = "": EXIT FUNCTION
+    n = 1
+    p = 1
+    getelementsnext:
+    i = INSTR(p, a$, sp)
+    IF n = i1 THEN
+        i1pos = p
+    END IF
+    IF n = i2 THEN
+        IF i THEN
+            getelements$ = MID$(a$, i1pos, i - i1pos)
+        ELSE
+            getelements$ = RIGHT$(a$, LEN(a$) - i1pos + 1)
+        END IF
+        EXIT FUNCTION
+    END IF
+    n = n + 1
+    p = i + 1
+    GOTO getelementsnext
+END FUNCTION
+
+SUB insertelements (a$, i, elements$)
+    IF i = 0 THEN
+        IF a$ = "" THEN
+            a$ = elements$
+            EXIT SUB
+        END IF
+        a$ = elements$ + sp + a$
+        EXIT SUB
+    END IF
+
+    a2$ = ""
+    n = numelements(a$)
+
+
+
+
+    FOR i2 = 1 TO n
+        IF i2 > 1 THEN a2$ = a2$ + sp
+        a2$ = a2$ + getelement$(a$, i2)
+        IF i = i2 THEN a2$ = a2$ + sp + elements$
+    NEXT
+
+    a$ = a2$
+
+END SUB
+
+FUNCTION numelements (a$)
+    IF a$ = "" THEN EXIT FUNCTION
+    n = 1
+    p = 1
+    numelementsnext:
+    i = INSTR(p, a$, sp)
+    IF i = 0 THEN numelements = n: EXIT FUNCTION
+    n = n + 1
+    p = i + 1
+    GOTO numelementsnext
+END FUNCTION
+
+SUB removeelements (a$, first, last, keepindexing)
+    a2$ = ""
+    'note: first and last MUST be valid
+    '      keepindexing means the number of elements will stay the same
+    '       but some elements will be equal to ""
+
+    n = numelements(a$)
+    FOR i = 1 TO n
+        IF i < first OR i > last THEN
+            a2$ = a2$ + sp + getelement(a$, i)
+        ELSE
+            IF keepindexing THEN a2$ = a2$ + sp
+        END IF
+    NEXT
+    IF LEFT$(a2$, 1) = sp THEN a2$ = RIGHT$(a2$, LEN(a2$) - 1)
+
+    a$ = a2$
+
+END SUB
+
+' a$ should be a function argument list
+' Returns number of function arguments (including empty ones) in the provided list
+FUNCTION countFunctionElements (a$)
+    Dim count As Long, p As Long, lvl As Long
+    p = 1
+    lvl = 1
+    i = 0
+
+    if Len(a$) = 0 Then
+        countFunctionElements = 0
+        Exit Function
+    End If
+
+    Do
+        Select Case Asc(a$, i + 1)
+            Case Asc("("):
+                lvl = lvl + 1
+
+            Case Asc(")"):
+                lvl = lvl - 1
+
+            Case Asc(","):
+                If lvl = 1 Then
+                    count = count + 1
+                End If
+
+        End Select
+
+        i = INSTR(p, a$, sp)
+        if i = 0 Then
+            Exit Do
+        End If
+
+        p = i + 1
+    Loop
+
+    ' Make sure to count the argument after the last comma
+    countFunctionElements = count + 1
+END FUNCTION
+
+' a$ should be a function argument list
+' Returns true if the argument was provided in the list
+FUNCTION hasFunctionElement(a$, element)
+    Dim count As Long, p As Long, lvl As Long
+    start = 0
+    p = 1
+    lvl = 1
+    i = 1
+
+    if Len(a$) = 0 Then
+        hasFunctionElement = 0
+        Exit Function
+    End If
+
+    ' Special case for a single provided argument
+    If INSTR(a$, sp) = 0 And Len(a$) <> 0 Then
+        hasFunctionElement = element = 1
+        Exit Function
+    End If
+
+    Do
+        If i > Len(a$) Then
+            Exit Do
+        End If
+
+        Select Case Asc(a$, i)
+            Case Asc("("):
+                lvl = lvl + 1
+
+            Case Asc(")"):
+                lvl = lvl - 1
+
+            Case Asc(","):
+                If lvl = 1 Then
+                    count = count + 1
+
+                    If element = count Then
+                        ' We have a element here if there's any elements
+                        ' inbetween the previous comma and this one
+                        hasFunctionElement = (i <> 1) And (i - 2 <> start)
+                        Exit Function
+                    End If
+
+                    start = i
+                End If
+        End Select
+
+        p = i
+        i = INSTR(i, a$, sp)
+
+        if i = 0 Then
+            Exit Do
+        End If
+
+        i = i + 1
+    Loop
+
+    If element > count + 1 Then
+        hasFunctionElement = 0
+        Exit Function
+    End If
+
+    ' Check if last argument was provided.
+    '
+    ' Syntax '2,3' has two arguments, the '3' argument is what gets compared here
+    ' Syntax '2,' has one argument, the comma is the last element so it fails this check.
+    If p > 0 Then
+        If Asc(a$, p) <> Asc(",") Then
+            hasFunctionElement = -1
+            Exit Function
+        End If
+    End If
+
+    hasFunctionElement = 0
+END FUNCTION
+
+' Returns true if the provided arguments are a valid set for the given function format
+' firstOptionalArgument returns the index of the first argument that is optional
+FUNCTION isValidArgSet(format As String, providedArgs() As Long, firstOptionalArgument As Long)
+    Dim maxArgument As Long, i As Long
+    Dim currentArg As Long, optionLvl As Long
+    Dim wasProvided(0 To 10) As Long
+    Dim As Long ArgProvided , ArgNotProvided, ArgIgnored
+
+    ArgProvided = -1
+    ArgNotProvided = 0
+    ArgIgnored = -2
+    firstOptionalArgument = 0
+
+    wasProvided(0) = ArgIgnored
+
+    ' Inside of each set of brackets, all arguments must either be provide or not provided, with no mixing.
+    ' For nested brackets, if the argument(s) inside the nested brackets are
+    ' provided, then the arguments inside the outer brackets also have to be
+    ' provided. Ex:
+    '
+    '     x[,y[,z]]
+    '
+    ' When x is provided, y and z are optional, but when y is provided x is required.
+    ' When z is provided both y and x are required.
+
+    maxArgument = UBOUND(providedArgs)
+
+    For i = 1 to Len(format)
+        Select Case Asc(format, i)
+            Case Asc("["):
+                optionLvl = optionLvl + 1
+                wasProvided(optionLvl) = ArgIgnored
+
+            Case Asc("]"):
+                optionLvl = optionLvl - 1
+
+                If wasProvided(optionLvl) = ArgIgnored Then
+                    ' If not provided, then we stay in the ignored state
+                    ' because whether this arg set was provided does not matter
+                    ' for the rest of the parsing
+                    If wasProvided(optionLvl + 1) = ArgProvided Then
+                        wasProvided(optionLvl) = ArgProvided
+                    End If
+                Else
+                    ' If an arg at this level was already not provided, then
+                    ' this optional set can't be provided either
+                    if wasProvided(optionLvl) = ArgNotProvided And wasProvided(optionLvl + 1) = ArgProvided Then
+                        isValidArgSet = 0
+                        EXIT FUNCTION
+                    End If
+                End If
+
+            Case Asc("?"):
+                currentArg = currentArg + 1
+                if optionLvl >= 1 And firstOptionalArgument = 0 Then firstOptionalArgument = currentArg
+
+                if wasProvided(optionLvl) = ArgIgnored Then
+                    If maxArgument >= currentArg Then
+                        wasProvided(optionLvl) = providedArgs(currentArg)
+                    else
+                        wasProvided(optionLvl) = 0
+                    End If
+                else
+                    if maxArgument < currentArg Then
+                        If wasProvided(optionLvl) <> ArgNotProvided Then
+                            isValidArgSet = 0
+                            Exit Function
+                        End If
+                    Elseif wasProvided(optionLvl) <> providedArgs(currentArg) Then
+                        isValidArgSet = 0
+                        EXIT FUNCTION
+                    End If
+                End If
+        End Select
+    Next
+
+    ' The base level of arguments are required. They can be in the
+    ' 'ignored' state though if all arguments are within brackets
+    if currentArg < maxArgument Or wasProvided(0) = ArgNotProvided then
+        isValidArgSet = 0
+        Exit Function
+    End If
+
+    isValidArgSet = -1
+END FUNCTION

--- a/tests/compile_tests/qb64pe/element.bas
+++ b/tests/compile_tests/qb64pe/element.bas
@@ -1,5 +1,8 @@
+Option _Explicit
 DEFLNG A-Z
 $Console:Only
+
+Dim Debug As Long
 
 '$include:'../../../source/global/constants.bas'
 sp = "@" ' Makes the output readable
@@ -104,7 +107,11 @@ tests(18).result = -1
 tests(18).firstOptional = 4
 
 ReDim provided(10) As Long
+Dim i As Long
+
 For i = 1 To UBOUND(tests)
+    Dim firstOpt As Long, result As Long
+
     firstOpt& = 0
 
     argStringToArray tests(i).providedArgs, provided()
@@ -126,7 +133,7 @@ System
 '$include:'../../../source/utilities/elements.bas'
 
 SUB argStringToArray(argString As String, provided() As Long)
-    ReDim provided(LEN(argString) / 4) As Long
+    ReDim provided(LEN(argString) / 4) As Long, i As Long
 
     for i = 1 to UBOUND(provided)
         provided(i) = CVL(MID$(argString, (i - 1) * 4 + 1, 4))
@@ -134,6 +141,8 @@ SUB argStringToArray(argString As String, provided() As Long)
 END SUB
 
 FUNCTION argStringPrint$(argString As String)
+    Dim res As String, i As Long
+
     res$ = ""
 
     If argString = "" Then argStringPrint$ = "": Exit Function

--- a/tests/compile_tests/qb64pe/element.bas
+++ b/tests/compile_tests/qb64pe/element.bas
@@ -1,0 +1,147 @@
+DEFLNG A-Z
+$Console:Only
+
+'$include:'../../../source/global/constants.bas'
+sp = "@" ' Makes the output readable
+
+Type TestCase
+    format As String
+    providedArgs As String
+    result As Long
+    firstOptional As Long
+End Type
+
+Dim tests(18) As TestCase
+
+tests(1).format = "?[?]"
+tests(1).providedArgs = MKL$(-1)
+tests(1).result = -1
+tests(1).firstOptional = 2
+
+tests(2).format = "?[?]"
+tests(2).providedArgs = MKL$(-1) + MKL$(-1)
+tests(2).result = -1
+tests(2).firstOptional = 2
+
+tests(3).format = "?[?]"
+tests(3).providedArgs = MKL$(0) + MKL$(-1)
+tests(3).result = 0
+tests(3).firstOptional = 2
+
+tests(4).format = "?[??]"
+tests(4).providedArgs = MKL$(0) + MKL$(-1)
+tests(4).result = 0
+tests(4).firstOptional = 2
+
+tests(5).format = "?[??]"
+tests(5).providedArgs = MKL$(0) + MKL$(-1) + MKL$(-1)
+tests(5).result = 0
+tests(5).firstOptional = 2
+
+tests(6).format = "?[??]"
+tests(6).providedArgs = MKL$(-1) + MKL$(-1) + MKL$(-1)
+tests(6).result = -1
+tests(6).firstOptional = 2
+
+tests(7).format = "?[??]"
+tests(7).providedArgs = MKL$(-1) + MKL$(0) + MKL$(0)
+tests(7).result = -1
+tests(7).firstOptional = 2
+
+tests(8).format = "?[??]"
+tests(8).providedArgs = MKL$(-1)
+tests(8).result = -1
+tests(8).firstOptional = 2
+
+tests(9).format = "?[?[?]]"
+tests(9).providedArgs = MKL$(-1)
+tests(9).result = -1
+tests(9).firstOptional = 2
+
+tests(10).format = "?[?[?]]"
+tests(10).providedArgs = MKL$(-1) + MKL$(-1) + MKL$(0)
+tests(10).result = -1
+tests(10).firstOptional = 2
+
+tests(11).format = "?[?[?]]"
+tests(11).providedArgs = MKL$(-1) + MKL$(-1) + MKL$(-1)
+tests(11).result = -1
+tests(11).firstOptional = 2
+
+tests(12).format = "?[?[?]]"
+tests(12).providedArgs = MKL$(-1) + MKL$(0) + MKL$(-1)
+tests(12).result = 0
+tests(12).firstOptional = 2
+
+tests(13).format = "?[[?][?]]"
+tests(13).providedArgs = MKL$(-1) + MKL$(0) + MKL$(-1)
+tests(13).result = -1
+tests(13).firstOptional = 2
+
+tests(14).format = "[?][??]"
+tests(14).providedArgs = MKL$(0) + MKL$(-1) + MKL$(-1)
+tests(14).result = -1
+tests(14).firstOptional = 1
+
+tests(15).format = "?"
+tests(15).providedArgs = MKL$(0) + MKL$(-1) + MKL$(-1)
+tests(15).result = 0
+tests(15).firstOptional = 0
+
+tests(16).format = "?"
+tests(16).providedArgs = ""
+tests(16).result = 0
+tests(16).firstOptional = 0
+
+tests(17).format = "?[?]"
+tests(17).providedArgs = ""
+tests(17).result = 0
+tests(17).firstOptional = 2
+
+tests(18).format = "???[?]"
+tests(18).providedArgs = MKL$(-1) + MKL$(-1) + MKL$(-1) + MKL$(-1)
+tests(18).result = -1
+tests(18).firstOptional = 4
+
+ReDim provided(10) As Long
+For i = 1 To UBOUND(tests)
+    firstOpt& = 0
+
+    argStringToArray tests(i).providedArgs, provided()
+    result& = isValidArgSet(tests(i).format, provided(), firstOpt&)
+
+    Print "Test"; i; ", Format: "; tests(i).format; ", Args: "; argStringPrint$(tests(i).providedArgs)
+    Print "    Expected:"; tests(i).result; ", Actual"; result&
+    Print "    firstOpt:"; tests(i).firstOptional; ", Actual"; firstOpt&
+    If tests(i).result = result& And tests(i).firstOptional = firstOpt& Then
+        Print "      PASS!"
+    Else
+        Print "      FAIL!"
+    End If
+    Print
+Next
+
+System
+
+'$include:'../../../source/utilities/elements.bas'
+
+SUB argStringToArray(argString As String, provided() As Long)
+    ReDim provided(LEN(argString) / 4) As Long
+
+    for i = 1 to UBOUND(provided)
+        provided(i) = CVL(MID$(argString, (i - 1) * 4 + 1, 4))
+    next
+END SUB
+
+FUNCTION argStringPrint$(argString As String)
+    res$ = ""
+
+    If argString = "" Then argStringPrint$ = "": Exit Function
+
+    res$ = STR$(CVL(MID$(argString, 1, 4)))
+    For i = 2 To LEN(argString) / 4
+        res$ = res$ + ", " + STR$(CVL(MID$(argString, (i - 1) * 4 + 1, 4)))
+    Next I
+
+    argStringPrint$ = res$
+END FUNCTION

--- a/tests/compile_tests/qb64pe/element.output
+++ b/tests/compile_tests/qb64pe/element.output
@@ -1,0 +1,89 @@
+Test 1 , Format: ?[?], Args: -1
+    Expected:-1 , Actual-1 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 2 , Format: ?[?], Args: -1, -1
+    Expected:-1 , Actual-1 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 3 , Format: ?[?], Args:  0, -1
+    Expected: 0 , Actual 0 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 4 , Format: ?[??], Args:  0, -1
+    Expected: 0 , Actual 0 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 5 , Format: ?[??], Args:  0, -1, -1
+    Expected: 0 , Actual 0 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 6 , Format: ?[??], Args: -1, -1, -1
+    Expected:-1 , Actual-1 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 7 , Format: ?[??], Args: -1,  0,  0
+    Expected:-1 , Actual-1 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 8 , Format: ?[??], Args: -1
+    Expected:-1 , Actual-1 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 9 , Format: ?[?[?]], Args: -1
+    Expected:-1 , Actual-1 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 10 , Format: ?[?[?]], Args: -1, -1,  0
+    Expected:-1 , Actual-1 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 11 , Format: ?[?[?]], Args: -1, -1, -1
+    Expected:-1 , Actual-1 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 12 , Format: ?[?[?]], Args: -1,  0, -1
+    Expected: 0 , Actual 0 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 13 , Format: ?[[?][?]], Args: -1,  0, -1
+    Expected:-1 , Actual-1 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 14 , Format: [?][??], Args:  0, -1, -1
+    Expected:-1 , Actual-1 
+    firstOpt: 1 , Actual 1 
+      PASS!
+
+Test 15 , Format: ?, Args:  0, -1, -1
+    Expected: 0 , Actual 0 
+    firstOpt: 0 , Actual 0 
+      PASS!
+
+Test 16 , Format: ?, Args: 
+    Expected: 0 , Actual 0 
+    firstOpt: 0 , Actual 0 
+      PASS!
+
+Test 17 , Format: ?[?], Args: 
+    Expected: 0 , Actual 0 
+    firstOpt: 2 , Actual 2 
+      PASS!
+
+Test 18 , Format: ???[?], Args: -1, -1, -1, -1
+    Expected:-1 , Actual-1 
+    firstOpt: 4 , Actual 4 
+      PASS!

--- a/tests/compile_tests/qb64pe/hasFunctionElement.bas
+++ b/tests/compile_tests/qb64pe/hasFunctionElement.bas
@@ -1,5 +1,7 @@
+Option _Explicit
 DEFLNG A-Z
 $Console:Only
+Dim Debug As Long
 Debug = -1
 
 '$include:'../../../source/global/constants.bas'
@@ -33,12 +35,16 @@ tests(5).results = MKL$(-1) + MKL$(0) + MKL$(-1) + MKL$(0)
 tests(6).args = "2" + sp + "," + sp + ","
 tests(6).results = MKL$(-1) + MKL$(0) + MKL$(0) + MKL$(0)
 
-ReDim provided(10) As Long
+ReDim provided(10) As Long, i As Long
 For i = 1 To UBOUND(tests)
     argStringToArray tests(i).results, provided()
 
     Print "Test"; i; ", Args: "; tests(i).args
+
+    Dim k As Long
     For k = 1 To UBOUND(provided)
+        Dim result As Long
+
         result& = hasFunctionElement(tests(i).args, k)
 
         Print "    Expected:"; provided(k); ", Actual"; result&;
@@ -57,7 +63,7 @@ System
 '$include:'../../../source/utilities/elements.bas'
 
 SUB argStringToArray(argString As String, provided() As Long)
-    ReDim provided(LEN(argString) / 4) As Long
+    ReDim provided(LEN(argString) / 4) As Long, i As Long
 
     for i = 1 to UBOUND(provided)
         provided(i) = CVL(MID$(argString, (i - 1) * 4 + 1, 4))
@@ -65,6 +71,8 @@ SUB argStringToArray(argString As String, provided() As Long)
 END SUB
 
 FUNCTION argStringPrint$(argString As String)
+    Dim res As String, i As Long
+
     res$ = ""
 
     res$ = STR$(CVL(MID$(argString, 1, 4)))

--- a/tests/compile_tests/qb64pe/hasFunctionElement.bas
+++ b/tests/compile_tests/qb64pe/hasFunctionElement.bas
@@ -1,0 +1,76 @@
+DEFLNG A-Z
+$Console:Only
+Debug = -1
+
+'$include:'../../../source/global/constants.bas'
+sp = "@" ' Makes the output readable
+
+Type TestCase
+    args As String
+    results As String
+End Type
+
+Dim tests(6) As TestCase
+
+tests(1).args = "2"
+tests(1).results = MKL$(-1) + MKL$(0) + MKL$(0) + MKL$(0)
+
+tests(2).args = "2" + sp + "," + sp + "3"
+tests(2).results = MKL$(-1) + MKL$(-1) + MKL$(0) + MKL$(0)
+
+' (2, foo(3, 2) ) -  includes two function arguments, with one of them being a function call
+tests(3).args = "2" + sp + "," + sp + _
+                    "foo" + sp + "(" + sp + "3" + sp + "," + sp + "2" + sp + ")"
+tests(3).results = MKL$(-1) + MKL$(-1) + MKL$(0) + MKL$(0) + MKL$(0)
+
+' Trailing comma at the end of argument list
+tests(4).args = "2" + sp + "," + sp + "3" + sp + ","
+tests(4).results = MKL$(-1) + MKL$(-1) + MKL$(0) + MKL$(0)
+
+tests(5).args = "2" + sp + "," + sp + "," + sp + "3"
+tests(5).results = MKL$(-1) + MKL$(0) + MKL$(-1) + MKL$(0)
+
+tests(6).args = "2" + sp + "," + sp + ","
+tests(6).results = MKL$(-1) + MKL$(0) + MKL$(0) + MKL$(0)
+
+ReDim provided(10) As Long
+For i = 1 To UBOUND(tests)
+    argStringToArray tests(i).results, provided()
+
+    Print "Test"; i; ", Args: "; tests(i).args
+    For k = 1 To UBOUND(provided)
+        result& = hasFunctionElement(tests(i).args, k)
+
+        Print "    Expected:"; provided(k); ", Actual"; result&;
+        If provided(k) = result& Then
+            Print " PASS!"
+        Else
+            Print " FAIL!"
+        End If
+    Next
+
+    Print
+Next
+
+System
+
+'$include:'../../../source/utilities/elements.bas'
+
+SUB argStringToArray(argString As String, provided() As Long)
+    ReDim provided(LEN(argString) / 4) As Long
+
+    for i = 1 to UBOUND(provided)
+        provided(i) = CVL(MID$(argString, (i - 1) * 4 + 1, 4))
+    next
+END SUB
+
+FUNCTION argStringPrint$(argString As String)
+    res$ = ""
+
+    res$ = STR$(CVL(MID$(argString, 1, 4)))
+    For i = 2 To LEN(argString) / 4
+        res$ = res$ + ", " + STR$(CVL(MID$(argString, (i - 1) * 4 + 1, 4)))
+    Next I
+
+    argStringPrint$ = res$
+END FUNCTION

--- a/tests/compile_tests/qb64pe/hasFunctionElement.output
+++ b/tests/compile_tests/qb64pe/hasFunctionElement.output
@@ -1,0 +1,36 @@
+Test 1 , Args: 2
+    Expected:-1 , Actual-1  PASS!
+    Expected: 0 , Actual 0  PASS!
+    Expected: 0 , Actual 0  PASS!
+    Expected: 0 , Actual 0  PASS!
+
+Test 2 , Args: 2@,@3
+    Expected:-1 , Actual-1  PASS!
+    Expected:-1 , Actual-1  PASS!
+    Expected: 0 , Actual 0  PASS!
+    Expected: 0 , Actual 0  PASS!
+
+Test 3 , Args: 2@,@foo@(@3@,@2@)
+    Expected:-1 , Actual-1  PASS!
+    Expected:-1 , Actual-1  PASS!
+    Expected: 0 , Actual 0  PASS!
+    Expected: 0 , Actual 0  PASS!
+    Expected: 0 , Actual 0  PASS!
+
+Test 4 , Args: 2@,@3@,
+    Expected:-1 , Actual-1  PASS!
+    Expected:-1 , Actual-1  PASS!
+    Expected: 0 , Actual 0  PASS!
+    Expected: 0 , Actual 0  PASS!
+
+Test 5 , Args: 2@,@,@3
+    Expected:-1 , Actual-1  PASS!
+    Expected: 0 , Actual 0  PASS!
+    Expected:-1 , Actual-1  PASS!
+    Expected: 0 , Actual 0  PASS!
+
+Test 6 , Args: 2@,@,
+    Expected:-1 , Actual-1  PASS!
+    Expected: 0 , Actual 0  PASS!
+    Expected: 0 , Actual 0  PASS!
+    Expected: 0 , Actual 0  PASS!


### PR DESCRIPTION
Currently functions only have very limited optional argument support, this expands it so that we can have more complex sets of optional arguments for functions, such as multiple arguments where not all need to be provided. This will be used in the future for some upcoming functionality.

Note that this does not support any generic optional argument format, the commas always have to be provided unless an optional argument is at the end of the parameter list. Thus, if you have a format with one required and two optional arguments and you want to omit the first optional one, then you need to call it as `foo(2, , 3)`, rather than `foo(2, 3)`. This is important for avoiding ambiguous situations, and is how many SUBs currently handle this.

The two functions that violate that requirement are INSTR() and _INSTRREV(), which use the format `[?],?,?` and allow omitting the comma for the first argument. This format is simply handled as a special case.

Fixes: #303

---

This doesn't add any functions that make use of the new optional parameters, but I did test the likely new parameters for `_LOADIMAGE()` which is `?[,[?][.?]]` and they work as expected, allowing any combination of the second and third parameter to be provided but requiring the first.