### PR TITLE
Lint and format markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,47 +2,48 @@
 
 ![QB64-PE](source/peLogo.png)
 
-
 QB64 is a modern extended BASIC+OpenGL language that retains QB4.5/QBasic compatibility and compiles native binaries for Windows (7 and up), Linux and macOS (Catalina and up).
 
-The Phoenix Edition is one of the new offshoots created when the old project related pages (QB64Team/www.qb64.org) went offline, but it's still the same programming language. For the whole story visit our new [Forum](https://qb64phoenix.com/forum/showthread.php?tid=259).
+The [Phoenix Edition](https://www.qb64phoenix.com) is one of the new offshoots created when the old project related pages (QB64Team/www.qb64.org) went offline, but it's still the same programming language. For the whole story visit our new [Forum](https://qb64phoenix.com/forum/showthread.php?tid=259).
 
 # Table of Contents
-1. [Installation](#Installation)
-    1. [Windows](#Windows)
-    2. [macOS](#macOS)
-    3. [Linux](#Linux)
 
-2.  [Usage](#Usage)
-3.  [Additional Info](#Additional_Info)
+1. [Installation](#installation)
+    1. [Windows](#windows)
+    2. [macOS](#macos)
+    3. [Linux](#linux)
 
-# Installation <a name="Installation"></a>
-Download the appropriate package for your operating system over at https://github.com/QB64-Phoenix-Edition/QB64pe/releases/latest
+2. [Usage](#usage)
+3. [Additional Information](#additional-information)
 
-<a name="Windows"></a>
+# Installation
+
+Download the appropriate package for your operating system over at <https://github.com/QB64-Phoenix-Edition/QB64pe/releases/latest>
+
 ## Windows
 
 Make sure to extract the package contents to a folder with full write permissions (failing to do so may result in IDE or compilation errors).
 
 * It is advisable to whitelist the 'qb64pe' folder in your antivirus/antimalware software *
 
-<a name="macOS"></a>
 ## macOS
+
 Before using QB64-PE make sure to install the Xcode command line tools with:
+
 ```bash
 xcode-select --install
 ```
 
 Run ```./setup_osx.command``` to compile QB64-PE for your OS version.
 
-<a name="Linux"></a>
 ## Linux
+
 Compile QB64-PE with ```./setup_lnx.sh```.
 
 Dependencies should be automatically installed. Required packages include OpenGL, ALSA and the GNU C++ Compiler.
 
-<a name="Usage"></a>
 # Usage
+
 Run the ```qb64pe``` executable to launch the IDE, which you can use to edit your .BAS files. From there, hit F5 to compile and run your code.
 
 To generate a binary without running it, hit F11.
@@ -55,13 +56,12 @@ Additionally, if you do not wish to use the integrated IDE and to only compile y
 
 Replacing `-c` with `-x` will compile without opening a separate compiler window.
 
-
-<a name="Additional_Info"></a>
 # Additional Information
-More about QB64-PE at our wiki: https://qb64phoenix.com/qb64wiki
 
-We have a community forum at: https://qb64phoenix.com/forum
+More about QB64-PE at our wiki: <https://qb64phoenix.com/qb64wiki>
 
-Find us on Discord: https://discord.gg/D2M7hepTSx
+We have a community forum at: <https://qb64phoenix.com/forum>
 
-Join us on Reddit: https://www.reddit.com/r/QB64pe/
+Find us on Discord: <https://discord.gg/D2M7hepTSx>
+
+Join us on Reddit: <https://www.reddit.com/r/QB64pe/>

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -54,11 +54,11 @@ Repository Layout
 - `internal/`
   - `c/` - Contains everything related to the C/C++ source files for QB64-PE.
     - `c_compiler/`
-      - On Windows, this folder is populated with the MinGW C++ compiler during the CI process (or when using `setup_win.bat`.
+      - On Windows, this folder is populated with the MinGW C++ compiler during the CI process (or when using `setup_win.bat`).
     - `parts/`
       - Contains the sources to many of the dependencies that QB64 uses. Most of the dependencies have a `build.mk` file that is used by the main `Makefile` to build them.
   - `source/`
-    - Contains a copy of the generated C++ source of a previous version of QB64-PE. This is used to build a copy of QB64-PE using only a C++ ccompiler. This is updated automatically via the CI process.
+    - Contains a copy of the generated C++ source of a previous version of QB64-PE. This is used to build a copy of QB64-PE using only a C++ compiler. This is updated automatically via the CI process.
   - `version.txt`
     - QB64-PE checks this file to determine if there is a version tag (`-foobar` on the end of the version) for this version of QB64-PE.
 - `source/`

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -54,7 +54,7 @@ Repository Layout
 - `internal/`
   - `c/` - Contains everything related to the C/C++ source files for QB64-PE.
     - `c_compiler/`
-      - On Windows, this folder is populated with the MinGW C++ compiler during the CI process (or when using `setup_win.bat`).
+      - On Windows, this folder is populated with the MinGW C++ compiler during the CI process (or when using `setup_win.cmd`).
     - `parts/`
       - Contains the sources to many of the dependencies that QB64 uses. Most of the dependencies have a `build.mk` file that is used by the main `Makefile` to build them.
   - `source/`
@@ -88,7 +88,7 @@ Repository Layout
   - Used as part of the Linux release to install dependencies and compile QB64-PE.
 - `setup_osx.command`
   - Used as part of the OSx release to compile QB64-PE.
-- `setup_win.bat`
+- `setup_win.cmd`
   - Used only for compiled QB64-PE directly from a clone of the repository (not a release, we distribute QB64-PE already compiled in the Windows release)
 - `Makefile`
   - Used for building QB64 programs.

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -38,61 +38,60 @@ This describes how QB64-PE itself is built by the CI process to produce a releas
 Repository Layout
 -----------------
 
- - `.ci/` - All files in this folder are related to the CI build process.
-   - `bootstrap.bat`
-     - Windows only, Downloads MinGW compiler, builds the precompiled version of QB64-PE located in `./internal/source` as `qb64pe_bootstrap.exe`.
-   - `bootstrap.sh`
-     - Linux and OSX, builds the precompiled version of QB64-PE located in `./internal/source` as `qb64pe_bootstrap.exe`.
-   - `compile.bat`
-     - Uses `qb64pe_bootstrap.exe` to build `./source/qb64pe.bas`. This compiled QB64-PE is the released `qb64pe.exe`.
-   - `compile.sh`
-     - Uses `qb64pe_bootstrap` to build `./source/qb64pe.bas`. This built QB64-PE is what is used for testing, and the sources from this QB64-PE are placed into `./internal/source`.
-   - `make-dist.sh`
-     - Copies all the relevant parts of QB64-PE into a new folder, which can be distributed as a release.
-   - `push-internal-source.sh`
-     - If `./internal/source` is different after building `./source/qb64pe.bas`, then this will automatically push those changes to the repository to update the sources used to build `qb64pe_bootstrap`.
- - `internal/`
-   - `c/` - Contains everything related to the C/C++ source files for QB64-PE.
-     - `c_compiler/` 
-       - On Windows, this folder is populated with the MinGW C++ compiler during the CI process (or when using `setup_win.bat`.
-     - `parts/`
-       - Contains the sources to many of the dependencies that QB64 uses. Most of the dependencies have a `build.mk` file that is used by the main `Makefile` to build them.
-   - `source/`
-     - Contains a copy of the generated C++ source of a previous version of QB64-PE. This is used to build a copy of QB64-PE using only a C++ ccompiler. This is updated automatically via the CI process.
-   - `version.txt`
-     - QB64-PE checks this file to determine if there is a version tag (`-foobar` on the end of the version) for this version of QB64-PE.
- - `source/`
-   - Contains the QB64 source to QB64-PE itself.
- - `tests/` - Contains the tests run on QB64-PE during CI to verify changes.
-   - `compile_tests/`
-     - Testcases related to specific dependencies that QB64 can pull in. These tests are largely intended to test that QB64-PE and the Makefile correctly pulls in the proper dependencies.
-   - `c`
-     - The source for the C++-based tests.
-   - `qbasic_testcases/`
-     - A variety of collected QB64 sample programs
-   - `dist/`
-     - Test files for distribution tests.
-   - `compile_tests.sh`
-     - Runs the `compile_tests` test cases.
-   - `qbasic_tests.sh`
-     - Compiled all the testcases in `qbasic_testcases` and verifies they compile successfully.
-   - `dist_tests.sh`
-     - Verifies the output of `make-dist.sh` is a functioning distribution of QB64-PE
-   - `run_dist_tests.sh`
-     - Runs the distribution test collections.
-   - `run_tests.sh`
-     - Runs all individual test collections.
-   - `run_c_tests.sh`
-     - Runs all the C++ test cases.
- - `setup_lnx.sh`
-   - Used as part of the Linux release to install dependencies and compile QB64-PE.
- - `setup_osx.command`
-   - Used as part of the OSx release to compile QB64-PE.
- - `setup_win.bat`
-   - Used only for compiled QB64-PE directly from a clone of the repository (not a release, we distribute QB64-PE already compiled in the Windows release)
- - `Makefile`
-   - Used for building QB64 programs.
-
+- `.ci/` - All files in this folder are related to the CI build process.
+  - `bootstrap.bat`
+    - Windows only, Downloads MinGW compiler, builds the precompiled version of QB64-PE located in `./internal/source` as `qb64pe_bootstrap.exe`.
+  - `bootstrap.sh`
+    - Linux and OSX, builds the precompiled version of QB64-PE located in `./internal/source` as `qb64pe_bootstrap.exe`.
+  - `compile.bat`
+    - Uses `qb64pe_bootstrap.exe` to build `./source/qb64pe.bas`. This compiled QB64-PE is the released `qb64pe.exe`.
+  - `compile.sh`
+    - Uses `qb64pe_bootstrap` to build `./source/qb64pe.bas`. This built QB64-PE is what is used for testing, and the sources from this QB64-PE are placed into `./internal/source`.
+  - `make-dist.sh`
+    - Copies all the relevant parts of QB64-PE into a new folder, which can be distributed as a release.
+  - `push-internal-source.sh`
+    - If `./internal/source` is different after building `./source/qb64pe.bas`, then this will automatically push those changes to the repository to update the sources used to build `qb64pe_bootstrap`.
+- `internal/`
+  - `c/` - Contains everything related to the C/C++ source files for QB64-PE.
+    - `c_compiler/`
+      - On Windows, this folder is populated with the MinGW C++ compiler during the CI process (or when using `setup_win.bat`.
+    - `parts/`
+      - Contains the sources to many of the dependencies that QB64 uses. Most of the dependencies have a `build.mk` file that is used by the main `Makefile` to build them.
+  - `source/`
+    - Contains a copy of the generated C++ source of a previous version of QB64-PE. This is used to build a copy of QB64-PE using only a C++ ccompiler. This is updated automatically via the CI process.
+  - `version.txt`
+    - QB64-PE checks this file to determine if there is a version tag (`-foobar` on the end of the version) for this version of QB64-PE.
+- `source/`
+  - Contains the QB64 source to QB64-PE itself.
+- `tests/` - Contains the tests run on QB64-PE during CI to verify changes.
+  - `compile_tests/`
+    - Testcases related to specific dependencies that QB64 can pull in. These tests are largely intended to test that QB64-PE and the Makefile correctly pulls in the proper dependencies.
+  - `c`
+    - The source for the C++-based tests.
+  - `qbasic_testcases/`
+    - A variety of collected QB64 sample programs
+  - `dist/`
+    - Test files for distribution tests.
+  - `compile_tests.sh`
+    - Runs the `compile_tests` test cases.
+  - `qbasic_tests.sh`
+    - Compiled all the testcases in `qbasic_testcases` and verifies they compile successfully.
+  - `dist_tests.sh`
+    - Verifies the output of `make-dist.sh` is a functioning distribution of QB64-PE
+  - `run_dist_tests.sh`
+    - Runs the distribution test collections.
+  - `run_tests.sh`
+    - Runs all individual test collections.
+  - `run_c_tests.sh`
+    - Runs all the C++ test cases.
+- `setup_lnx.sh`
+  - Used as part of the Linux release to install dependencies and compile QB64-PE.
+- `setup_osx.command`
+  - Used as part of the OSx release to compile QB64-PE.
+- `setup_win.bat`
+  - Used only for compiled QB64-PE directly from a clone of the repository (not a release, we distribute QB64-PE already compiled in the Windows release)
+- `Makefile`
+  - Used for building QB64 programs.
 
 Makefile Usage and Parameters
 -----------------------------
@@ -139,9 +138,9 @@ Versioning
 
 QB64 Phoenix Edition follows SemVer, which means that major releases indicate a breaking change, minor releases indicate new features, and patch release indicates bug fixes.
 
- - Release versions of QB64-PE will have just a version number in the form `X.Y.Z`. All other versions of QB64-PE will have some kind of 'tag' at the end of the version, which is arbitrary text after a `-` placed on the end of the version.
- - CI versions get a tag in the form of `-XX-YYYYYYYY`, where `XX` is the number of commits since the last release, and `YYYYYYYY` is the first 8 digits of the commit hash of that build.
- - If you build the repository directly, you would get an `-UNKNOWN` version, which indicates that due to not running through the CI process we do not know what particular version (if any) that you are using.
+- Release versions of QB64-PE will have just a version number in the form `X.Y.Z`. All other versions of QB64-PE will have some kind of 'tag' at the end of the version, which is arbitrary text after a `-` placed on the end of the version.
+- CI versions get a tag in the form of `-XX-YYYYYYYY`, where `XX` is the number of commits since the last release, and `YYYYYYYY` is the first 8 digits of the commit hash of that build.
+- If you build the repository directly, you would get an `-UNKNOWN` version, which indicates that due to not running through the CI process we do not know what particular version (if any) that you are using.
 
 Release Process
 ---------------

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -24,7 +24,7 @@ spaces also exist in the `*.output` and/or `*.err` files respectively, those
 spaces are often overseen or even get stripped by some Editors when saving the
 file. Also the test **can not** produce trailing empty lines, you **must** make
 sure the test output ends with the last meaningful line.
- 
+
 Tests can also have an optional `*.flags` file. The contents of this file will
 be provide as command line arguments to QB64-PE when compiling the test source.
 


### PR DESCRIPTION
This PR is simple: it runs all markdown documents in the repository through a markdown linter and formatter, resolving numerous markdown violations. It replaces HTML anchor tags with markdown internal links and corrects a few typos. The rendered content remains unchanged.