### PR TITLE
Fix FILES to work for cases where fileSpec$ does not contain a directory

### DIFF
--- a/internal/c/libqb/src/filesystem.cpp
+++ b/internal/c/libqb/src/filesystem.cpp
@@ -792,6 +792,9 @@ void sub_files(qbs *str, int32_t passed) {
         } else {
             std::string d;
             filepath_split(fileSpec, d, pathName);
+            if (d.empty())
+                d = "./"; // default to the current directory if one is not specified
+
             directory = FS_GetFQN(d.c_str());
         }
     } else {


### PR DESCRIPTION
This PR fixes `FILES` to work for cases where `fileSpec$` does not contain a directory.

For example, the following will now correctly assume the current directory.

```vb
FILES "*.bas"
```

This was reported here: https://qb64phoenix.com/forum/showthread.php?tid=2401