### PR TITLE
Update MinGW toolchain to v12.2.0 r2

### DIFF
--- a/setup_mingw.cmd
+++ b/setup_mingw.cmd
@@ -48,9 +48,9 @@ if "%MINGW%"=="mingw64" if "%~1"=="32" set MINGW=mingw32
 
 rem Set the correct file to download based on processor type
 if "%MINGW%"=="mingw32" (
-    set url="https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev1/i686-12.2.0-release-win32-dwarf-rt_v10-rev1.7z"
+    set url="https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/i686-12.2.0-release-win32-dwarf-msvcrt-rt_v10-rev2.7z"
 ) else (
-    set url="https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev1/x86_64-12.2.0-release-win32-seh-rt_v10-rev1.7z"
+    set url="https://github.com/niXman/mingw-builds-binaries/releases/download/12.2.0-rt_v10-rev2/x86_64-12.2.0-release-win32-seh-msvcrt-rt_v10-rev2.7z"
 )
 
 rem Download 7zr.exe. We'll need this to extract the MINGW archive


### PR DESCRIPTION
This updates the MinGW toolchain to v12.2.0 r2.

This was released on Dec 11, 2022, and I've been using this since then for all my QB64-PE tests, PRs etc. I have not gotten any false positives with this and hope it will reduce the false positives we've been getting with r1.