### PR TITLE
Fix fonts getting vertically misaligned

### DIFF
--- a/internal/c/libqb/include/image.h
+++ b/internal/c/libqb/include/image.h
@@ -36,21 +36,21 @@
         IMAGE_DEBUG_PRINT("Condition (%s) failed", #_exp_)
 #else
 #    ifdef _MSC_VER
-#        define IMAGE_DEBUG_PRINT(_fmt_, ...) // Don't do anything in release builds
+#        define IMAGE_DEBUG_PRINT(_fmt_, ...)       // Don't do anything in release builds
 #    else
 #        define IMAGE_DEBUG_PRINT(_fmt_, _args_...) // Don't do anything in release builds
 #    endif
-#    define IMAGE_DEBUG_CHECK(_exp_) // Don't do anything in release builds
+#    define IMAGE_DEBUG_CHECK(_exp_)                // Don't do anything in release builds
 #endif
 
 // The byte ordering here are straight from libqb.cpp. So, if libqb.cpp is wrong, then we are wrong! ;)
-#define IMAGE_GET_BGRA_RED(c) ((uint8_t)((uint32_t)(c) >> 16 & 0xFF))
-#define IMAGE_GET_BGRA_GREEN(c) ((uint8_t)((uint32_t)(c) >> 8 & 0xFF))
-#define IMAGE_GET_BGRA_BLUE(c) ((uint8_t)((uint32_t)(c) & 0xFF))
+#define IMAGE_GET_BGRA_RED(c) ((uint8_t)((uint32_t)(c) >> 16 & 0xFFu))
+#define IMAGE_GET_BGRA_GREEN(c) ((uint8_t)((uint32_t)(c) >> 8 & 0xFFu))
+#define IMAGE_GET_BGRA_BLUE(c) ((uint8_t)((uint32_t)(c) & 0xFFu))
 #define IMAGE_GET_BGRA_ALPHA(c) ((uint8_t)((uint32_t)(c) >> 24))
-#define IMAGE_GET_BGRA_BGR(c) ((uint32_t)(c) & 0xFFFFFF)
+#define IMAGE_GET_BGRA_BGR(c) ((uint32_t)(c) & 0xFFFFFFu)
 #define IMAGE_MAKE_BGRA(r, g, b, a)                                                                                                                            \
-    ((uint32_t)(((uint8_t)(b) | ((uint32_t)((uint8_t)(g)) << 8)) | ((uint32_t)((uint8_t)(r)) << 16) | ((uint32_t)((uint8_t)(a)) << 24)))
+    ((uint32_t)((uint8_t)(b) | ((uint32_t)((uint8_t)(g)) << 8) | ((uint32_t)((uint8_t)(r)) << 16) | ((uint32_t)((uint8_t)(a)) << 24)))
 //-----------------------------------------------------------------------------------------------------
 
 //-----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR resolves the issue reported by @loopy750 here https://qb64phoenix.com/forum/showthread.php?tid=1756&pid=16896#pid16896

In addition to this, `_UPRINTSTRING` now works correctly when commands like `WINDOW` and `VIEW` are used.

Note: `_PRINTSTRING` partially works with `VIEW` where it only clips but does not offset the rendering relative to the viewport. This should be addressed in a separate PR. I'll add a card about it.