### PR TITLE
Avoid miniaudio runtime linking on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ ifneq ($(filter y,$(DEP_AUDIO_MINIAUDIO)),)
 		CXXLIBS += -lwinmm -lksguid -ldxguid -lole32
 	endif
 	ifeq ($(OS),osx)
-		CXXLIBS += -framework CoreFoundation -framework CoreAudio -framework CoreMIDI -framework AudioUnit -framework AudioToolbox
+		CXXLIBS += -lpthread -lm -framework CoreFoundation -framework CoreAudio -framework CoreMIDI -framework AudioUnit -framework AudioToolbox
 	endif
 	QBLIB_NAME := $(addsuffix 1,$(QBLIB_NAME))
 

--- a/internal/c/parts/audio/miniaudio_impl.cpp
+++ b/internal/c/parts/audio/miniaudio_impl.cpp
@@ -12,6 +12,11 @@
 // Enable Ogg Vorbis decoding
 #define STB_VORBIS_HEADER_ONLY
 #include "extras/stb_vorbis.c"
+// Due to the way miniaudio links to macOS frameworks at runtime, the application may not pass Apple's notarization process :(
+// So, we will avoid runtime linking on macOS. See this discussion for more info: https://github.com/mackron/miniaudio/issues/203
+#ifdef __APPLE__
+#    define MA_NO_RUNTIME_LINKING
+#endif
 // The main miniaudio header
 #define MINIAUDIO_IMPLEMENTATION
 #include "miniaudio.h"


### PR DESCRIPTION
Due to Apple's stricter notarization process on `Ventura` & `Sonoma`, `miniaudio` is not able to link to relevant frameworks at runtime. This causes it to fallback to the `null-audio` backend and eventually not play any audio.

To workaround this issue, we bypass runtime linking on macOS.

See the macOS build section here: https://miniaud.io/docs/manual/index.html#Building

This issue was reported here: https://qb64phoenix.com/forum/showthread.php?tid=2016