### PR TITLE
Tiny fixes that allow the IDE to be compiled with LLVM MinGW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,10 @@ ifeq ($(OS),win)
 	EXTENSION := .exe
 
 	# Check bitness by seeing which compiler we have
-	ifeq ($(wildcard $(PATH_INTERNAL_C)\c_compiler\i686-w64-mingw32),)
-		BITS := 64
-	else
+	ifeq "$(filter $(findstring aarch64,$(shell $(CC) -dumpmachine)) $(findstring x86_64,$(shell $(CC) -dumpmachine)),aarch64 x86_64)" ""
 		BITS := 32
+	else
+		BITS := 64
 	endif
 endif
 

--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -10999,8 +10999,8 @@ void qbsub_width(int32 option, int32 value1, int32 value2, int32 value3, int32 v
             if (value4 < value2)
                 value4 = value2; // and don't make that buffer height smaller than the console height
 
-            SMALL_RECT rect = {0, 0, width - 1, height - 1};
-            COORD bufferSize = {value3, value4};
+            SMALL_RECT rect = {0, 0, (SHORT)(width - 1), (SHORT)(height - 1)};
+            COORD bufferSize = {(SHORT)value3, (SHORT)value4};
             SetConsoleScreenBufferSize(hConsole, bufferSize); // set the buffer
             SetConsoleWindowInfo(hConsole, TRUE, &rect);      // set the console itself
             return;
@@ -14929,7 +14929,7 @@ void qbg_sub_locate(int32 row, int32 column, int32 cursor, int32 start, int32 st
             column = cl_bufinfo.dwCursorPosition.X + 1;
         if (row == 0)
             row = cl_bufinfo.dwCursorPosition.Y + 1;
-        COORD pos = {column - 1, row - 1};
+        COORD pos = {(SHORT)(column - 1), (SHORT)(row - 1)};
         HANDLE output = GetStdHandle(STD_OUTPUT_HANDLE);
         SetConsoleCursorPosition(output, pos);
 #else
@@ -20800,7 +20800,7 @@ uint32 func_screen(int32 y, int32 x, int32 returncol, int32 passed) {
     if (read_page->console) {
         SECURITY_ATTRIBUTES SecAttribs = {sizeof(SECURITY_ATTRIBUTES), 0, 1};
         HANDLE cl_conout = CreateFileA("CONOUT$", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, &SecAttribs, OPEN_EXISTING, 0, 0);
-        COORD cp1 = {x - 1, y - 1};
+        COORD cp1 = {(SHORT)(x - 1), (SHORT)(y - 1)};
         DWORD t;
         uint16 a;
         if (returncol) {
@@ -27905,7 +27905,7 @@ void *tcp_host_open(int64 port) {
     // and insert into the port field
     // Bind the socket to our local server address
     static int nret;
-    nret = bind(listeningSocket, (LPSOCKADDR)&serverInfo, sizeof(struct sockaddr));
+    nret = ::bind(listeningSocket, (LPSOCKADDR)&serverInfo, sizeof(struct sockaddr));
     if (nret == SOCKET_ERROR) {
         closesocket(listeningSocket);
         return NULL;

--- a/internal/c/parts/network/log.txt
+++ b/internal/c/parts/network/log.txt
@@ -1,1 +1,0 @@
--sockets based implementation


### PR DESCRIPTION
There are three parts to this:

- `libqb.cpp`: All changes here are to satisfy errors that Clang threw while compiling. All of them involve casting and scope resolution.
- `log.txt` and `src.c` in `internal/c/parts/network/`: these two were dead / empty files that I removed while trying to upgrade `libcurl` to the latest version
- `Makefile`: Makefile was building the 32-bit ARM version of `libcurl` which then failed to link against 64-bit libraries and object files for the rest of the source. Initially, I thought this was due to an issue with `libcurl`'s makefile. Hence, I decided to update `libcurl` then. However, on close inspection, I found that `ARCH` was being set as `w32` [here](https://github.com/QB64-Phoenix-Edition/QB64pe/blob/2cb0db1e2885ec47d0f3edfa48c85efec4e55700/internal/c/parts/network/http/build.mk#L14). Hence, I made a minor change to the main `Makefile` that sets `BITS` after checking the output text from `gcc -dumpmachine`.

Also see #313.