### PR TITLE
clean up CONST somewhat.  Fix const names being used in other consts.

### DIFF
--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -24509,6 +24509,7 @@ SUB Set_OrderOfOperations
     'I used a range here so I could add in new priority levels as needed.
     'OName ended up becoming the name of our commands, as I modified things.... Go figure!  LOL!
     REDIM OName(10000) AS STRING, PL(10000) AS INTEGER
+    SHARED Skip_NoPrefix_Low AS INTEGER, Skip_NoPrefix_Max AS INTEGER 'to skip the no_prefixed functions
     'Constants get evaluated first, with a Priority Level of 1
 
     i = i + 1: OName(i) = "C_UOF": PL(i) = 5 'convert to unsigned offset
@@ -24572,6 +24573,34 @@ SUB Set_OrderOfOperations
     i = i + 1: OName(i) = "_BLUE": PL(i) = 10
     i = i + 1: OName(i) = "_ALPHA": PL(i) = 10
 
+    Skip_NoPrefix_Low = i + 1
+    i = i + 1:: OName(i) = "PI": PL(i) = 10
+    i = i + 1: OName(i) = "ACOS": PL(i) = 10
+    i = i + 1: OName(i) = "ASIN": PL(i) = 10
+    i = i + 1: OName(i) = "ARCSEC": PL(i) = 10
+    i = i + 1: OName(i) = "ARCCSC": PL(i) = 10
+    i = i + 1: OName(i) = "ARCCOT": PL(i) = 10
+    i = i + 1: OName(i) = "SECH": PL(i) = 10
+    i = i + 1: OName(i) = "CSCH": PL(i) = 10
+    i = i + 1: OName(i) = "COTH": PL(i) = 10
+    i = i + 1: OName(i) = "D2R": PL(i) = 10
+    i = i + 1: OName(i) = "D2G": PL(i) = 10
+    i = i + 1: OName(i) = "R2D": PL(i) = 10
+    i = i + 1: OName(i) = "R2G": PL(i) = 10
+    i = i + 1: OName(i) = "G2D": PL(i) = 10
+    i = i + 1: OName(i) = "G2R": PL(i) = 10
+    i = i + 1: OName(i) = "ROUND": PL(i) = 10
+    i = i + 1: OName(i) = "CEIL": PL(i) = 10
+    i = i + 1: OName(i) = "SEC": PL(i) = 10
+    i = i + 1: OName(i) = "CSC": PL(i) = 10
+    i = i + 1: OName(i) = "COT": PL(i) = 10
+    i = i + 1: OName(i) = "RGBA": PL(i) = 10
+    i = i + 1: OName(i) = "RGB": PL(i) = 10
+    i = i + 1: OName(i) = "RED": PL(i) = 10
+    i = i + 1: OName(i) = "GREEN": PL(i) = 10
+    i = i + 1: OName(i) = "BLUE": PL(i) = 10
+    i = i + 1: OName(i) = "ALPHA": PL(i) = 10
+    Skip_NoPrefix_Max = i
     'Exponents with PL 20
     i = i + 1: OName(i) = "^": PL(i) = 20
     i = i + 1: OName(i) = "SQR": PL(i) = 20
@@ -24607,6 +24636,39 @@ SUB Set_OrderOfOperations
     i = i + 1: OName(i) = ",": PL(i) = 1000
 
     REDIM _PRESERVE OName(i) AS STRING, PL(i) AS INTEGER
+
+
+
+    'init the suffix conversions once here and be done with them as well.
+    'and the below is a conversion list so symbols don't get cross confused.
+    REDIM _PRESERVE PP_TypeMod(27) AS STRING, PP_ConvertedMod(27) AS STRING
+    PP_TypeMod(1) = "~`": PP_ConvertedMod(1) = "C_UBI" 'unsigned bit
+    PP_TypeMod(2) = "~%%": PP_ConvertedMod(2) = "C_UBY" 'unsigned byte
+    PP_TypeMod(3) = "~%&": PP_ConvertedMod(3) = "C_UOF" 'unsigned offset
+    PP_TypeMod(4) = "~%": PP_ConvertedMod(4) = "C_UIN" 'unsigned integer
+    PP_TypeMod(5) = "~&&": PP_ConvertedMod(5) = "C_UIF" 'unsigned integer64
+    PP_TypeMod(6) = "~&": PP_ConvertedMod(6) = "C_ULO" 'unsigned long
+    PP_TypeMod(7) = "`": PP_ConvertedMod(7) = "C_BI" 'bit
+    PP_TypeMod(8) = "%%": PP_ConvertedMod(8) = "C_BY" 'byte
+    PP_TypeMod(9) = "%&": PP_ConvertedMod(9) = "C_OF" 'offset
+    PP_TypeMod(10) = "%": PP_ConvertedMod(10) = "C_IN" 'integer
+    PP_TypeMod(11) = "&&": PP_ConvertedMod(11) = "C_IF" 'integer64
+    PP_TypeMod(12) = "&": PP_ConvertedMod(12) = "C_LO" 'long
+    PP_TypeMod(13) = "!": PP_ConvertedMod(13) = "C_SI" 'single
+    PP_TypeMod(14) = "##": PP_ConvertedMod(14) = "C_FL" 'float
+    PP_TypeMod(15) = "#": PP_ConvertedMod(15) = "C_DO" 'double
+    PP_TypeMod(16) = "_RGB32": PP_ConvertedMod(16) = "C_RG" 'rgb32
+    PP_TypeMod(17) = "_RGBA32": PP_ConvertedMod(17) = "C_RA" 'rgba32
+    PP_TypeMod(18) = "_RED32": PP_ConvertedMod(18) = "C_RX" 'red32
+    PP_TypeMod(19) = "_GREEN32": PP_ConvertedMod(19) = "C_GR" 'green32
+    PP_TypeMod(20) = "_BLUE32": PP_ConvertedMod(20) = "C_BL" 'blue32
+    PP_TypeMod(21) = "_ALPHA32": PP_ConvertedMod(21) = "C_AL" 'alpha32
+    PP_TypeMod(22) = "RGB32": PP_ConvertedMod(22) = "C_RG" 'rgb32
+    PP_TypeMod(23) = "RGBA32": PP_ConvertedMod(23) = "C_RA" 'rgba32
+    PP_TypeMod(24) = "RED32": PP_ConvertedMod(24) = "C_RX" 'red32
+    PP_TypeMod(25) = "GREEN32": PP_ConvertedMod(25) = "C_GR" 'green32
+    PP_TypeMod(26) = "BLUE32": PP_ConvertedMod(26) = "C_BL" 'blue32
+    PP_TypeMod(27) = "ALPHA32": PP_ConvertedMod(27) = "C_AL" 'alpha32
 END SUB
 
 FUNCTION EvaluateNumbers$ (p, num() AS STRING)
@@ -24899,7 +24961,7 @@ FUNCTION DWD$ (exp$) 'Deal With Duplicates
 END FUNCTION
 
 SUB PreParse (e$)
-    STATIC TotalPrefixedPP_TypeMod AS LONG, TotalPP_TypeMod AS LONG
+    SHARED Skip_NoPrefix_Low AS INTEGER, Skip_NoPrefix_Max AS INTEGER
     t$ = e$ 'preserve the original string
 
     'replace existing CONST values
@@ -24937,49 +24999,12 @@ SUB PreParse (e$)
         NEXT
     NEXT
 
-
-    IF PP_TypeMod(0) = "" THEN
-        REDIM PP_TypeMod(100) AS STRING, PP_ConvertedMod(100) AS STRING 'Large enough to hold all values to begin with
-        PP_TypeMod(0) = "Initialized" 'Set so we don't do this section over and over, as we keep the values in shared memory.
-        'and the below is a conversion list so symbols don't get cross confused.
-        i = i + 1: PP_TypeMod(i) = "~`": PP_ConvertedMod(i) = "C_UBI" 'unsigned bit
-        i = i + 1: PP_TypeMod(i) = "~%%": PP_ConvertedMod(i) = "C_UBY" 'unsigned byte
-        i = i + 1: PP_TypeMod(i) = "~%&": PP_ConvertedMod(i) = "C_UOF" 'unsigned offset
-        i = i + 1: PP_TypeMod(i) = "~%": PP_ConvertedMod(i) = "C_UIN" 'unsigned integer
-        i = i + 1: PP_TypeMod(i) = "~&&": PP_ConvertedMod(i) = "C_UIF" 'unsigned integer64
-        i = i + 1: PP_TypeMod(i) = "~&": PP_ConvertedMod(i) = "C_ULO" 'unsigned long
-        i = i + 1: PP_TypeMod(i) = "`": PP_ConvertedMod(i) = "C_BI" 'bit
-        i = i + 1: PP_TypeMod(i) = "%%": PP_ConvertedMod(i) = "C_BY" 'byte
-        i = i + 1: PP_TypeMod(i) = "%&": PP_ConvertedMod(i) = "C_OF" 'offset
-        i = i + 1: PP_TypeMod(i) = "%": PP_ConvertedMod(i) = "C_IN" 'integer
-        i = i + 1: PP_TypeMod(i) = "&&": PP_ConvertedMod(i) = "C_IF" 'integer64
-        i = i + 1: PP_TypeMod(i) = "&": PP_ConvertedMod(i) = "C_LO" 'long
-        i = i + 1: PP_TypeMod(i) = "!": PP_ConvertedMod(i) = "C_SI" 'single
-        i = i + 1: PP_TypeMod(i) = "##": PP_ConvertedMod(i) = "C_FL" 'float
-        i = i + 1: PP_TypeMod(i) = "#": PP_ConvertedMod(i) = "C_DO" 'double
-        i = i + 1: PP_TypeMod(i) = "_RGB32": PP_ConvertedMod(i) = "C_RG" 'rgb32
-        i = i + 1: PP_TypeMod(i) = "_RGBA32": PP_ConvertedMod(i) = "C_RA" 'rgba32
-        i = i + 1: PP_TypeMod(i) = "_RED32": PP_ConvertedMod(i) = "C_RX" 'red32
-        i = i + 1: PP_TypeMod(i) = "_GREEN32": PP_ConvertedMod(i) = "C_GR" 'green32
-        i = i + 1: PP_TypeMod(i) = "_BLUE32": PP_ConvertedMod(i) = "C_BL" 'blue32
-        i = i + 1: PP_TypeMod(i) = "_ALPHA32": PP_ConvertedMod(i) = "C_AL" 'alpha32
-        TotalPrefixedPP_TypeMod = i
-        i = i + 1: PP_TypeMod(i) = "RGB32": PP_ConvertedMod(i) = "C_RG" 'rgb32
-        i = i + 1: PP_TypeMod(i) = "RGBA32": PP_ConvertedMod(i) = "C_RA" 'rgba32
-        i = i + 1: PP_TypeMod(i) = "RED32": PP_ConvertedMod(i) = "C_RX" 'red32
-        i = i + 1: PP_TypeMod(i) = "GREEN32": PP_ConvertedMod(i) = "C_GR" 'green32
-        i = i + 1: PP_TypeMod(i) = "BLUE32": PP_ConvertedMod(i) = "C_BL" 'blue32
-        i = i + 1: PP_TypeMod(i) = "ALPHA32": PP_ConvertedMod(i) = "C_AL" 'alpha32
-        TotalPP_TypeMod = i
-        REDIM _PRESERVE PP_TypeMod(i) AS STRING, PP_ConvertedMod(i) AS STRING 'And then resized to just contain the necessary space in memory
-    END IF
-    t$ = e$
-
     'First strip all spaces
-    t$ = ""
-    FOR i = 1 TO LEN(e$)
-        IF MID$(e$, i, 1) <> " " THEN t$ = t$ + MID$(e$, i, 1)
-    NEXT
+    l = 0
+    DO
+        l = INSTR(t$, " ")
+        IF l THEN t$ = LEFT$(t$, l - 1) + MID$(t$, l + 1)
+    LOOP UNTIL l = 0
 
     t$ = UCASE$(t$)
     IF t$ = "" THEN e$ = "ERROR -- NULL string; nothing to evaluate": EXIT SUB
@@ -25015,9 +25040,8 @@ SUB PreParse (e$)
         END IF
     LOOP UNTIL l = 0
 
-    uboundPP_TypeMod = TotalPrefixedPP_TypeMod
-    IF qb64prefix_set = 1 THEN uboundPP_TypeMod = TotalPP_TypeMod
-    FOR j = 1 TO uboundPP_TypeMod
+    FOR j = 1 TO UBOUND(PP_TypeMod)
+        IF qb64prefix_set = 0 AND j > 21 THEN EXIT FOR 'only check the no_prefix junk if necessary
         l = 0
         DO
             l = INSTR(l + 1, t$, PP_TypeMod(j))
@@ -25050,15 +25074,10 @@ SUB PreParse (e$)
         IF l > 0 AND l > 2 THEN 'Don't check the starting bracket; there's nothing before it.
             good = 0
             FOR i = 1 TO UBOUND(OName)
+                IF qb64prefix_set = 0 AND i >= Skip_NoPrefix_Low AND i <= Skip_NoPrefix_Max THEN EXIT FOR 'don't check the no_prefix junk if we don't have to.
                 m$ = MID$(t$, l - LEN(OName(i)), LEN(OName(i)))
                 IF m$ = OName(i) THEN
                     good = -1: EXIT FOR 'We found an operator after our ), and it's not a CONST (like PI)
-                ELSE
-                    IF LEFT$(OName(i), 1) = "_" AND qb64prefix_set = 1 THEN
-                        'try without prefix
-                        m$ = MID$(t$, l - (LEN(OName(i)) - 1), LEN(OName(i)) - 1)
-                        IF m$ = MID$(OName(i), 2) THEN good = -1: EXIT FOR
-                    END IF
                 END IF
             NEXT
             IF NOT good THEN e$ = "ERROR - Improper operations before (.": EXIT SUB
@@ -25073,15 +25092,10 @@ SUB PreParse (e$)
         IF l > 0 AND l < LEN(t$) THEN
             good = 0
             FOR i = 1 TO UBOUND(OName)
+                IF qb64prefix_set = 0 AND i >= Skip_NoPrefix_Low AND i <= Skip_NoPrefix_Max THEN EXIT FOR 'don't check the no_prefix junk if we don't have to.
                 m$ = MID$(t$, l + 1, LEN(OName(i)))
                 IF m$ = OName(i) THEN
                     good = -1: EXIT FOR 'We found an operator after our ), and it's not a CONST (like PI
-                ELSE
-                    IF LEFT$(OName(i), 1) = "_" AND qb64prefix_set = 1 THEN
-                        'try without prefix
-                        m$ = MID$(t$, l + 1, LEN(OName(i)) - 1)
-                        IF m$ = MID$(OName(i), 2) THEN good = -1: EXIT FOR
-                    END IF
                 END IF
             NEXT
             IF MID$(t$, l + 1, 1) = ")" THEN good = -1

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -24695,6 +24695,7 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
         END SELECT
     END IF
 
+
     SELECT CASE PL(p) 'divide up the work so we want do as much case checking
         CASE 5 'Type conversions
             'Note, these are special cases and work with the number BEFORE the command and not after
@@ -24720,21 +24721,21 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
             EXIT FUNCTION
         CASE 10 'functions
             SELECT CASE OName(p) 'Depending on our operator..
-                CASE "_PI"
+                CASE "_PI", "PI"
                     n1 = 3.14159265358979323846264338327950288## 'Future compatable in case something ever stores extra digits for PI
                     IF num(2) <> "" THEN n1 = n1 * VAL(num(2))
-                CASE "_ACOS": n1 = _ACOS(VAL(num(2)))
-                CASE "_ASIN": n1 = _ASIN(VAL(num(2)))
-                CASE "_ARCSEC"
+                CASE "_ACOS", "ACOS": n1 = _ACOS(VAL(num(2)))
+                CASE "_ASIN", "ASIN": n1 = _ASIN(VAL(num(2)))
+                CASE "_ARCSEC", "ARCSEC"
                     IF ABS(VAL(num(2))) < 1 THEN EvaluateNumbers$ = "ERROR - ABS(_ARCSEC) value < 1": EXIT FUNCTION
                     n1 = _ARCSEC(VAL(num(2)))
-                CASE "_ARCCSC"
+                CASE "_ARCCSC", "ARCCSC"
                     IF ABS(VAL(num(2))) < 1 THEN EvaluateNumbers$ = "ERROR - ABS(_ARCCSC) value < 1": EXIT FUNCTION
                     n1 = _ARCCSC(VAL(num(2)))
-                CASE "_ARCCOT": n1 = _ARCCOT(VAL(num(2)))
-                CASE "_SECH": n1 = _SECH(VAL(num(2)))
-                CASE "_CSCH": n1 = _CSCH(VAL(num(2)))
-                CASE "_COTH": n1 = _COTH(VAL(num(2)))
+                CASE "_ARCCOT", "ARCCOT": n1 = _ARCCOT(VAL(num(2)))
+                CASE "_SECH", "SECH": n1 = _SECH(VAL(num(2)))
+                CASE "_CSCH", "CSCH": n1 = _CSCH(VAL(num(2)))
+                CASE "_COTH", "COTH": n1 = _COTH(VAL(num(2)))
                 CASE "C_RG"
                     n$ = num(2)
                     IF n$ = "" THEN EvaluateNumbers$ = "ERROR - Invalid null _RGB32": EXIT FUNCTION
@@ -24777,7 +24778,7 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
                     n3 = VAL(MID$(num(2), c2 + 1))
                     n4 = VAL(MID$(num(2), c3 + 1))
                     n1 = _RGBA32(n, n2, n3, n4)
-                CASE "_RGB"
+                CASE "_RGB", "RGB"
                     n$ = num(2)
                     IF n$ = "" THEN EvaluateNumbers$ = "ERROR - Invalid null _RGB": EXIT FUNCTION
                     c1 = INSTR(n$, ",")
@@ -24798,7 +24799,7 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
                     t = _NEWIMAGE(1, 1, n4)
                     n1 = _RGB(n, n2, n3, t)
                     _FREEIMAGE t
-                CASE "_RGBA"
+                CASE "_RGBA", "RGBA"
                     n$ = num(2)
                     IF n$ = "" THEN EvaluateNumbers$ = "ERROR - Invalid null _RGBA": EXIT FUNCTION
                     c1 = INSTR(n$, ",")
@@ -24821,7 +24822,7 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
                     t = _NEWIMAGE(1, 1, n5)
                     n1 = _RGBA(n, n2, n3, n4, t)
                     _FREEIMAGE t
-                CASE "_RED", "_GREEN", "_BLUE", "_ALPHA"
+                CASE "_RED", "_GREEN", "_BLUE", "_ALPHA", "RED", "GREEN", "BLUE", "ALPHA"
                     n$ = num(2)
                     IF n$ = "" THEN EvaluateNumbers$ = "ERROR - Invalid null " + OName(p): EXIT FUNCTION
                     c1 = INSTR(n$, ",")
@@ -24837,10 +24838,10 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
                     END SELECT
                     t = _NEWIMAGE(1, 1, n4)
                     SELECT CASE OName(p)
-                        CASE "_RED": n1 = _RED(n, t)
-                        CASE "_BLUE": n1 = _BLUE(n, t)
-                        CASE "_GREEN": n1 = _GREEN(n, t)
-                        CASE "_ALPHA": n1 = _ALPHA(n, t)
+                        CASE "_RED", "RED": n1 = _RED(n, t)
+                        CASE "_BLUE", "BLUE": n1 = _BLUE(n, t)
+                        CASE "_GREEN", "GREEN": n1 = _GREEN(n, t)
+                        CASE "_ALPHA", "ALPHA": n1 = _ALPHA(n, t)
                     END SELECT
                     _FREEIMAGE t
                 CASE "C_RX", "C_GR", "C_BL", "C_AL"
@@ -24859,21 +24860,21 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
                 CASE "LOG": n1 = LOG(VAL(num(2)))
                 CASE "EXP": n1 = EXP(VAL(num(2)))
                 CASE "ATN": n1 = ATN(VAL(num(2)))
-                CASE "_D2R": n1 = 0.0174532925 * (VAL(num(2)))
-                CASE "_D2G": n1 = 1.1111111111 * (VAL(num(2)))
-                CASE "_R2D": n1 = 57.2957795 * (VAL(num(2)))
-                CASE "_R2G": n1 = 0.015707963 * (VAL(num(2)))
-                CASE "_G2D": n1 = 0.9 * (VAL(num(2)))
-                CASE "_G2R": n1 = 63.661977237 * (VAL(num(2)))
+                CASE "_D2R", "D2R": n1 = 0.0174532925 * (VAL(num(2)))
+                CASE "_D2G", "D2G": n1 = 1.1111111111 * (VAL(num(2)))
+                CASE "_R2D", "R2D": n1 = 57.2957795 * (VAL(num(2)))
+                CASE "_R2G", "R2G": n1 = 0.015707963 * (VAL(num(2)))
+                CASE "_G2D", "G2D": n1 = 0.9 * (VAL(num(2)))
+                CASE "_G2R", "G2R": n1 = 63.661977237 * (VAL(num(2)))
                 CASE "ABS": n1 = ABS(VAL(num(2)))
                 CASE "SGN": n1 = SGN(VAL(num(2)))
                 CASE "INT": n1 = INT(VAL(num(2)))
-                CASE "_ROUND": n1 = _ROUND(VAL(num(2)))
-                CASE "_CEIL": n1 = _CEIL(VAL(num(2)))
+                CASE "_ROUND", "ROUND": n1 = _ROUND(VAL(num(2)))
+                CASE "_CEIL", "CEIL": n1 = _CEIL(VAL(num(2)))
                 CASE "FIX": n1 = FIX(VAL(num(2)))
-                CASE "_SEC": n1 = _SEC(VAL(num(2)))
-                CASE "_CSC": n1 = _CSC(VAL(num(2)))
-                CASE "_COT": n1 = _COT(VAL(num(2)))
+                CASE "_SEC", "SEC": n1 = _SEC(VAL(num(2)))
+                CASE "_CSC", "CSC": n1 = _CSC(VAL(num(2)))
+                CASE "_COT", "COT": n1 = _COT(VAL(num(2)))
             END SELECT
         CASE 20 TO 60 'Math Operators
             SELECT CASE OName(p) 'Depending on our operator..

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -24985,7 +24985,7 @@ SUB PreParse (e$)
                     t$ = LEFT$(t$, found - 1) + _TRIM$(r$) + MID$(t$, found + LEN(thisConstName$))
                 END IF
             LOOP UNTIL found = 0
-            thisConstName$ = LEFT$(constname(i2), LEN(constname(i2)) - LEN(constnamesymbol(i2)))
+            thisConstName$ = constname(i2) 'name without the symbol on the 2nd pass
         NEXT
     NEXT
 

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -24510,7 +24510,6 @@ SUB Set_OrderOfOperations
     'I used a range here so I could add in new priority levels as needed.
     'OName ended up becoming the name of our commands, as I modified things.... Go figure!  LOL!
     REDIM OName(10000) AS STRING, PL(10000) AS INTEGER
-    SHARED Skip_NoPrefix_Low AS INTEGER, Skip_NoPrefix_Max AS INTEGER 'to skip the no_prefixed functions
     SHARED PP_TypeMod_NoPrefix_Limit AS INTEGER
     'Constants get evaluated first, with a Priority Level of 1
 
@@ -24575,34 +24574,6 @@ SUB Set_OrderOfOperations
     i = i + 1: OName(i) = "_BLUE": PL(i) = 10
     i = i + 1: OName(i) = "_ALPHA": PL(i) = 10
 
-    Skip_NoPrefix_Low = i + 1
-    i = i + 1:: OName(i) = "PI": PL(i) = 10
-    i = i + 1: OName(i) = "ACOS": PL(i) = 10
-    i = i + 1: OName(i) = "ASIN": PL(i) = 10
-    i = i + 1: OName(i) = "ARCSEC": PL(i) = 10
-    i = i + 1: OName(i) = "ARCCSC": PL(i) = 10
-    i = i + 1: OName(i) = "ARCCOT": PL(i) = 10
-    i = i + 1: OName(i) = "SECH": PL(i) = 10
-    i = i + 1: OName(i) = "CSCH": PL(i) = 10
-    i = i + 1: OName(i) = "COTH": PL(i) = 10
-    i = i + 1: OName(i) = "D2R": PL(i) = 10
-    i = i + 1: OName(i) = "D2G": PL(i) = 10
-    i = i + 1: OName(i) = "R2D": PL(i) = 10
-    i = i + 1: OName(i) = "R2G": PL(i) = 10
-    i = i + 1: OName(i) = "G2D": PL(i) = 10
-    i = i + 1: OName(i) = "G2R": PL(i) = 10
-    i = i + 1: OName(i) = "ROUND": PL(i) = 10
-    i = i + 1: OName(i) = "CEIL": PL(i) = 10
-    i = i + 1: OName(i) = "SEC": PL(i) = 10
-    i = i + 1: OName(i) = "CSC": PL(i) = 10
-    i = i + 1: OName(i) = "COT": PL(i) = 10
-    i = i + 1: OName(i) = "RGBA": PL(i) = 10
-    i = i + 1: OName(i) = "RGB": PL(i) = 10
-    i = i + 1: OName(i) = "RED": PL(i) = 10
-    i = i + 1: OName(i) = "GREEN": PL(i) = 10
-    i = i + 1: OName(i) = "BLUE": PL(i) = 10
-    i = i + 1: OName(i) = "ALPHA": PL(i) = 10
-    Skip_NoPrefix_Max = i
     'Exponents with PL 20
     i = i + 1: OName(i) = "^": PL(i) = 20
     i = i + 1: OName(i) = "SQR": PL(i) = 20
@@ -24725,21 +24696,21 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
             EXIT FUNCTION
         CASE 10 'functions
             SELECT CASE OName(p) 'Depending on our operator..
-                CASE "_PI", "PI"
+                CASE "_PI"
                     n1 = 3.14159265358979323846264338327950288## 'Future compatable in case something ever stores extra digits for PI
                     IF num(2) <> "" THEN n1 = n1 * VAL(num(2))
-                CASE "_ACOS", "ACOS": n1 = _ACOS(VAL(num(2)))
-                CASE "_ASIN", "ASIN": n1 = _ASIN(VAL(num(2)))
-                CASE "_ARCSEC", "ARCSEC"
+                CASE "_ACOS": n1 = _ACOS(VAL(num(2)))
+                CASE "_ASIN": n1 = _ASIN(VAL(num(2)))
+                CASE "_ARCSEC"
                     IF ABS(VAL(num(2))) < 1 THEN EvaluateNumbers$ = "ERROR - ABS(_ARCSEC) value < 1": EXIT FUNCTION
                     n1 = _ARCSEC(VAL(num(2)))
-                CASE "_ARCCSC", "ARCCSC"
+                CASE "_ARCCSC"
                     IF ABS(VAL(num(2))) < 1 THEN EvaluateNumbers$ = "ERROR - ABS(_ARCCSC) value < 1": EXIT FUNCTION
                     n1 = _ARCCSC(VAL(num(2)))
-                CASE "_ARCCOT", "ARCCOT": n1 = _ARCCOT(VAL(num(2)))
-                CASE "_SECH", "SECH": n1 = _SECH(VAL(num(2)))
-                CASE "_CSCH", "CSCH": n1 = _CSCH(VAL(num(2)))
-                CASE "_COTH", "COTH": n1 = _COTH(VAL(num(2)))
+                CASE "_ARCCOT": n1 = _ARCCOT(VAL(num(2)))
+                CASE "_SECH": n1 = _SECH(VAL(num(2)))
+                CASE "_CSCH": n1 = _CSCH(VAL(num(2)))
+                CASE "_COTH": n1 = _COTH(VAL(num(2)))
                 CASE "C_RG"
                     n$ = num(2)
                     IF n$ = "" THEN EvaluateNumbers$ = "ERROR - Invalid null _RGB32": EXIT FUNCTION
@@ -24782,7 +24753,7 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
                     n3 = VAL(MID$(num(2), c2 + 1))
                     n4 = VAL(MID$(num(2), c3 + 1))
                     n1 = _RGBA32(n, n2, n3, n4)
-                CASE "_RGB", "RGB"
+                CASE "_RGB"
                     n$ = num(2)
                     IF n$ = "" THEN EvaluateNumbers$ = "ERROR - Invalid null _RGB": EXIT FUNCTION
                     c1 = INSTR(n$, ",")
@@ -24803,7 +24774,7 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
                     t = _NEWIMAGE(1, 1, n4)
                     n1 = _RGB(n, n2, n3, t)
                     _FREEIMAGE t
-                CASE "_RGBA", "RGBA"
+                CASE "_RGBA"
                     n$ = num(2)
                     IF n$ = "" THEN EvaluateNumbers$ = "ERROR - Invalid null _RGBA": EXIT FUNCTION
                     c1 = INSTR(n$, ",")
@@ -24826,7 +24797,7 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
                     t = _NEWIMAGE(1, 1, n5)
                     n1 = _RGBA(n, n2, n3, n4, t)
                     _FREEIMAGE t
-                CASE "_RED", "_GREEN", "_BLUE", "_ALPHA", "RED", "GREEN", "BLUE", "ALPHA"
+                CASE "_RED", "_GREEN", "_BLUE", "_ALPHA"
                     n$ = num(2)
                     IF n$ = "" THEN EvaluateNumbers$ = "ERROR - Invalid null " + OName(p): EXIT FUNCTION
                     c1 = INSTR(n$, ",")
@@ -24842,10 +24813,10 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
                     END SELECT
                     t = _NEWIMAGE(1, 1, n4)
                     SELECT CASE OName(p)
-                        CASE "_RED", "RED": n1 = _RED(n, t)
-                        CASE "_BLUE", "BLUE": n1 = _BLUE(n, t)
-                        CASE "_GREEN", "GREEN": n1 = _GREEN(n, t)
-                        CASE "_ALPHA", "ALPHA": n1 = _ALPHA(n, t)
+                        CASE "_RED": n1 = _RED(n, t)
+                        CASE "_BLUE": n1 = _BLUE(n, t)
+                        CASE "_GREEN": n1 = _GREEN(n, t)
+                        CASE "_ALPHA": n1 = _ALPHA(n, t)
                     END SELECT
                     _FREEIMAGE t
                 CASE "C_RX", "C_GR", "C_BL", "C_AL"
@@ -24864,21 +24835,21 @@ FUNCTION EvaluateNumbers$ (p, num() AS STRING)
                 CASE "LOG": n1 = LOG(VAL(num(2)))
                 CASE "EXP": n1 = EXP(VAL(num(2)))
                 CASE "ATN": n1 = ATN(VAL(num(2)))
-                CASE "_D2R", "D2R": n1 = 0.0174532925 * (VAL(num(2)))
-                CASE "_D2G", "D2G": n1 = 1.1111111111 * (VAL(num(2)))
-                CASE "_R2D", "R2D": n1 = 57.2957795 * (VAL(num(2)))
-                CASE "_R2G", "R2G": n1 = 0.015707963 * (VAL(num(2)))
-                CASE "_G2D", "G2D": n1 = 0.9 * (VAL(num(2)))
-                CASE "_G2R", "G2R": n1 = 63.661977237 * (VAL(num(2)))
+                CASE "_D2R": n1 = 0.0174532925 * (VAL(num(2)))
+                CASE "_D2G": n1 = 1.1111111111 * (VAL(num(2)))
+                CASE "_R2D": n1 = 57.2957795 * (VAL(num(2)))
+                CASE "_R2G": n1 = 0.015707963 * (VAL(num(2)))
+                CASE "_G2D": n1 = 0.9 * (VAL(num(2)))
+                CASE "_G2R": n1 = 63.661977237 * (VAL(num(2)))
                 CASE "ABS": n1 = ABS(VAL(num(2)))
                 CASE "SGN": n1 = SGN(VAL(num(2)))
                 CASE "INT": n1 = INT(VAL(num(2)))
-                CASE "_ROUND", "ROUND": n1 = _ROUND(VAL(num(2)))
-                CASE "_CEIL", "CEIL": n1 = _CEIL(VAL(num(2)))
+                CASE "_ROUND": n1 = _ROUND(VAL(num(2)))
+                CASE "_CEIL": n1 = _CEIL(VAL(num(2)))
                 CASE "FIX": n1 = FIX(VAL(num(2)))
-                CASE "_SEC", "SEC": n1 = _SEC(VAL(num(2)))
-                CASE "_CSC", "CSC": n1 = _CSC(VAL(num(2)))
-                CASE "_COT", "COT": n1 = _COT(VAL(num(2)))
+                CASE "_SEC": n1 = _SEC(VAL(num(2)))
+                CASE "_CSC": n1 = _CSC(VAL(num(2)))
+                CASE "_COT": n1 = _COT(VAL(num(2)))
             END SELECT
         CASE 20 TO 60 'Math Operators
             SELECT CASE OName(p) 'Depending on our operator..
@@ -24968,29 +24939,35 @@ FUNCTION DWD$ (exp$) 'Deal With Duplicates
 END FUNCTION
 
 SUB PreParse (e$)
-    SHARED Skip_NoPrefix_Low AS INTEGER, Skip_NoPrefix_Max AS INTEGER
-    t$ = e$ 'preserve the original string
+    SHARED PP_TypeMod_NoPrefix_Limit AS INTEGER
+    t$ = UCASE$(e$) 'preserve the original string
 
     'replace existing CONST values
+    sep$ = "()+-*/\><=^"
     FOR i2 = 0 TO constlast
-        thisConstName$ = constname(i2) + constnamesymbol(i2)
+        thisConstName$ = constname(i2)
         FOR replaceConstPass = 1 TO 2
             found = 0
             DO
-                found = INSTR(found + 1, UCASE$(t$), thisConstName$)
+                found = INSTR(found + 1, t$, thisConstName$)
                 IF found THEN
+                    IF found > 1 THEN
+                        IF INSTR(sep$, MID$(t$, found - 1, 1)) = 0 THEN _CONTINUE
+                    END IF
+                    IF found + LEN(thisConstName$) <= LEN(t$) THEN
+                        IF INSTR(sep$, MID$(t$, found + LEN(thisConstName$), 1)) = 0 THEN _CONTINUE
+                    END IF
                     t = consttype(i2)
                     IF t AND ISSTRING THEN e$ = "ERROR -- Can not evaluate STRING constants in the math evaluator": EXIT SUB
                     IF t AND ISFLOAT THEN
-                        r$ = STR$(constfloat(i2))
-                        r$ = N2S(r$)
+                        r$ = N2S(STR$(constfloat(i2)))
                     ELSE
                         IF t AND ISUNSIGNED THEN r$ = STR$(constuinteger(i2)) ELSE r$ = STR$(constinteger(i2))
                     END IF
                     t$ = LEFT$(t$, found - 1) + _TRIM$(r$) + MID$(t$, found + LEN(thisConstName$))
                 END IF
             LOOP UNTIL found = 0
-            thisConstName$ = constname(i2) 'name without the symbol on the 2nd pass
+            thisConstName$ = constname(i2) + constnamesymbol(i2)
         NEXT
     NEXT
 
@@ -25001,7 +24978,6 @@ SUB PreParse (e$)
         IF l THEN t$ = LEFT$(t$, l - 1) + MID$(t$, l + 1)
     LOOP UNTIL l = 0
 
-    t$ = UCASE$(t$)
     IF t$ = "" THEN e$ = "ERROR -- NULL string; nothing to evaluate": EXIT SUB
 
     'ERROR CHECK by counting our brackets
@@ -25069,10 +25045,15 @@ SUB PreParse (e$)
         IF l > 0 AND l > 2 THEN 'Don't check the starting bracket; there's nothing before it.
             good = 0
             FOR i = 1 TO UBOUND(OName)
-                IF qb64prefix_set = 0 AND i >= Skip_NoPrefix_Low AND i <= Skip_NoPrefix_Max THEN _CONTINUE 'don't check the no_prefix junk if we don't have to.
                 m$ = MID$(t$, l - LEN(OName(i)), LEN(OName(i)))
                 IF m$ = OName(i) THEN
-                    good = -1: EXIT FOR 'We found an operator after our )
+                    good = -1: EXIT FOR 'We found an operator after our ), and it's not a CONST (like PI)
+                ELSE
+                    IF LEFT$(OName(i), 1) = "_" AND qb64prefix_set = 1 THEN
+                        'try without prefix
+                        m$ = MID$(t$, l - (LEN(OName(i)) - 1), LEN(OName(i)) - 1)
+                        IF m$ = MID$(OName(i), 2) THEN good = -1: EXIT FOR
+                    END IF
                 END IF
             NEXT
             IF NOT good THEN e$ = "ERROR - Improper operations before (.": EXIT SUB
@@ -25087,10 +25068,15 @@ SUB PreParse (e$)
         IF l > 0 AND l < LEN(t$) THEN
             good = 0
             FOR i = 1 TO UBOUND(OName)
-                IF qb64prefix_set = 0 AND i >= Skip_NoPrefix_Low AND i <= Skip_NoPrefix_Max THEN _CONTINUE 'don't check the no_prefix junk if we don't have to.
                 m$ = MID$(t$, l + 1, LEN(OName(i)))
                 IF m$ = OName(i) THEN
                     good = -1: EXIT FOR 'We found an operator after our ), and it's not a CONST (like PI
+                ELSE
+                    IF LEFT$(OName(i), 1) = "_" AND qb64prefix_set = 1 THEN
+                        'try without prefix
+                        m$ = MID$(t$, l + 1, LEN(OName(i)) - 1)
+                        IF m$ = MID$(OName(i), 2) THEN good = -1: EXIT FOR
+                    END IF
                 END IF
             NEXT
             IF MID$(t$, l + 1, 1) = ")" THEN good = -1

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -24511,6 +24511,7 @@ SUB Set_OrderOfOperations
     'OName ended up becoming the name of our commands, as I modified things.... Go figure!  LOL!
     REDIM OName(10000) AS STRING, PL(10000) AS INTEGER
     SHARED Skip_NoPrefix_Low AS INTEGER, Skip_NoPrefix_Max AS INTEGER 'to skip the no_prefixed functions
+    SHARED PP_TypeMod_NoPrefix_Limit AS INTEGER
     'Constants get evaluated first, with a Priority Level of 1
 
     i = i + 1: OName(i) = "C_UOF": PL(i) = 5 'convert to unsigned offset
@@ -24664,6 +24665,9 @@ SUB Set_OrderOfOperations
     PP_TypeMod(19) = "_GREEN32": PP_ConvertedMod(19) = "C_GR" 'green32
     PP_TypeMod(20) = "_BLUE32": PP_ConvertedMod(20) = "C_BL" 'blue32
     PP_TypeMod(21) = "_ALPHA32": PP_ConvertedMod(21) = "C_AL" 'alpha32
+
+    PP_TypeMod_NoPrefix_Limit = 21 'Update this value if more underscore values are ever added before this point
+
     PP_TypeMod(22) = "RGB32": PP_ConvertedMod(22) = "C_RG" 'rgb32
     PP_TypeMod(23) = "RGBA32": PP_ConvertedMod(23) = "C_RA" 'rgba32
     PP_TypeMod(24) = "RED32": PP_ConvertedMod(24) = "C_RX" 'red32
@@ -25031,8 +25035,8 @@ SUB PreParse (e$)
         END IF
     LOOP UNTIL l = 0
 
-    FOR j = 1 TO UBOUND(PP_TypeMod)
-        IF qb64prefix_set = 0 AND j > 21 THEN EXIT FOR 'only check the no_prefix junk if necessary
+    IF qb64prefix_set THEN j_limit = UBOUND(PP_TypeMod) ELSE j_limit = PP_TypeMod_NoPrefix_Limit
+    FOR j = 1 TO j_limit
         l = 0
         DO
             l = INSTR(l + 1, t$, PP_TypeMod(j))


### PR DESCRIPTION
Believe it or not, CONST is still broke...  /sigh

I have no idea how nobody has complained yet, but currently CONST is not allowing us to use constants in our constants.

CONST foo = 1
CONST foo2 = foo + foo

The above for example.  ^^

Sure, we look up the const.  Sure we substitute it properly.  Sure, we do all we should do with it...

..and then we overwrite it and replace it back with our original string which we started with!   

[hr]

This should fix that.

This should also clean up some of the program flow and code logic to enable the no_prefix stuff to be easier to follow in the code, without backtracking and looping and using multiple loop values and everything that it's doing now.