### PR TITLE
Add a short delay after killing pulseaudio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,6 +176,7 @@ endif
 	DEP_ICON_RC := y
 	DEP_SOCKETS := y
 	DEP_HTTP := y
+	DEP_CONSOLE := y
 endif
 
 include $(PATH_INTERNAL_C)/libqb/build.mk

--- a/tests/compile_tests.sh
+++ b/tests/compile_tests.sh
@@ -141,6 +141,7 @@ do
         if [ "$CI_TESTING" == "y" ] && command -v pulseaudio > /dev/null
         then
             pulseaudio -k
+            sleep .5
             pulseaudio -D
         fi
     else


### PR DESCRIPTION
It seems to sometimes not be dead when we go to start it, presumably the `pulseaudio -k` doesn't actually wait for the process to exit.