### PR TITLE
Optimize string addition somewhat to reduce IDE lag

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -11856,7 +11856,7 @@ SUB ideinsline (i, text$)
     idegotoline i
     'insert line
     textlen = LEN(text$)
-    idet$ = LEFT$(idet$, ideli - 1) + MKL$(textlen) + text$ + MKL$(textlen) + RIGHT$(idet$, LEN(idet$) - ideli + 1)
+    idet$ = LEFT$(idet$, ideli - 1) + (MKL$(textlen) + text$ + MKL$(textlen)) + RIGHT$(idet$, LEN(idet$) - ideli + 1)
     iden = iden + 1
 END SUB
 
@@ -12536,7 +12536,7 @@ SUB idesetline (i, text$)
 
     IF i <> -1 THEN idegotoline i
     textlen = LEN(text$)
-    idet$ = LEFT$(idet$, ideli - 1) + MKL$(textlen) + text$ + MKL$(textlen) + RIGHT$(idet$, LEN(idet$) - ideli + 1 - CVL(MID$(idet$, ideli, 4)) - 8)
+    idet$ = LEFT$(idet$, ideli - 1) + (MKL$(textlen) + text$ + MKL$(textlen)) + RIGHT$(idet$, LEN(idet$) - ideli + 1 - CVL(MID$(idet$, ideli, 4)) - 8)
 
 END SUB
 


### PR DESCRIPTION
Very simple change here, to basically take:

a$ = b$ + c$ + d$ + e$ + f$

And make it:

a$ = b$ + (c$ + d$ + e$) + f$

....

This speeds up the IDE due to (c$ + d$ + e$) being small strings, while a$ and f$ are larger strings...  It's more efficient to move and add those small strings first, than it is to add them to the large strings, making them larger, at each step.