### PR TITLE
The -o flag should not strip extensions except for .exe

### DIFF
--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -12323,11 +12323,11 @@ IF idemode = 0 AND No_C_Compile_Mode = 0 THEN
             path.out$ = getfilepath$(outputfile_cmd$)
             f$ = MID$(outputfile_cmd$, LEN(path.out$) + 1)
 
-            If UCASE$(GetFileExtension$(f$)) = "EXE" Then
+            IF UCASE$(GetFileExtension$(f$)) = "EXE" THEN
                 file$ = RemoveFileExtension$(f$)
-            Else
+            ELSE
                 file$ = f$
-            End If
+            END IF
         END IF
 
         IF LEN(path.out$) OR OutputIsRelativeToStartDir THEN

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -12322,7 +12322,12 @@ IF idemode = 0 AND No_C_Compile_Mode = 0 THEN
             'resolve relative path for output file
             path.out$ = getfilepath$(outputfile_cmd$)
             f$ = MID$(outputfile_cmd$, LEN(path.out$) + 1)
-            file$ = RemoveFileExtension$(f$)
+
+            If UCASE$(GetFileExtension$(f$)) = "EXE" Then
+                file$ = RemoveFileExtension$(f$)
+            Else
+                file$ = f$
+            End If
         END IF
 
         IF LEN(path.out$) OR OutputIsRelativeToStartDir THEN

--- a/source/utilities/file.bas
+++ b/source/utilities/file.bas
@@ -72,6 +72,20 @@ FUNCTION RemoveFileExtension$ (f$)
 END FUNCTION
 
 '
+' Returns the extension on the end of a file name
+'
+' Returns "" if there is no extension
+'
+FUNCTION GetFileExtension$ (f$)
+    FOR i = LEN(f$) TO 1 STEP -1
+        a = ASC(f$, i)
+        IF a = 47 OR a = 92 THEN EXIT FOR
+        IF a = 46 THEN GetFileExtension$ = MID$(f$, i + 1): EXIT FUNCTION
+    NEXT
+    GetFileExtension$ = ""
+END FUNCTION
+
+'
 ' Fixes the provided filename and path to use the correct path separator
 '
 SUB PATH_SLASH_CORRECT (a$)

--- a/tests/compile_tests/filename/filename.extra.extension.bas
+++ b/tests/compile_tests/filename/filename.extra.extension.bas
@@ -1,0 +1,2 @@
+$Console:Only
+System

--- a/tests/compile_tests/qb64pe/file.bas
+++ b/tests/compile_tests/qb64pe/file.bas
@@ -1,0 +1,41 @@
+DEFLNG A-Z
+$Console:Only
+
+Type TestCase
+    file As String
+    expectedExtension As String
+End Type
+
+Dim tests(5) As TestCase
+
+tests(1).file = "foobar.exe"
+tests(1).expectedExtension = "exe"
+
+tests(2).file = "foobar.EXE"
+tests(2).expectedExtension = "EXE"
+
+tests(3).file = "foobar."
+tests(3).expectedExtension = ""
+
+tests(4).file = "foobar"
+tests(4).expectedExtension = ""
+
+tests(5).file = "foobar.tar.gz"
+tests(5).expectedExtension = "gz"
+
+For i = 1 To UBOUND(tests)
+    result$ = GetFileExtension$(tests(i).file)
+
+    Print "Test"; i; ", Filename: "; tests(i).file
+    Print "    Expected: "; tests(i).expectedExtension; ", Actual: "; result$
+
+    If result$ = tests(i).expectedExtension Then
+        Print "      PASS!"
+    Else
+        Print "      FAIL!"
+    End If
+Next
+
+System
+
+'$include:'../../../source/utilities/file.bas'

--- a/tests/compile_tests/qb64pe/file.output
+++ b/tests/compile_tests/qb64pe/file.output
@@ -1,0 +1,15 @@
+Test 1 , Filename: foobar.exe
+    Expected: exe, Actual: exe
+      PASS!
+Test 2 , Filename: foobar.EXE
+    Expected: EXE, Actual: EXE
+      PASS!
+Test 3 , Filename: foobar.
+    Expected: , Actual: 
+      PASS!
+Test 4 , Filename: foobar
+    Expected: , Actual: 
+      PASS!
+Test 5 , Filename: foobar.tar.gz
+    Expected: gz, Actual: gz
+      PASS!


### PR DESCRIPTION
Current the -o flag will strip any "extension" on the provided filename, which is fairly problimatic on Linux and Mac OS since those executables do not have other extensions and names like "foobar.v1" will get the ".v1" stripped off. This can happen on Windows as well if you leave off the .exe (QB64-PE will add it for you, but also strip off the existing extension if there was one).

QB64-PE stripping off the ".exe" when provided that on Linux and Mac OS might actually be useful behavior people are relying on (so that they don't need to provide different names when compiling on Linux/Mac OS) so we are preserving that behavior and still removing the extension if it is exactly "EXE", otherwise we now leave it in place.

Fixes: #297