### PR TITLE
Udt string offsets & bump to version 3.14.0

### DIFF
--- a/source/global/version.bas
+++ b/source/global/version.bas
@@ -1,9 +1,9 @@
 DIM SHARED Version AS STRING
 DIM SHARED IsCiVersion AS _BYTE
 
-Version$ = "3.13.1"
-$VERSIONINFO:FILEVERSION#=3,13,1,0
-$VERSIONINFO:PRODUCTVERSION#=3,13,1,0
+Version$ = "3.14.0"
+$VERSIONINFO:FILEVERSION#=3,14,0,0
+$VERSIONINFO:PRODUCTVERSION#=3,14,0,0
 
 ' If ./internal/version.txt exist, then this is some kind of CI build with a label
 IF _FILEEXISTS("internal/version.txt") THEN

--- a/source/utilities/type.bas
+++ b/source/utilities/type.bas
@@ -630,11 +630,11 @@ END SUB
 SUB initialise_udt_varstrings (n$, udt, buf, base_offset)
     IF NOT udtxvariable(udt) THEN EXIT SUB
     element = udtxnext(udt)
-    offset = 0
+    offset = base_offset
     DO WHILE element
         IF udtetype(element) AND ISSTRING THEN
             IF (udtetype(element) AND ISFIXEDLENGTH) = 0 THEN
-                WriteBufLine buf, "*(qbs**)(((char*)" + n$ + ")+" + STR$(base_offset + offset) + ") = qbs_new(0,0);"
+                WriteBufLine buf, "*(qbs**)(((char*)" + n$ + ")+" + STR$(offset) + ") = qbs_new(0,0);"
             END IF
         ELSEIF udtetype(element) AND ISUDT THEN
             initialise_udt_varstrings n$, udtetype(element) AND 511, buf, offset
@@ -647,14 +647,14 @@ END SUB
 SUB free_udt_varstrings (n$, udt, buf, base_offset)
     IF NOT udtxvariable(udt) THEN EXIT SUB
     element = udtxnext(udt)
-    offset = 0
+    offset = base_offset
     DO WHILE element
         IF udtetype(element) AND ISSTRING THEN
             IF (udtetype(element) AND ISFIXEDLENGTH) = 0 THEN
-                WriteBufLine buf, "qbs_free(*((qbs**)(((char*)" + n$ + ")+" + STR$(base_offset + offset) + ")));"
+                WriteBufLine buf, "qbs_free(*((qbs**)(((char*)" + n$ + ")+" + STR$(offset) + ")));"
             END IF
         ELSEIF udtetype(element) AND ISUDT THEN
-            initialise_udt_varstrings n$, udtetype(element) AND 511, buf, offset
+            free_udt_varstrings n$, udtetype(element) AND 511, buf, offset
         END IF
         offset = offset + udtesize(element) \ 8
         element = udtenext(element)
@@ -664,19 +664,19 @@ END SUB
 SUB clear_udt_with_varstrings (n$, udt, buf, base_offset)
     IF NOT udtxvariable(udt) THEN EXIT SUB
     element = udtxnext(udt)
-    offset = 0
+    offset = base_offset
     DO WHILE element
         IF udtetype(element) AND ISSTRING THEN
             IF (udtetype(element) AND ISFIXEDLENGTH) = 0 THEN
-                WriteBufLine buf, "(*(qbs**)(((char*)" + n$ + ")+" + STR$(base_offset + offset) + "))->len=0;"
+                WriteBufLine buf, "(*(qbs**)(((char*)" + n$ + ")+" + STR$(offset) + "))->len=0;"
             ELSE
-                WriteBufLine buf, "memset((char*)" + n$ + "+" + STR$(base_offset + offset) + ",0," + STR$(udtesize(element) \ 8) + ");"
+                WriteBufLine buf, "memset((char*)" + n$ + "+" + STR$(offset) + ",0," + STR$(udtesize(element) \ 8) + ");"
             END IF
         ELSE
             IF udtetype(element) AND ISUDT THEN
-                clear_udt_with_varstrings n$, udtetype(element) AND 511, buf, base_offset + offset
+                clear_udt_with_varstrings n$, udtetype(element) AND 511, buf, offset
             ELSE
-                WriteBufLine buf, "memset((char*)" + n$ + "+" + STR$(base_offset + offset) + ",0," + STR$(udtesize(element) \ 8) + ");"
+                WriteBufLine buf, "memset((char*)" + n$ + "+" + STR$(offset) + ",0," + STR$(udtesize(element) \ 8) + ");"
             END IF
         END IF
         offset = offset + udtesize(element) \ 8

--- a/tests/compile_tests/types/nested_udt.bas
+++ b/tests/compile_tests/types/nested_udt.bas
@@ -1,0 +1,31 @@
+$Console:Only
+
+Type t1
+    a As String
+End Type
+
+Type t2
+    b As t1
+    s As String
+End Type
+
+Type t3
+    n As Long
+    c As t2
+End Type
+
+'Test nested variable length string in UDT variable
+Dim test As t3
+test.c.s = "Hello"
+test.c.b.a = " world"
+Print test.c.s; test.c.b.a
+
+
+'Test nested variable length string in UDT array
+Dim arr(3) as t3
+For i = 0 to 3
+    arr(2).c.b.a = Str$(i)
+    Print arr(2).c.b.a;
+Next i
+
+System

--- a/tests/compile_tests/types/nested_udt.output
+++ b/tests/compile_tests/types/nested_udt.output
@@ -1,0 +1,2 @@
+Hello world
+ 0 1 2 3


### PR DESCRIPTION
Fixes an error in the initialisation of variable-length strings in UDTs. Fixes #524 

Also bumps the version to 3.14.0, on the assumption that this is the last feature to go in before release.