### PR TITLE
Fix menu item `Run #Only (No EXE)`

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -5928,7 +5928,7 @@ FUNCTION ide2 (ignore)
                 GOTO idemrun
             END IF
 
-            IF menu$(m, s) = "Run only (No exe)" THEN
+            IF menu$(m, s) = "Run #Only (No EXE)" THEN
                 PCOPY 3, 0: SCREEN , , 3, 0
                 NoExeSaved = -1
                 startPaused = 0


### PR DESCRIPTION
This fixes the error `MENU ITEM [Run #Only (No EXE) NOT IMPLEMENTED!` that occurs because the string below https://github.com/QB64-Phoenix-Edition/QB64pe/blob/82ecfc09c783f4647251b25e0dd0553415402632/source/ide/ide_methods.bas#L5931
does not match with

https://github.com/QB64-Phoenix-Edition/QB64pe/blob/82ecfc09c783f4647251b25e0dd0553415402632/source/ide/ide_methods.bas#L336

I changed the menu string in an earlier PR not knowing that we compare the string later to see if the menu was clicked.
We should seriously consider consolidating and moving these strings to `CONST`s or `DATA` to avoid these issues in the future.

This issue was reported here: https://qb64phoenix.com/forum/showthread.php?tid=2063&pid=20329#pid20329