### PR TITLE
Reliably enable window defocus on Linux

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -31964,11 +31964,11 @@ extern "C" void qb64_os_event_linux(XEvent *event, Display *display, int *qb64_o
 
     if (*qb64_os_event_info == OS_EVENT_POST_PROCESSING) {
         switch (event->type) {
-        case EnterNotify:
+        case FocusIn:
             window_focused = -1;
             break;
 
-        case LeaveNotify:
+        case FocusOut:
             window_focused = 0;
             // Iterate over all modifiers
             for (uint32 key = VK + QBVK_RSHIFT; key <= VK + QBVK_MODE; key++) {

--- a/internal/c/parts/core/freeglut/freeglut_window.c
+++ b/internal/c/parts/core/freeglut/freeglut_window.c
@@ -1155,7 +1155,10 @@ void fgOpenWindow( SFG_Window* window, const char* title,
         StructureNotifyMask | SubstructureNotifyMask | ExposureMask |
         ButtonPressMask | ButtonReleaseMask | KeyPressMask | KeyReleaseMask |
         VisibilityChangeMask | EnterWindowMask | LeaveWindowMask |
-        PointerMotionMask | ButtonMotionMask;
+        PointerMotionMask | ButtonMotionMask |
+    // QB64-PE: custom code begin
+        FocusChangeMask;
+    // QB64-PE: custom code end
     winAttr.background_pixmap = None;
     winAttr.background_pixel  = 0;
     winAttr.border_pixel      = 0;

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -1536,16 +1536,14 @@ FUNCTION ide2 (ignore)
             END IF
         END IF
 
-        IF os$ = "WIN" OR MacOSX = 1 THEN
-            IF _WINDOWHASFOCUS THEN
-                LOCATE , , 1
-                _PALETTECOLOR 5, IDEBracketHighlightColor, 0
-                _PALETTECOLOR 6, IDEBackgroundColor2, 0
-            ELSE
-                LOCATE , , 0
-                _PALETTECOLOR 5, IDEBackgroundColor, 0
-                _PALETTECOLOR 6, IDEBackgroundColor, 0
-            END IF
+        IF _WINDOWHASFOCUS THEN
+            LOCATE , , 1
+            _PALETTECOLOR 5, IDEBracketHighlightColor, 0
+            _PALETTECOLOR 6, IDEBackgroundColor2, 0
+        ELSE
+            LOCATE , , 0
+            _PALETTECOLOR 5, IDEBackgroundColor, 0
+            _PALETTECOLOR 6, IDEBackgroundColor, 0
         END IF
 
         IF KALT THEN 'alt held
@@ -1570,7 +1568,7 @@ FUNCTION ide2 (ignore)
                 idealthighlight = 0
                 LOCATE , , 0: COLOR 0, 7: _PRINTSTRING (1, 1), menubar$
                 IF ideentermenu = 1 AND KCONTROL = 0 THEN 'alt was pressed then released
-                    IF _WINDOWHASFOCUS OR os$ = "LNX" THEN
+                    IF _WINDOWHASFOCUS THEN
                         LOCATE , , , IDENormalCursorStart, IDENormalCursorEnd
                         skipdisplay = 0
                         ideentermenu = 0
@@ -4421,7 +4419,7 @@ FUNCTION ide2 (ignore)
                 DO
                     _LIMIT 100
                     GetInput
-                    IF _WINDOWHASFOCUS = 0 AND (os$ = "WIN" OR MacOSX = 1) THEN
+                    IF _WINDOWHASFOCUS = 0 THEN
                         COLOR 0, 7: _PRINTSTRING (1, 1), menubar$
                         SCREEN , , 3, 0: PCOPY 3, 0
                         GOTO ideloop
@@ -4434,7 +4432,7 @@ FUNCTION ide2 (ignore)
                 KB = KEY_ESC
             END IF
 
-            IF _WINDOWHASFOCUS = 0 AND (os$ = "WIN" OR MacOSX = 1) THEN
+            IF _WINDOWHASFOCUS = 0 THEN
                 COLOR 0, 7: _PRINTSTRING (1, 1), menubar$
                 SCREEN , , 3, 0: PCOPY 3, 0
                 GOTO ideloop
@@ -4657,7 +4655,7 @@ FUNCTION ide2 (ignore)
                 DO
                     _LIMIT 100
                     GetInput
-                    IF _WINDOWHASFOCUS = 0 AND (os$ = "WIN" OR MacOSX = 1) THEN
+                    IF _WINDOWHASFOCUS = 0 THEN
                         COLOR 0, 7: _PRINTSTRING (1, 1), menubar$
                         PCOPY 3, 0: SCREEN , , 3, 0
                         GOTO ideloop
@@ -4677,7 +4675,7 @@ FUNCTION ide2 (ignore)
                     ideexit = 1: GOTO ideloop
                 END IF
             END IF
-            IF _WINDOWHASFOCUS = 0 AND (os$ = "WIN" OR MacOSX = 1) THEN
+            IF _WINDOWHASFOCUS = 0 THEN
                 COLOR 0, 7: _PRINTSTRING (1, 1), menubar$
                 PCOPY 3, 0: SCREEN , , 3, 0
                 IF IdeDebugMode = 2 THEN GOTO EnterDebugMode


### PR DESCRIPTION
The FocusIn/FocusOut X11 events are more reflective of active foreground window that Enter/Leave, which only relates to mouse movement. In particular, FocusOut fires when Alt-Tabbing away so the alt key is correctly released.

Also re-enable IDE defocus processing on Linux so the Alt key no longer keeps the menus selected when Alt-Tabbing. This effectively reverts https://github.com/QB64Team/qb64/pull/1 which as far as I can tell was solely because one person didn't like the defocus behaviour.