### PR TITLE
Fix Math Evaluator

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -5511,15 +5511,20 @@ FUNCTION ide2 (ignore)
                     IF LEN(retval$) THEN
                         Dim num As ParseNum
                         mathEvalExpr$ = retval$
+
+                        retval$ = lineformat(retval$)
+                        Error_Happened = 0
+
                         ev0$ = Evaluate_Expression$(retval$, num)
                         ev$ = ev0$
+
                         mathEvalError%% = INSTR(ev$, "ERROR") > 0
-                        IF mathEvalError%% = 0 AND mathEvalHEX%% THEN ev$ = "&H" + HEX$(VAL(ev$))
+                        IF mathEvalError%% = 0 AND mathEvalHEX%% THEN ev$ = "&H" + HEX$(num.ui)
                         DO
                             b1$ = "#Insert;"
                             IF mathEvalHEX%% THEN b2$ = "#Decimal;" ELSE b2$ = "#HEX$;"
                             IF mathEvalError%% = 0 AND mathEvalComment%% THEN
-                                mathMsg$ = ev$ + " '" + retval$
+                                mathMsg$ = ev$ + " '" + mathEvalExpr$
                                 b3$ = "#Uncomment;"
                             ELSE
                                 mathMsg$ = ev$
@@ -5534,7 +5539,7 @@ FUNCTION ide2 (ignore)
                                         EXIT DO
                                     CASE 2
                                         mathEvalHEX%% = NOT mathEvalHEX%%
-                                        IF mathEvalHEX%% THEN ev$ = "&H" + HEX$(VAL(ev$)) ELSE ev$ = ev0$
+                                        IF mathEvalHEX%% THEN ev$ = "&H" + HEX$(num.ui) ELSE ev$ = ev0$
                                     CASE 3
                                         mathEvalComment%% = NOT mathEvalComment%%
                                 END SELECT

--- a/source/utilities/const_eval.bas
+++ b/source/utilities/const_eval.bas
@@ -590,11 +590,11 @@ FUNCTION Factor&(exp$, state AS ParserState)
             IF Unary&(exp$, state) = 0 THEN FixupErrorMessage state, "*": EXIT FUNCTION
 
             IF (num.typ AND ISFLOAT) OR (state.num.typ AND ISFLOAT) THEN
-                num.f = num.f * state.num.f
-                num.i = num.f
+                ParseNumSetF num, FLOATTYPE - ISPOINTER, num.f * state.num.f
+            ELSEIF (num.typ AND ISUNSIGNED) OR (state.num.typ AND ISUNSIGNED) THEN
+                ParseNumSetUI num, UINTEGER64TYPE - ISPOINTER, num.ui * state.num.ui
             ELSE
-                num.i = num.i * state.num.i
-                num.f = num.i
+                ParseNumSetI num, INTEGER64TYPE - ISPOINTER, num.i * state.num.i
             END IF
         ELSEIF ele$ = "/" THEN
             ele$ = getnextelement$(exp$, state.index, state.strIndex)

--- a/tests/compile_tests/const/expression.bas
+++ b/tests/compile_tests/const/expression.bas
@@ -45,6 +45,8 @@ CONST const__str2 = "foobar" + "foobar2"
 CONST const__str3 = const__str + const__str2
 CONST const__str4 = (const__str + (const__str2))
 
+CONST const__unsignedint = 2~&& * 5~&&
+
 PRINT const__OR
 PRINT const__AND
 PRINT const__NOT
@@ -86,5 +88,7 @@ PRINT const__str
 PRINT const__str2
 PRINT const__str3
 PRINT const__str4
+
+PRINT const__unsignedint
 
 SYSTEM

--- a/tests/compile_tests/const/expression.output
+++ b/tests/compile_tests/const/expression.output
@@ -33,3 +33,4 @@ foobar
 foobarfoobar2
 foobarfoobarfoobar2
 foobarfoobarfoobar2
+ 10 


### PR DESCRIPTION
The math evaluator was not running the input through lineformat before
evaluation, resulting in Evaluate_Expression$() giving the wrong result
since the input wasn't tokenized.

I also addressed a bug when doing multiplication with unsigned values.