### PR TITLE
Fix DECLARE DYNAMIC LIBRARY path issue

### DIFF
--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -4605,7 +4605,7 @@ DO
                                 '--------------------------(without path)------------------------------
                                 'check for .dll (direct)
                                 IF LEN(libname$) = 0 THEN
-                                    IF _FILEEXISTS(x$ + ".dll") THEN
+                                    IF _FILEEXISTS(x$ + ".dll") OR _FILEEXISTS(FixDirectoryName(path.source$) + x$ + ".dll") OR _FILEEXISTS(FixDirectoryName(idepath$) + x$ + ".dll") THEN
                                         libname$ = x$ + ".dll"
                                         inlinelibname$ = x$ + ".dll"
                                     END IF
@@ -4703,14 +4703,14 @@ DO
                                 IF MacOSX THEN 'dylib support
                                     'check for .dylib (direct)
                                     IF LEN(libname$) = 0 THEN
-                                        IF _FILEEXISTS("lib" + x$ + "." + libver$ + ".dylib") THEN
+                                        IF _FILEEXISTS("lib" + x$ + "." + libver$ + ".dylib") OR _FILEEXISTS(FixDirectoryName(path.source$) + "lib" + x$ + "." + libver$ + ".dylib") OR _FILEEXISTS(FixDirectoryName(idepath$) + "lib" + x$ + "." + libver$ + ".dylib") THEN
                                             libname$ = "lib" + x$ + "." + libver$ + ".dylib"
                                             inlinelibname$ = "lib" + x$ + "." + libver$ + ".dylib"
                                             libname$ = "./" + libname$: inlinelibname$ = "./" + inlinelibname$
                                         END IF
                                     END IF
                                     IF LEN(libname$) = 0 THEN
-                                        IF _FILEEXISTS("lib" + x$ + ".dylib") THEN
+                                        IF _FILEEXISTS("lib" + x$ + ".dylib") OR _FILEEXISTS(FixDirectoryName(path.source$) + "lib" + x$ + ".dylib") OR _FILEEXISTS(FixDirectoryName(idepath$) + "lib" + x$ + ".dylib") THEN
                                             libname$ = "lib" + x$ + ".dylib"
                                             inlinelibname$ = "lib" + x$ + ".dylib"
                                             libname$ = "./" + libname$: inlinelibname$ = "./" + inlinelibname$
@@ -4720,14 +4720,14 @@ DO
 
                                 'check for .so (direct)
                                 IF LEN(libname$) = 0 THEN
-                                    IF _FILEEXISTS("lib" + x$ + ".so." + libver$) THEN
+                                    IF _FILEEXISTS("lib" + x$ + ".so." + libver$) OR _FILEEXISTS(FixDirectoryName(path.source$) + "lib" + x$ + ".so." + libver$) OR _FILEEXISTS(FixDirectoryName(idepath$) + "lib" + x$ + ".so." + libver$) THEN
                                         libname$ = "lib" + x$ + ".so." + libver$
                                         inlinelibname$ = "lib" + x$ + ".so." + libver$
                                         libname$ = "./" + libname$: inlinelibname$ = "./" + inlinelibname$
                                     END IF
                                 END IF
                                 IF LEN(libname$) = 0 THEN
-                                    IF _FILEEXISTS("lib" + x$ + ".so") THEN
+                                    IF _FILEEXISTS("lib" + x$ + ".so") OR _FILEEXISTS(FixDirectoryName(path.source$) + "lib" + x$ + ".so") OR _FILEEXISTS(FixDirectoryName(idepath$) + "lib" + x$ + ".so") THEN
                                         libname$ = "lib" + x$ + ".so"
                                         inlinelibname$ = "lib" + x$ + ".so"
                                         libname$ = "./" + libname$: inlinelibname$ = "./" + inlinelibname$


### PR DESCRIPTION
This PR fixes `DECLARE DYNAMIC LIBRARY` to load shared libraries from the source path when `Output EXE to Source Path` is enabled.

Currently, when `Output EXE to Source Path` is checked and something like the following is used, it expects the shared library to be present next to the `qb64pe` executable.
```vb
DECLARE DYNAMIC LIBRARY "foo"
``` 

Prefixing a `./` to the library name does not help either because then it simply replaces the `./` with an absolute path.

To work around this, we simply do a few more checks to satisfy the `direct without path` condition and allow the user to place the shared library where their source file is located.