### PR TITLE
Enable globbing by default when using llvm-mingw

### DIFF
--- a/internal/c/qbx.cpp
+++ b/internal/c/qbx.cpp
@@ -71,6 +71,10 @@ extern int32 vWatchHandle();
     #endif
 */
 
+#ifdef QB64_WINDOWS
+extern int _CRT_glob = -1; // enable globbing on llvm-mingw by default
+#endif
+
 extern int32 sub_gl_called;
 
 #ifdef QB64_GUI


### PR DESCRIPTION
By default, QB64-PE compiled with MinGW supports command line wildcard expansion. However, this does not seem to be the case when using llvm-mingw. This PR enables globbing by default for Windows regardless of the MinGW toolchain.