### PR TITLE
Wiki dev

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -2376,7 +2376,7 @@ FUNCTION ide2 (ignore)
                         x = l
                         x3 = 1
                         c = ASC(Help_Txt$, x)
-                        DO UNTIL c = 13
+                        DO UNTIL ASC(Help_Txt$, x + 1) > 127
                             IF Help_Select = 2 THEN
                                 IF y >= Help_SelY1 AND y <= Help_SelY2 THEN
                                     IF x3 >= Help_SelX1 AND x3 <= Help_SelX2 THEN
@@ -2464,7 +2464,7 @@ FUNCTION ide2 (ignore)
                         x = l
                         a$ = ""
                         c = ASC(Help_Txt$, x)
-                        DO UNTIL c = 13
+                        DO UNTIL ASC(Help_Txt$, x + 1) > 127
                             lnk = CVI(MID$(Help_Txt$, x + 2, 2))
                             IF lnk THEN a$ = a$ + CHR$(c) ELSE a$ = a$ + CHR$(0) 'only add text with links
                             x = x + 4: c = ASC(Help_Txt$, x)
@@ -2485,7 +2485,7 @@ FUNCTION ide2 (ignore)
                             c = ASC(Help_Txt$, x)
                             oldlnk = 0
                             lnkx1 = 0: lnkx2 = 0
-                            DO UNTIL c = 13
+                            DO UNTIL ASC(Help_Txt$, x + 1) > 127
                                 lnk = CVI(MID$(Help_Txt$, x + 2, 2))
                                 IF lnkx1 = 0 AND lnk <> 0 AND oldlnk = 0 AND px = x2 THEN lnkx1 = x2
                                 IF lnkx1 <> 0 AND lnk = 0 AND lnkx2 = 0 THEN lnkx2 = x2 - 1
@@ -2597,7 +2597,7 @@ FUNCTION ide2 (ignore)
                 x = l
                 x2 = 1
                 c = ASC(Help_Txt$, x)
-                DO UNTIL c = 13
+                DO UNTIL ASC(Help_Txt$, x + 1) > 127
 
                     IF x2 = Help_cx THEN
                         lnk = CVI(MID$(Help_Txt$, x + 2, 2))
@@ -17723,7 +17723,7 @@ SUB Help_ShowText
             sx = Help_wx1
             c = ASC(Help_Txt$, x): col = ASC(Help_Txt$, x + 1)
             LOCATE sy, sx
-            DO UNTIL c = 13
+            DO UNTIL col > 127
                 COLOR col AND 15, col \ 16
                 IF IdeSystem = 3 AND Help_Select = 2 THEN
                     IF y >= Help_SelY1 AND y <= Help_SelY2 THEN
@@ -17744,8 +17744,7 @@ SUB Help_ShowText
             Help_LineLen(y - Help_sy) = x3 - 1
 
             FOR x4 = 1 TO Help_wx2 - POS(0) + 1
-                IF col = 0 THEN col = 7
-                COLOR col AND 15, col \ 16
+                COLOR 7, (col - 128) \ 16
                 IF IdeSystem = 3 AND Help_Select = 2 THEN
                     IF y >= Help_SelY1 AND y <= Help_SelY2 THEN
                         IF x3 >= Help_SelX1 AND x3 <= Help_SelX2 THEN

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -17703,19 +17703,9 @@ SUB Help_ShowText
 
     REDIM Help_LineLen(Help_wh)
 
-    COLOR 7, 0
-
-    'CLS
-    'FOR y = Help_wy1 - 1 TO Help_wy2 + 1
-    '    FOR x = Help_wx1 - 1 TO Help_wx2 + 1
-    '        LOCATE y, x: PRINT chr$(219);
-    '    NEXT
-    'NEXT
-
     sy = Help_wy1
     FOR y = Help_sy TO Help_sy + Help_wh - 1
         IF y <= help_h THEN
-            'PRINT CVL(MID$(Help_Line$, (y - 1) * 4 + 1, 4)), LEN(Help_Txt$)
             l = CVL(MID$(Help_Line$, (y - 1) * 4 + 1, 4))
             x = l
             x3 = 1
@@ -17778,21 +17768,6 @@ SUB Help_ShowText
         END IF
         sy = sy + 1
     NEXT
-
-    'LOCATE Help_cy - Help_sy + Help_wy1, Help_cx - Help_sx + Help_wx1
-    'COLOR 15, 4
-    'PRINT CHR$(SCREEN(CSRLIN, POS(0)));
-
-    'c = 0
-    'DO
-    '    old_kcontrol = KCONTROL
-    '    GetInput
-    '    IF KB > 0 THEN c = 1
-    '    IF mCLICK THEN c = 1
-    '    IF mWHEEL THEN c = 1
-    '    IF KCONTROL AND old_kcontrol = 0 THEN c = 0
-    '    IF mB THEN c = 1
-    'LOOP UNTIL c
 
 END SUB
 

--- a/source/ide/wiki/wiki_global.bas
+++ b/source/ide/wiki/wiki_global.bas
@@ -27,7 +27,7 @@ DIM SHARED Help_Col_Link: Help_Col_Link = 9
 DIM SHARED Help_Col_Bold: Help_Col_Bold = 15
 DIM SHARED Help_Col_Italic: Help_Col_Italic = 3
 DIM SHARED Help_Col_Section: Help_Col_Section = 8
-DIM SHARED Help_Bold, Help_Italic, Help_Heading
+DIM SHARED Help_Bold, Help_Italic, Help_LinkTxt, Help_Heading
 DIM SHARED Help_Underline, Help_ChkBlank
 DIM SHARED Help_LockWrap, Help_LockParse
 DIM SHARED Help_DList, Help_LIndent$

--- a/source/ide/wiki/wiki_global.bas
+++ b/source/ide/wiki/wiki_global.bas
@@ -52,7 +52,7 @@ DIM SHARED Help_Search_Str AS STRING
 DIM SHARED Help_PageLoaded AS STRING
 DIM SHARED Help_Recaching, Help_IgnoreCache
 
-'HTML entity replacements
+'Entity replacements
 '(for non HTML chars only, ie. no &amp; &lt; &gt; &quot; which are handled in SUB Wiki$ directly)
 TYPE wikiEntityReplace
     enti AS STRING * 8 '= entity as supported (ie. name where available, else as decimal number)
@@ -62,42 +62,46 @@ DIM SHARED wpEntRepl(0 TO 10) AS wikiEntityReplace
 DIM SHARED wpEntReplCnt: wpEntReplCnt = -1 'wpEntRepl index counter (pre-increment, hence
 'you don't need "wpEntReplCnt - 1" when used in loops, just do "0 TO wpEntReplCnt"
 wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&apos;": wpEntRepl(wpEntReplCnt).repl = "'" 'apostrophe
-wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&#91;": wpEntRepl(wpEntReplCnt).repl = "[" 'open square bracket
-wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&#93;": wpEntRepl(wpEntReplCnt).repl = "]" 'close square bracket
-wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&#123;": wpEntRepl(wpEntReplCnt).repl = "{" 'open curly bracket
-wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&#125;": wpEntRepl(wpEntReplCnt).repl = "}" 'close curly bracket
+wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&#91;": wpEntRepl(wpEntReplCnt).repl = "[" 'square bracket (open)
+wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&#93;": wpEntRepl(wpEntReplCnt).repl = "]" 'square bracket (close)
+wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&#123;": wpEntRepl(wpEntReplCnt).repl = "{" 'curly bracket (open)
+wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&#125;": wpEntRepl(wpEntReplCnt).repl = "}" 'curly bracket (close)
 wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&pi;": wpEntRepl(wpEntReplCnt).repl = CHR$(227) 'pi
 wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&theta;": wpEntRepl(wpEntReplCnt).repl = CHR$(233) 'theta
 wpEntReplCnt = wpEntReplCnt + 1: wpEntRepl(wpEntReplCnt).enti = "&nbsp;": wpEntRepl(wpEntReplCnt).repl = CHR$(255) 'non-breaking space
 
-'Unicode replacements
+'UTF-8 replacements
 TYPE wikiUtf8Replace
     utf8 AS STRING * 4 '= MKI$(reversed hex 2-byte UTF-8 sequence) or MKL$(reversed hex 3/4-byte UTF-8 sequence)
     repl AS STRING * 8 '= replacement string (1-8 chars)
 END TYPE
-DIM SHARED wpUtfRepl(0 TO 40) AS wikiUtf8Replace
+DIM SHARED wpUtfRepl(0 TO 65) AS wikiUtf8Replace
 DIM SHARED wpUtfReplCnt: wpUtfReplCnt = -1 'wpUtfRepl index counter (pre-increment, hence
 'you don't need "wpUtfReplCnt - 1" when used in loops, just do "0 TO wpUtfReplCnt"
 'Note: All UTF-8 values must be reversed in MKI$/MKL$, as it flips them to little endian.
 '      In the wiki text they are noted in big endian, hence we need to pre-flip them.
 '2-byte sequences
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HB6C2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(20) 'pilcrow
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA7C2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(21) 'section
 wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA9C2): wpUtfRepl(wpUtfReplCnt).repl = "(c)" 'copyright
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA9C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(130) 'accent (é)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA2C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(131) 'accent (â)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA0C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(133) 'accent (à)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA5C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(134) 'accent (å)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA7C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(135) 'accent (ç)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HAAC3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(136) 'accent (ê)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HABC3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(137) 'accent (ë)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA8C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(138) 'accent (è)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HAFC3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(139) 'accent (ï)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HAEC3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(140) 'accent (î)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA2C2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(155) 'cents (ø)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HBDC2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(171) 'fraction (½)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HBCC2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(172) 'fraction (¼)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA9C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(130) 'accent (‚)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA2C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(131) 'accent (ƒ)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA0C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(133) 'accent (…)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA5C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(134) 'accent (†)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA7C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(135) 'accent (‡)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HAAC3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(136) 'accent (ˆ)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HABC3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(137) 'accent (‰)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA8C3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(138) 'accent (Š)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HAFC3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(139) 'accent (‹)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HAEC3): wpUtfRepl(wpUtfReplCnt).repl = CHR$(140) 'accent (Œ)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA2C2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(155) 'cents
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HBDC2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(171) 'fraction («)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HBCC2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(172) 'fraction (¬)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&H80CF): wpUtfRepl(wpUtfReplCnt).repl = CHR$(227) 'pi
 wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKI$(&HA0C2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(255) 'non-breaking space
 '3-byte sequences
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HA680E2): wpUtfRepl(wpUtfReplCnt).repl = "..." 'ellipsis
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HA680E2): wpUtfRepl(wpUtfReplCnt).repl = "..." 'ellipsis (hori.)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HAE8BE2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(240) 'ellipsis (vert.) (ð)
 wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H8C94E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(218) 'single line draw (top/left corner)
 wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9094E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(191) 'single line draw (top/right corner)
 wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9494E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(192) 'single line draw (bottom/left corner)
@@ -109,14 +113,36 @@ wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HAC94E2): 
 wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HA494E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(180) 'single line draw (vert. line + left connection)
 wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9C94E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(195) 'single line draw (vert. line + right connection)
 wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HBC94E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(197) 'single line draw (hori./vert. line cross)
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HB296E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(30) 'triangle up
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HBC96E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(31) 'triangle down
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H8497E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(17) 'triangle left
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HBA96E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(16) 'triangle right
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9186E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(24) 'arrow up
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9386E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(25) 'arrow down
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9086E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(27) 'arrow left
-wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9286E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(26) 'arrow right
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HB296E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(30) 'triangle (up)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HBC96E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(31) 'triangle (down)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H8497E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(17) 'triangle (left)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HBA96E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(16) 'triangle (right)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9186E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(24) 'arrow (up)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9386E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(25) 'arrow (down)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9586E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(18) 'arrow (up down)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HA886E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(23) 'arrow (up down with base)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9086E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(27) 'arrow (left)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9286E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(26) 'arrow (right)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9486E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(29) 'arrow (left right)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HBA98E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(1) 'face (drawing)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HBB98E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(2) 'face (solid)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HA599E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(3) 'card suit (heart)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HA699E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(4) 'card suit (diamond)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HA399E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(5) 'card suit (club)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HA099E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(6) 'card suit (spade)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H8299E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(11) 'gender sign (male)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H8099E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(12) 'gender sign (female)
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HAA99E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(13) 'eighth note
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HAB99E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(14) 'beamed eighth notes
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HA280E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(7) 'bullet
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9897E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(8) 'inverse bullet
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H8B97E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(9) 'circle
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9997E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(10) 'inverse circle
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HBC98E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(15) 'sun with rays
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HBC80E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(19) 'double exclamation
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&HAC96E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(22) 'rectangle
+wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H9F88E2): wpUtfRepl(wpUtfReplCnt).repl = CHR$(28) 'right angle
 '4-byte sequences
 wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H80989FF0): wpUtfRepl(wpUtfReplCnt).repl = ":)" 'smily
 wpUtfReplCnt = wpUtfReplCnt + 1: wpUtfRepl(wpUtfReplCnt).utf8 = MKL$(&H88989FF0): wpUtfRepl(wpUtfReplCnt).repl = ";)" 'wink
+

--- a/source/ide/wiki/wiki_methods.bas
+++ b/source/ide/wiki/wiki_methods.bas
@@ -377,20 +377,13 @@ SUB WikiParse (a$) 'Wiki page interpret
         'Direct HTML code is not handled in Code/Output blocks (hard lock), as all text
         'could be part of the code example itself (just imagine a HTML parser/writer demo)
         IF Help_LockParse <= 0 THEN
-            s$ = "<sup>": IF c$(LEN(s$)) = s$ THEN Help_AddTxt "^", col, 0: i = i + LEN(s$) - 1: GOTO charDone
-            s$ = "</sup>": IF c$(LEN(s$)) = s$ THEN i = i + LEN(s$) - 1: GOTO charDone
-
             s$ = "<center>" 'centered section
             IF c$(LEN(s$)) = s$ THEN
                 i = i + LEN(s$) - 1
                 wla$ = wikiLookAhead$(a$, i + 1, "</center>")
-                IF INSTR(wla$, "#toc") > 0 OR INSTR(wla$, "#top") > 0 OR INSTR(wla$, "to Top") > 0 THEN
-                    i = i + LEN(wla$) + 9 'ignore TOC/TOP links
-                ELSE
-                    Help_Center = 1: Help_CIndent$ = wikiBuildCIndent$(wla$)
-                    Help_AddTxt SPACE$(ASC(Help_CIndent$, 1)), col, 0 'center content
-                    Help_CIndent$ = MID$(Help_CIndent$, 2)
-                END IF
+                Help_Center = 1: Help_CIndent$ = wikiBuildCIndent$(wla$)
+                Help_AddTxt SPACE$(ASC(Help_CIndent$, 1)), col, 0 'center content
+                Help_CIndent$ = MID$(Help_CIndent$, 2)
                 GOTO charDone
             END IF
             s$ = "</center>"
@@ -406,9 +399,7 @@ SUB WikiParse (a$) 'Wiki page interpret
                 FOR ii = i TO LEN(a$) - 1
                     IF MID$(a$, ii, 1) = ">" THEN
                         wla$ = wikiLookAhead$(a$, ii + 1, "</p>")
-                        IF INSTR(wla$, "#toc") > 0 OR INSTR(wla$, "#top") > 0 OR INSTR(wla$, "to Top") > 0 THEN
-                            i = ii + LEN(wla$) + 4 'ignore TOC/TOP links
-                        ELSEIF INSTR(MID$(a$, i, ii - i), "center") > 0 THEN
+                        IF INSTR(MID$(a$, i, ii - i), "center") > 0 THEN
                             Help_Center = 1: Help_CIndent$ = wikiBuildCIndent$(wla$)
                             Help_AddTxt SPACE$(ASC(Help_CIndent$, 1)), col, 0 'center (if in style)
                             Help_CIndent$ = MID$(Help_CIndent$, 2)
@@ -426,28 +417,7 @@ SUB WikiParse (a$) 'Wiki page interpret
                 Help_NewLine
                 GOTO charDone
             END IF
-            s$ = "<span" 'custom inline attributes ignored
-            IF c$(LEN(s$)) = s$ THEN
-                i = i + LEN(s$) - 1
-                FOR ii = i TO LEN(a$) - 1
-                    IF MID$(a$, ii, 1) = ">" THEN i = ii: EXIT FOR
-                NEXT
-                GOTO charDone
-            END IF
-            s$ = "</span>"
-            IF c$(LEN(s$)) = s$ THEN
-                i = i + LEN(s$) - 1
-                GOTO charDone
-            END IF
 
-            s$ = "<div" 'ignore divisions (TOC and letter links)
-            IF c$(LEN(s$)) = s$ THEN
-                i = i + LEN(s$) - 1
-                FOR ii = i TO LEN(a$) - 1
-                    IF MID$(a$, ii, 6) = "</div>" THEN i = ii + 5: EXIT FOR
-                NEXT
-                GOTO charDone
-            END IF
             s$ = "<!--" 'ignore HTML comments
             IF c$(LEN(s$)) = s$ THEN
                 i = i + LEN(s$) - 1

--- a/source/ide/wiki/wiki_methods.bas
+++ b/source/ide/wiki/wiki_methods.bas
@@ -361,8 +361,9 @@ SUB WikiParse (a$) 'Wiki page interpret
                             EXIT FOR '       'one image does not, so ignore this gallery
                         END IF
                         wla$ = StrReplace$(wla$, ";", ":")
+                        wla$ = StrReplace$(wla$, "''none''", "''no versions''")
                         wla$ = StrReplace$(wla$, "''all''", "''all versions''")
-                        wla$ = "* " + LEFT$(wla$, LEN(wla$) - 3) + CHR$(10)
+                        wla$ = "* " + LEFT$(wla$, LEN(wla$) - 3) + MKI$(&H0A0A)
                         a$ = LEFT$(a$, ii) + wla$ + MID$(a$, ii + LEN(v$) + 1)
                         n = LEN(a$): i = ii
                     END IF
@@ -576,7 +577,7 @@ SUB WikiParse (a$) 'Wiki page interpret
                 ELSEIF c$(2) = "}}" THEN
                     IF cb$ = "Parameter" THEN
                         Help_Italic = 0: col = Help_Col
-                    ELSEIF LCASE$(LEFT$(cb$, 5)) = "small" THEN
+                    ELSEIF LEFT$(cb$, 5) = "Small" THEN
                         IF ASC(cb$, 6) = 196 THEN
                             Help_AddTxt " " + STRING$(Help_ww - Help_Pos, 196), 15, 0
                             Help_BG_Col = 0: col = Help_Col
@@ -645,20 +646,6 @@ SUB WikiParse (a$) 'Wiki page interpret
                     Help_BG_Col = 0: Help_LockParse = 0
                     Help_Bold = 0: Help_Italic = 0: col = Help_Col
                 END IF
-                'Pre Block
-                IF cb$ = "PreStart" AND Help_LockParse = 0 THEN
-                    Help_CheckRemoveBlankLine
-                    Help_Bold = 0: Help_Italic = 0: col = Help_Col
-                    Help_LIndent$ = "  ": Help_LockParse = -2
-                    Help_NewLine
-                    IF c$(3) = "}}" + CHR$(10) THEN i = i + 1
-                END IF
-                IF cb$ = "PreEnd" AND Help_LockParse <> 0 THEN
-                    Help_LIndent$ = ""
-                    Help_CheckRemoveBlankLine
-                    Help_LockParse = 0
-                    Help_Bold = 0: Help_Italic = 0: col = Help_Col
-                END IF
                 'Text Block
                 IF cb$ = "TextStart" AND Help_LockParse = 0 THEN
                     Help_CheckBlankLine
@@ -671,6 +658,20 @@ SUB WikiParse (a$) 'Wiki page interpret
                     Help_CheckFinishLine: Help_CheckRemoveBlankLine
                     Help_AddTxt STRING$(Help_ww, 196), 15, 0: Help_NewLine
                     Help_BG_Col = 0: Help_LockParse = 0
+                    Help_Bold = 0: Help_Italic = 0: col = Help_Col
+                END IF
+                'Pre Block
+                IF cb$ = "PreStart" AND Help_LockParse = 0 THEN
+                    Help_CheckRemoveBlankLine
+                    Help_Bold = 0: Help_Italic = 0: col = Help_Col
+                    Help_LIndent$ = "  ": Help_LockParse = -2
+                    Help_NewLine
+                    IF c$(3) = "}}" + CHR$(10) THEN i = i + 1
+                END IF
+                IF cb$ = "PreEnd" AND Help_LockParse <> 0 THEN
+                    Help_LIndent$ = ""
+                    Help_CheckRemoveBlankLine
+                    Help_LockParse = 0
                     Help_Bold = 0: Help_Italic = 0: col = Help_Col
                 END IF
                 'Fixed Block
@@ -703,7 +704,7 @@ SUB WikiParse (a$) 'Wiki page interpret
                 END IF
 
                 'Small template text will be centered (maybe as block note)
-                IF LCASE$(cb$) = "small" AND Help_LockParse <= 0 THEN 'keep as is in Code/Output blocks
+                IF cb$ = "Small" AND Help_LockParse <= 0 THEN 'keep as is in Code/Output blocks
                     wla$ = wikiLookAhead$(a$, i + 1, "}}")
                     Help_CIndent$ = wikiBuildCIndent$(wla$): iii = 0
                     IF i > 31 AND ASC(Help_CIndent$, 1) >= Help_ww / 4 THEN
@@ -772,7 +773,7 @@ SUB WikiParse (a$) 'Wiki page interpret
             IF c$(4) = "----" AND nl = 1 THEN
                 i = i + 3
                 Help_CheckBlankLine
-                Help_AddTxt STRING$(Help_ww, 196), 8, 0
+                Help_AddTxt STRING$(Help_ww, 196), 14, 0
                 Help_ChkBlank = 1
                 GOTO charDone
             END IF
@@ -780,7 +781,7 @@ SUB WikiParse (a$) 'Wiki page interpret
                 IF c$(4) = "<hr>" THEN i = i + 3
                 IF c$(6) = "<hr />" THEN i = i + 5
                 Help_CheckBlankLine
-                Help_AddTxt STRING$(Help_ww, 196), 8, 0
+                Help_AddTxt STRING$(Help_ww, 196), 14, 0
                 Help_ChkBlank = 1
                 GOTO charDone
             END IF

--- a/source/ide/wiki/wiki_methods.bas
+++ b/source/ide/wiki/wiki_methods.bas
@@ -449,7 +449,8 @@ SUB WikiParse (a$) 'Wiki page interpret
             IF c$(LEN(s$)) = s$ THEN
                 i = i + LEN(s$) - 1
                 FOR ii = i TO LEN(a$) - 1
-                    IF MID$(a$, ii, 3) = "-->" THEN i = ii + 2: EXIT FOR
+                    IF MID$(a$, ii, 4) = "-->" + CHR$(10) THEN i = ii + 3: GOTO charDoneKnl
+                    IF MID$(a$, ii, 3) = "-->" THEN i = ii + 2: GOTO charDone
                 NEXT
                 GOTO charDone
             END IF
@@ -922,8 +923,8 @@ SUB WikiParse (a$) 'Wiki page interpret
 
         'Line break handling (no restrictions)
         IF c = 10 OR c$(4) = "<br>" OR c$(6) = "<br />" THEN
-            IF c$(4) = "<br>" THEN i = i + 3
-            IF c$(6) = "<br />" THEN i = i + 5
+            IF c$(4) = "<br>" THEN i = i + 3: IF ASC(c$(5), 5) = 10 THEN i = i + 1
+            IF c$(6) = "<br />" THEN i = i + 5: IF ASC(c$(7), 7) = 10 THEN i = i + 1
             IF c = 10 THEN 'on real new line only
                 IF dl > 1 THEN dl = dl - 1 'update def list state
                 IF Help_LockParse = 0 THEN Help_LIndent$ = "" 'end indention outside blocks
@@ -1317,7 +1318,10 @@ FUNCTION wikiBuildCIndent$ (a$) 'Pre-calc center indentions
         b$ = b$ + MID$(org$, i, 1)
         charDoneUtf:
     NEXT
-
+    b$ = StrReplace$(b$, "<br>" + CHR$(10), CHR$(10)) 'convert HTML line breaks
+    b$ = StrReplace$(b$, "<br>", CHR$(10))
+    b$ = StrReplace$(b$, "<br />" + CHR$(10), CHR$(10)) 'convert XHTML line breaks
+    b$ = StrReplace$(b$, "<br />", CHR$(10))
     b$ = _TRIM$(b$) + CHR$(10) 'safety fallback
 
     i = 1: st = 1: br = 0: res$ = ""

--- a/source/utilities/s-buffer/sb_qb64pe_extension.bm
+++ b/source/utilities/s-buffer/sb_qb64pe_extension.bm
@@ -25,7 +25,7 @@ SELECT CASE UCASE$(LEFT$(sbMode$, 1))
     CASE "B" 'binary
         IF buf% > UBOUND(SBufN) THEN GOSUB newBuf
         nul& = SeekBuf&(buf%, 0, SBM_BufStart)
-    CASE "I" 'input (try to load from file, if yet unkown)
+    CASE "I" 'input (try to load from file, if yet unknown)
         IF buf% > UBOUND(SBufN) THEN GOSUB loadBuf
         nul& = SeekBuf&(buf%, 0, SBM_BufStart)
     CASE "O" 'output


### PR DESCRIPTION
Finally I got the HTML Entity and UTF-8 handling working to a sufficient grade to properly parse our Wiki pages. However, some breaking changes were required to get along with it. Some pages such as `ASCII`, `_PRINTSTRING`, `_SCREENPRINT` and others contain UTF-8 chars for the lower 32 control chars, which got problematic especially for the `Carriage Return` CHR$(13) code, which was used as line delimiter in the Help_Txt$ variable and so never was printed but created a new line which screwed up the page layout.
To be able to really display all 256 chars, another method for line break detection was needed. Fortunately the Help_Txt$ variable is an interleaved string of char/color/link values, so to be able to use the full range for chars, the line end marker had to go either into the color or link part. As the links are not really predictable (unless counting them in a pre-pass) you cannot set a defined value you can call "safe" as a constant marker, so color is the part remaining.
The color value is actually encoded like the result of the `SCREEN` function when used to get the color, i.e. the lower nibble (bits 0-3) are the foreground (0-15) and the first 3 bits of the upper nibble (bits 4-6) are the background (0-7) while the remaining bit 7 is the "blinking" foreground flag. As we don't use blinking colors in the IDE help, this bit is the perfect candidate for use as line end marker. Hence, where formerly the char position value was tested for = 13 or <> 13, you'll now see that the color position value is checked for > 127 or < 128 respectively.

The second big change targets the handling of links, templates and centered text. Formerly the text in those layout elements was simply copied over into the Help_Txt$, bypassing the remaining parser code and so never running through the Entity/UTF-8 substitution stage. To change this, the flow logic was changed so that the text is not simply copied without further processing, but instead only flags are set to indicate the processed layout element and then the main parser continues, running all chars through the substitution stage and accumulating them in the respective variables at the end.

Apart from that two big changes, some more fixes were made, mainly to filter/skip useless line feeds in the Wiki text and also some more old code was removed, which formerly handled things which I've eliminated from the Wiki pages in the meantime.
The list of recognized UTF-8 sequences has grown by 20+ more chars and the IDE will show dynamically created warnings at the top of help pages, if unknown Entities/UTF-8 are detected in it and asking people to report it in the Forum, so we can update and complete the list over time.

As a result of all that, and of the fact that I've implemented local links handling a while back already, I've now also removed the filters for all those "Return to Table of Contents" links and the "Letter rows" at the top of the alphabetic index page. All those links are now properly rendered and working just like in the online Wiki, so you can happily jump around on the pages. The IDE help pages are now probably as close as we can come to the real Wiki feeling.
