### PR TITLE
Do not throw an error if voice is out of range in func_play()

### DIFF
--- a/internal/c/parts/audio/audio.cpp
+++ b/internal/c/parts/audio/audio.cpp
@@ -2773,15 +2773,8 @@ double func_play(uint32_t voice, int32_t passed) {
         return 0.0;
     }
 
-    if (passed) {
-        if (voice >= AudioEngine::PSG_VOICES) {
-            error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
-
-            return 0.0;
-        }
-    } else {
-        voice = 0; // use voice 0 by default
-    }
+    // Default to voice 0 if voice is out of range
+    voice = (passed && voice < AudioEngine::PSG_VOICES) ? voice : 0;
 
     if (audioEngine.InitializePSG(voice)) {
         // Only proceed if the underlying PSG is initialized


### PR DESCRIPTION
This PR removes the voice range check in `func_play()`. If the voice is out of range, it now simply defaults to zero, aligning the behavior with QB45 standards.

This issue was identified during a wiki update.