### PR TITLE
Bump minimum C++ version in Makefile to 14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ all: $(EXE)
 CLEAN_LIST :=
 CLEAN_DEP_LIST :=
 
-CXXFLAGS += -w -std=gnu++11
+CXXFLAGS += -w -std=gnu++14
 
 ifeq ($(OS),lnx)
 	CXXLIBS += -lGL -lGLU -lX11 -lpthread -ldl -lrt


### PR DESCRIPTION
This PR changes the previous `-std=gnu++11` in the Makefile to `-std=gnu++14`.

As such, this change allows code the uses the relaxed rules for constexpr functions to compile correctly without generating the error: `body of 'constexpr' function not a return-statement`.