### PR TITLE
Allow setting environment variables with space in values

### DIFF
--- a/internal/c/libqb/src/environ.cpp
+++ b/internal/c/libqb/src/environ.cpp
@@ -70,13 +70,11 @@ void sub_environ(qbs *str) {
     buf = (char *)malloc(str->len + 1);
     buf[str->len] = '\0';
     memcpy(buf, str->chr, str->len);
-    // Name and value may be separated by = or space
-    separator = strchr(buf, ' ');
-    if (!separator) {
-        separator = strchr(buf, '=');
-    }
-    if (!separator) {
+    // Name and value may be separated by = or space, whichever appears first.
+    separator = buf + strcspn(buf, " =");
+    if (*separator == '\0') {
         // It is an error is there is no separator
+        free(buf);
         error(5);
         return;
     }

--- a/tests/compile_tests/environ/set_environ.bas
+++ b/tests/compile_tests/environ/set_environ.bas
@@ -1,0 +1,48 @@
+$CONSOLE:ONLY
+ON ERROR GOTO ehandler
+
+'Test setting with =
+ENVIRON "FOO=BAR"
+PRINT ENVIRON$("FOO")
+
+
+'Test settings with space
+ENVIRON "VAR VAL"
+PRINT ENVIRON$("VAR")
+
+
+'Test setting value with spaces with = separator
+ENVIRON "ABC=DEF GHI"
+PRINT ENVIRON$("ABC")
+
+
+'Test setting value with spaces with space separator
+ENVIRON "JKL MNO PQR"
+PRINT ENVIRON$("JKL")
+
+
+'Test overwriting existing
+ENVIRON "X=XY"
+ENVIRON "X=ZZZ"
+PRINT ENVIRON$("X")
+
+
+'Test unset variable with = separator
+ENVIRON "NAME=LUKE"
+ENVIRON "NAME="
+PRINT "["; ENVIRON$("NAME"); "]"
+
+
+'Test unset variable with space separator
+ENVIRON "TEXT BOO"
+ENVIRON "TEXT "
+PRINT "["; ENVIRON$("TEXT"); "]"
+
+'Test no separator
+ENVIRON "NOSEP"
+
+SYSTEM
+
+ehandler:
+print "Error"; ERR; "line"; _ERRORLINE
+RESUME NEXT

--- a/tests/compile_tests/environ/set_environ.output
+++ b/tests/compile_tests/environ/set_environ.output
@@ -1,0 +1,8 @@
+BAR
+VAL
+DEF GHI
+MNO PQR
+ZZZ
+[]
+[]
+Error 5 line 42 


### PR DESCRIPTION
Fixes #386 which turned out to be an issue with assigning environment variables with values containing spaces.
