### PR TITLE
Allow _MIDISOUNDBANK to use the default soundbank

### DIFF
--- a/internal/c/parts/audio/audio.cpp
+++ b/internal/c/parts/audio/audio.cpp
@@ -2346,8 +2346,8 @@ void sub__midisoundbank(qbs *qbsFileName, qbs *qbsRequirements, int32_t passed) 
     enum struct SoundBankFormat { WOPL = 0, OP2, TMB, OPL, SF2, SF3, SFO, AD, UNKNOWN };
     static const char *SoundBankName[] = {"wopl", "op2", "tmb", "opl", "sf2", "sf3", "sfo", "ad", "unknown"};
 
-    if (!audioEngine.isInitialized || !qbsFileName->len) {
-        AUDIO_DEBUG_PRINT("Invalid parameters passed");
+    if (!audioEngine.isInitialized) {
+        AUDIO_DEBUG_PRINT("Audio engine is not initialized");
         return;
     }
 
@@ -2376,7 +2376,7 @@ void sub__midisoundbank(qbs *qbsFileName, qbs *qbsRequirements, int32_t passed) 
         }
     }
 
-    if (fromMemory) {
+    if (fromMemory && qbsFileName->len) {
         // Only bother setting up the format if we are loading from memory
         switch (format) {
         case SoundBankFormat::SF2:
@@ -2404,10 +2404,14 @@ void sub__midisoundbank(qbs *qbsFileName, qbs *qbsRequirements, int32_t passed) 
             return;
         }
     } else {
-        std::string fileName(reinterpret_cast<const char *>(qbsFileName->chr), qbsFileName->len);
+        if (qbsFileName->len) {
+            std::string fileName(reinterpret_cast<const char *>(qbsFileName->chr), qbsFileName->len);
 
-        if (FS_FileExists(filepath_fix_directory(fileName)))
-            g_InstrumentBankManager.SetPath(fileName.c_str());
+            if (FS_FileExists(filepath_fix_directory(fileName)))
+                g_InstrumentBankManager.SetPath(fileName.c_str());
+        } else {
+            g_InstrumentBankManager.SetPath(nullptr); // load the default sound bank
+        }
     }
 }
 

--- a/internal/c/parts/audio/extras/foo_midi/InstrumentBankManager.cpp
+++ b/internal/c/parts/audio/extras/foo_midi/InstrumentBankManager.cpp
@@ -35,6 +35,8 @@ void InstrumentBankManager::SetPath(const char *path) {
             fileName = path;
         }
 #endif
+    } else {
+        SetDefaults();
     }
 }
 
@@ -48,6 +50,8 @@ void InstrumentBankManager::SetData(const uint8_t *data, size_t size, Type type)
             this->type = Type::TinySoundFont; // primesynth cannot load soundfonts from memory
         else
             this->type = type;
+    } else {
+        SetDefaults();
     }
 }
 
@@ -326,5 +330,5 @@ void InstrumentBankManager::SetDefaults() {
     uncompress(&data[0], &size_mz, defaultBank, sizeof(defaultBank));
     fileName.clear();
     location = Location::Memory;
-    this->type = Type::Opal;
+    type = Type::Opal;
 }

--- a/internal/c/parts/audio/extras/foo_midi/InstrumentBankManager.h
+++ b/internal/c/parts/audio/extras/foo_midi/InstrumentBankManager.h
@@ -20,8 +20,6 @@ class InstrumentBankManager {
 
     InstrumentBankManager() { SetDefaults(); };
 
-    void SetDefaults();
-
     auto GetType() { return type; }
 
     auto GetLocation() { return location; }
@@ -44,4 +42,6 @@ class InstrumentBankManager {
     Location location;
     std::string fileName;
     std::vector<uint8_t> data;
+
+    void SetDefaults();
 };

--- a/internal/c/parts/audio/extras/foo_midi/VSTiPlayer.cpp
+++ b/internal/c/parts/audio/extras/foo_midi/VSTiPlayer.cpp
@@ -419,7 +419,6 @@ void VSTiPlayer::Render(audio_sample *sampleData, uint32_t sampleCount) {
                     left += _Samples[i * _ChannelCount + j]; // even channels go to the left
             }
 
-            // Average the samples for each channel
             sampleData[i << 1] = left;        // left channel
             sampleData[(i << 1) + 1] = right; // right channel
         }

--- a/internal/c/parts/audio/extras/midi_ma_vtable.cpp
+++ b/internal/c/parts/audio/extras/midi_ma_vtable.cpp
@@ -335,7 +335,7 @@ static auto ma_midi_init_common(ma_midi *pMIDI, const std::vector<uint8_t> &tune
 
     default:
         AUDIO_DEBUG_PRINT("Unknown synth type. Falling back to OpalPlayer");
-        g_InstrumentBankManager.SetDefaults();
+        g_InstrumentBankManager.SetPath(nullptr);
         [[fallthrough]];
 
     case InstrumentBankManager::Type::Opal:


### PR DESCRIPTION
The modification enables users to revert to the built-in soundbank by passing an empty string to _MIDISOUNDBANK. Before this change, it was not possible to switch back to the default soundbank once an external one had been used with _MIDISOUNDBANK.