### PR TITLE
Remove usage of node.js 16 in workflow

### DIFF
--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -28,7 +28,7 @@ jobs:
       PLATFORM: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
 
       # A deploy key is setup so that the potential push of ./internal/source can
       # trigger a new build. Care is taken to make sure loops cannot happen.
-    - uses: webfactory/ssh-agent@v0.7.0
+    - uses: webfactory/ssh-agent@v0.9.0
       if: ${{ github.event_name == 'push' && matrix.prefix == 'lnx' }}
       with:
         ssh-private-key: ${{ secrets.ACTION_DEPLOY_KEY }}
@@ -110,7 +110,7 @@ jobs:
       if: ${{ github.event_name == 'push' &&  matrix.prefix == 'lnx' && github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'Merge pull request') }}
       run: .ci/push-internal-source.sh
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: qb64pe-${{ matrix.prefix }}${{ matrix.prefix == 'win' && format('-{0}', matrix.platform) || '' }}-${{ env.version }}


### PR DESCRIPTION
A few of the actions we use require manual updating to a version that uses node.js v20. None of the changes appear to impact our usage of them.