### PR TITLE
Change IDE save method as discussed on Discord

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -12463,9 +12463,9 @@ SUB idesave (f$)
     ideerror = 1
     IF INSTR(_OS$, "WIN") THEN LineEnding$ = CHR$(13) + CHR$(10) ELSE LineEnding$ = CHR$(10)
     FOR i = 1 TO iden
-        outfile$ = outfile$ + idegetline(i)  + LineEnding$
+        outfile$ =  idegetline(i)  + LineEnding$
+        PUT #151, , outfile$
     NEXT
-    PUT #151, 1, outfile$
     CLOSE #151
     IdeSaveBookmarks f$
     ideunsaved = 0


### PR DESCRIPTION
String manipulation has too much overhead for larger files to write all at once.   The best write speeds, from multiple testing experiments in various conditions, come from simply using PUT to place the data line by line to the drive.

This change reflects that method of file saving.