### PR TITLE
Create Windows GUI applications only when both DEP_CONSOLE_ONLY & DEP_CONSOLE are not defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,6 +350,8 @@ ifeq ($(OS),win)
 
 	ifneq ($(filter y,$(DEP_CONSOLE_ONLY) $(DEP_CONSOLE)),)
 		CXXLIBS += -mconsole
+	else
+		CXXLIBS += -mwindows
 	endif
 
 	ifneq ($(filter y,$(DEP_CONSOLE_ONLY)),)
@@ -358,7 +360,7 @@ ifeq ($(OS),win)
 
 		LICENSE_IN_USE := $(filter-out freeglut,$(LICENSE_IN_USE))
 	else
-		CXXLIBS += -mwindows -lopengl32 -lglu32 -lwinmm
+		CXXLIBS += -lopengl32 -lglu32 -lwinmm
 	endif
 
 	ifneq ($(filter y,$(DEP_SOCKETS)),)

--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,7 @@ ifeq ($(OS),win)
 
 		LICENSE_IN_USE := $(filter-out freeglut,$(LICENSE_IN_USE))
 	else
-		CXXLIBS += -lopengl32 -lglu32 -lwinmm
+		CXXLIBS += -lopengl32 -lglu32 -lwinmm -lgdi32
 	endif
 
 	ifneq ($(filter y,$(DEP_SOCKETS)),)


### PR DESCRIPTION
This pull request addresses an issue where both `-mconsole` and `-mwindows` flags are sent for `DEP_CONSOLE` applications. Typically, this doesn't cause problems with MinGW, as it seems to prioritize `-mconsole`. However, LLVM MinGW gives preference to `-mwindows`, resulting in the complete disabling of the Windows console when `QB64pe.bas` is compiled with LLVM MinGW.

This pull request addresses the final issue remaining from the list of issues I observed when using LLVM MinGW. By resolving this problem, we now have an opportunity to consider moving away from MinGW and adopting LLVM MinGW as the backend for all possible Windows targets in a future PR.