### PR TITLE
Fix #124

### DIFF
--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -4140,25 +4140,21 @@ DO
                         END IF
                     NEXT
 
+                    og_libpath$ = libpath$ ' save the original libpath
+
                     'Accept ./ and .\ as a reference to the source file
                     'folder, replacing it with the actual full path, if available
                     IF libpath$ = "./" OR libpath$ = ".\" THEN
                         libpath$ = ""
                         IF NoIDEMode THEN
-                            libpath$ = path.source$
-                            IF LEN(libpath$) > 0 AND RIGHT$(libpath$, 1) <> pathsep$ THEN libpath$ = libpath$ + pathsep$
+                            libpath$ = FixDirectoryName(path.source$)
                         ELSE
                             IF LEN(ideprogname) THEN libpath$ = idepath$ + pathsep$
                         END IF
                     END IF
 
                     'Create a path which can be used for inline code (uses \\ instead of \)
-                    libpath_inline$ = ""
-                    FOR z = 1 TO LEN(libpath$)
-                        a = ASC(libpath$, z)
-                        libpath_inline$ = libpath_inline$ + CHR$(a)
-                        IF a = 92 THEN libpath_inline$ = libpath_inline$ + "\"
-                    NEXT
+                    libpath_inline$ = GetEscapedPath(libpath$)
 
                     IF LEN(x$) THEN
                         IF dynamiclibrary = 0 THEN
@@ -4475,6 +4471,21 @@ DO
                                         sfheader = 1
                                         GOTO GotHeader
                                     END IF
+                                    ' a740g: Fallback to source path
+                                    libpath$ = FixDirectoryName(idepath$) + og_libpath$
+                                    libpath_inline$ = GetEscapedPath(libpath$)
+                                    IF _FILEEXISTS(libpath$ + x$ + ".h") THEN
+                                        headername$ = libpath_inline$ + x$ + ".h"
+                                        IF customtypelibrary = 0 THEN sfdeclare = 0
+                                        sfheader = 1
+                                        GOTO GotHeader
+                                    END IF
+                                    IF _FILEEXISTS(libpath$ + x$ + ".hpp") THEN
+                                        headername$ = libpath_inline$ + x$ + ".hpp"
+                                        IF customtypelibrary = 0 THEN sfdeclare = 0
+                                        sfheader = 1
+                                        GOTO GotHeader
+                                    END IF
                                 END IF 'Windows
 
                                 IF os$ = "LNX" THEN
@@ -4523,6 +4534,21 @@ DO
                                     END IF
                                     IF _FILEEXISTS("/usr/include/" + x$ + ".hpp") THEN
                                         headername$ = "/usr/include/" + x$ + ".hpp"
+                                        IF customtypelibrary = 0 THEN sfdeclare = 0
+                                        sfheader = 1
+                                        GOTO GotHeader
+                                    END IF
+                                    ' a740g: Fallback to source path
+                                    libpath$ = FixDirectoryName(idepath$) + og_libpath$
+                                    libpath_inline$ = GetEscapedPath(libpath$)
+                                    IF _FILEEXISTS(libpath$ + x$ + ".h") THEN
+                                        headername$ = libpath_inline$ + x$ + ".h"
+                                        IF customtypelibrary = 0 THEN sfdeclare = 0
+                                        sfheader = 1
+                                        GOTO GotHeader
+                                    END IF
+                                    IF _FILEEXISTS(libpath$ + x$ + ".hpp") THEN
+                                        headername$ = libpath_inline$ + x$ + ".hpp"
                                         IF customtypelibrary = 0 THEN sfdeclare = 0
                                         sfheader = 1
                                         GOTO GotHeader

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -4472,7 +4472,11 @@ DO
                                         GOTO GotHeader
                                     END IF
                                     ' a740g: Fallback to source path
-                                    libpath$ = FixDirectoryName(idepath$) + og_libpath$
+                                    IF inclevel > 0 THEN
+                                        libpath$ = getfilepath(incname(inclevel)) + og_libpath$
+                                    ELSE
+                                        libpath$ = FixDirectoryName(idepath$) + og_libpath$
+                                    END IF
                                     libpath_inline$ = GetEscapedPath(libpath$)
                                     IF _FILEEXISTS(libpath$ + x$ + ".h") THEN
                                         headername$ = libpath_inline$ + x$ + ".h"
@@ -4539,7 +4543,11 @@ DO
                                         GOTO GotHeader
                                     END IF
                                     ' a740g: Fallback to source path
-                                    libpath$ = FixDirectoryName(idepath$) + og_libpath$
+                                    IF inclevel > 0 THEN
+                                        libpath$ = getfilepath(incname(inclevel)) + og_libpath$
+                                    ELSE
+                                        libpath$ = FixDirectoryName(idepath$) + og_libpath$
+                                    END IF
                                     libpath_inline$ = GetEscapedPath(libpath$)
                                     IF _FILEEXISTS(libpath$ + x$ + ".h") THEN
                                         headername$ = libpath_inline$ + x$ + ".h"

--- a/source/utilities/file.bas
+++ b/source/utilities/file.bas
@@ -4,19 +4,19 @@
 '
 ' Returns: 0 on success, 1 on error
 FUNCTION CopyFile& (sourceFile$, destFile$)
-    DIM sourcefileNo, destFileNo
+    DIM sourceFileNo, destFileNo
     DIM fileLength AS _INTEGER64
 
     E = 0
     sourceFileNo = FREEFILE
-    OPEN sourceFile$ FOR BINARY as #sourceFileNo
-    if E = 1 THEN GOTO errorCleanup
+    OPEN sourceFile$ FOR BINARY AS #sourceFileNo
+    IF E = 1 THEN GOTO errorCleanup
 
     fileLength = LOF(sourceFileNo)
 
     destFileNo = FREEFILE
-    OPEN destFile$ FOR BINARY as #destFileNo
-    if E = 1 THEN GOTO errorCleanup
+    OPEN destFile$ FOR BINARY AS #destFileNo
+    IF E = 1 THEN GOTO errorCleanup
 
     ' Read the file in one go
     buffer$ = SPACE$(fileLength)
@@ -24,7 +24,7 @@ FUNCTION CopyFile& (sourceFile$, destFile$)
     GET #sourceFileNo, , buffer$
     PUT #destFileNo, , buffer$
 
-errorCleanup:
+    errorCleanup:
     IF sourceFileNo <> 0 THEN CLOSE #sourceFileNo
     IF destFileNo <> 0 THEN CLOSE #destFileNo
 
@@ -99,3 +99,26 @@ SUB PATH_SLASH_CORRECT (a$)
         NEXT
     END IF
 END SUB
+
+' Return a pathname where all "\" are correctly escaped
+FUNCTION GetEscapedPath$ (path_name AS STRING)
+    DIM buf AS STRING, z AS _UNSIGNED LONG, a AS _UNSIGNED _BYTE
+
+    FOR z = 1 TO LEN(path_name)
+        a = ASC(path_name, z)
+        buf = buf + CHR$(a)
+        IF a = 92 THEN buf = buf + "\"
+    NEXT
+
+    GetEscapedPath = buf
+END FUNCTION
+
+' Adds a trailing \ or / if to the name if needed
+FUNCTION FixDirectoryName$ (dir_name AS STRING)
+    IF LEN(dir_name) > 0 AND RIGHT$(dir_name, 1) <> pathsep$ THEN
+        FixDirectoryName = dir_name + pathsep$
+    ELSE
+        FixDirectoryName = dir_name
+    END IF
+END FUNCTION
+

--- a/source/utilities/file.bas
+++ b/source/utilities/file.bas
@@ -113,7 +113,7 @@ FUNCTION GetEscapedPath$ (path_name AS STRING)
     GetEscapedPath = buf
 END FUNCTION
 
-' Adds a trailing \ or / if to the name if needed
+' Adds a trailing \ or / to a directory name if needed
 FUNCTION FixDirectoryName$ (dir_name AS STRING)
     IF LEN(dir_name) > 0 AND RIGHT$(dir_name, 1) <> pathsep$ THEN
         FixDirectoryName = dir_name + pathsep$


### PR DESCRIPTION
This fixes #124.

Well, it basically adds more functionality on top of what we already had so that we do not break any old code.

With this PR, `DECLARE LIB` will go looking for any libs / headers just like it used to. However, if it is not able to find the headers libs, then it would additionally look inside the source folder.

So now a `Declare Library "include/math/vector"` would also look for `<source directory>/include/math/vector.h`.