### PR TITLE
Fix divide in CONST

### DIFF
--- a/source/utilities/const_eval.bas
+++ b/source/utilities/const_eval.bas
@@ -600,13 +600,8 @@ FUNCTION Factor&(exp$, state AS ParserState)
             ele$ = getnextelement$(exp$, state.index, state.strIndex)
             IF Unary&(exp$, state) = 0 THEN FixupErrorMessage state, "/": EXIT FUNCTION
 
-            IF (num.typ AND ISFLOAT) OR (state.num.typ AND ISFLOAT) THEN
-                ParseNumSetF num, FLOATTYPE - ISPOINTER, num.f / state.num.f
-            ELSEIF (num.typ AND ISUNSIGNED) OR (state.num.typ AND ISUNSIGNED) THEN
-                ParseNumSetUI num, UINTEGER64TYPE - ISPOINTER, num.ui / state.num.ui
-            ELSE
-                ParseNumSetI num, INTEGER64TYPE - ISPOINTER, num.i / state.num.i
-            END IF
+            ' Regular division is always done as floating-point
+            ParseNumSetF num, FLOATTYPE - ISPOINTER, num.f / state.num.f
         ELSE
             IF CONST_EVAL_DEBUG THEN  _Echo "Factor done!"
             state.num = num

--- a/tests/compile_tests/const/expression.bas
+++ b/tests/compile_tests/const/expression.bas
@@ -47,6 +47,8 @@ CONST const__str4 = (const__str + (const__str2))
 
 CONST const__unsignedint = 2~&& * 5~&&
 
+CONST const__division_floating = 1& / 5&
+
 PRINT const__OR
 PRINT const__AND
 PRINT const__NOT
@@ -90,5 +92,7 @@ PRINT const__str3
 PRINT const__str4
 
 PRINT const__unsignedint
+
+PRINT const__division_floating
 
 SYSTEM

--- a/tests/compile_tests/const/expression.output
+++ b/tests/compile_tests/const/expression.output
@@ -34,3 +34,4 @@ foobarfoobar2
 foobarfoobarfoobar2
 foobarfoobarfoobar2
  10 
+ .2 


### PR DESCRIPTION
The regular division symbol always converts its arguments to floating point before dividing, similar to how integer division converts its arguments to integers before dividing.