### PR TITLE
Bump version to 3.13.0

### DIFF
--- a/source/global/version.bas
+++ b/source/global/version.bas
@@ -1,9 +1,9 @@
 DIM SHARED Version AS STRING
 DIM SHARED IsCiVersion AS _BYTE
 
-Version$ = "3.12.0"
-$VERSIONINFO:FILEVERSION#=3,12,0,0
-$VERSIONINFO:PRODUCTVERSION#=3,12,0,0
+Version$ = "3.13.0"
+$VERSIONINFO:FILEVERSION#=3,13,0,0
+$VERSIONINFO:PRODUCTVERSION#=3,13,0,0
 
 ' If ./internal/version.txt exist, then this is some kind of CI build with a label
 IF _FILEEXISTS("internal/version.txt") THEN


### PR DESCRIPTION
This version includes the following fixes and changes:

- Fix typos (#467, #483)
- Add support for _MOUSEWHEEL and _MOUSEMOVEMENTx on macOS (#468)
- Fix issues with DATA on macOS (#470)
- Fix "Export As" menu state (#473)
- Fix GLUT thread to redraw at an accurate 60 FPS (#474)
- Add support for _CLIPBOARDIMAGE on macOS & Linux and other clipboard fixes (#475)
- Avoid monitoring special keys (on Windows) when the window is not in focus (#476)
- Open GUI file dialog in the IDE when Ctrl+S is pressed (#477)
- Add support for _NEGATE, _ANDALSO & _ORELSE Boolean operators (#478, #484)
- Fix mono-mode font rendering and quality issues (#480)
- Fix font width calculation when loading monospaced fonts (#487)
- Create Windows GUI applications only when both DEP_CONSOLE_ONLY & DEP_CONSOLE are not defined (#481)
- Fix macOS startup script bugs (#484)
- Wiki fixes (#485)
- IDE error reporting fixes (#486)