### PR TITLE
Update TSF and add SF3 support and enhance $MIDISOUNDFONT behavior

### DIFF
--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -3493,11 +3493,21 @@ DO
                     ' Verify there are no extra characters after end quote
                     IF INSTR(MidiSoundFont$, CHR$(34)) <> LEN(MidiSoundFont$) THEN a$ = "Unexpected characters after the quoted file name": GOTO errmes
 
+                    ' Strip the trailing quote
                     MidiSoundFont$ = MID$(MidiSoundFont$, 1, LEN(MidiSoundFont$) - 1)
 
                     IF NOT _FILEEXISTS(MidiSoundFont$) THEN
-                        a$ = "Soundfont file " + AddQuotes$(MidiSoundFont$) + " could not be found!"
-                        GOTO errmes
+                        ' Just try to concatenate the path with the source or include path and check if we are able to find the file
+                        IF inclevel > 0 AND _FILEEXISTS(getfilepath(incname(inclevel)) + MidiSoundFont$) THEN
+                            MidiSoundFont$ = getfilepath(incname(inclevel)) + MidiSoundFont$
+                        ELSEIF _FILEEXISTS(FixDirectoryName(idepath$) + MidiSoundFont$) THEN
+                            MidiSoundFont$ = FixDirectoryName(idepath$) + MidiSoundFont$
+                        END IF
+
+                        IF NOT _FILEEXISTS(MidiSoundFont$) THEN
+                            a$ = "Soundfont file " + AddQuotes$(MidiSoundFont$) + " could not be found!"
+                            GOTO errmes
+                        END IF
                     END IF
                 ELSE
                     ' Constant values, only one for now


### PR DESCRIPTION
This is a small PR and has two changes.

1. It updates `TinySoundFont` (`TSF`) to the latest version. The latest version of `TSF` adds SoundFont3 support (SF3 = SF2 + Ogg Vorbis compression). The SF3 support in `TSF` uses `stb_vorbis.c`. Since we are already using `stb_vorbis.c`, enabling SF3 support is trivial.
2. `$MIDISOUNDFONT` behavior was updated so that it now looks for SoundFonts relative to the source and `$INCLUDE` files in addition to what it was already doing.