### PR TITLE
Fix mouse _MOUSEMOVEMENTX/Y issue on Windows on ARM with C++ optimizations

### DIFF
--- a/internal/c/parts/core/freeglut/freeglut_main.c
+++ b/internal/c/parts/core/freeglut/freeglut_main.c
@@ -1677,7 +1677,8 @@ LRESULT CALLBACK fgWindowProc( HWND hWnd, UINT uMsg, WPARAM wParam,
 {
     // QB64-PE: custom code begin
     static int raw_setup = 0;
-    static RAWINPUTDEVICE Rid[1];
+    static RAWINPUTDEVICE rawInputDevice;
+    static RAWINPUT rawInput;
     int qb64_os_event_info = 0;
     LRESULT qb64_os_event_return = 1;
 
@@ -2051,16 +2052,14 @@ LRESULT CALLBACK fgWindowProc( HWND hWnd, UINT uMsg, WPARAM wParam,
         return 0;
 
     // QB64-PE: custom code begin
+    // Adapted from https://learn.microsoft.com/en-us/windows/win32/dxtecharts/taking-advantage-of-high-dpi-mouse-movement
     case WM_INPUT: {
         if (raw_setup) {
-            // Adapted from http://msdn.microsoft.com/en-us/library/windows/desktop/ee418864%28v=vs.85%29.aspx#WM_INPUT
-            UINT dwSize = sizeof(RAWINPUT);
-            static BYTE lpb[sizeof(RAWINPUT)];
-            GetRawInputData((HRAWINPUT)lParam, RID_INPUT, lpb, &dwSize, sizeof(RAWINPUTHEADER));
-            RAWINPUT *raw = (RAWINPUT *)lpb;
-            if (raw->header.dwType == RIM_TYPEMOUSE) {
-                int xPosRelative = raw->data.mouse.lLastX;
-                int yPosRelative = raw->data.mouse.lLastY;
+            UINT dwSize = sizeof(rawInput);
+            GetRawInputData((HRAWINPUT)lParam, RID_INPUT, (LPVOID)&rawInput, &dwSize, sizeof(RAWINPUTHEADER));
+            if (rawInput.header.dwType == RIM_TYPEMOUSE) {
+                LONG xPosRelative = rawInput.data.mouse.lLastX;
+                LONG yPosRelative = rawInput.data.mouse.lLastY;
                 if (xPosRelative || yPosRelative)
                     qb64_custom_event(QB64_EVENT_RELATIVE_MOUSE_MOVEMENT, xPosRelative, yPosRelative, 0, 0, 0, 0, 0, 0, NULL, NULL);
             }
@@ -2071,7 +2070,7 @@ LRESULT CALLBACK fgWindowProc( HWND hWnd, UINT uMsg, WPARAM wParam,
 
     case WM_MOUSEMOVE:
     {
-	// QB64-PE: custom code begin
+        // QB64-PE: custom code begin
         if (!raw_setup) {
             raw_setup = 1;
 #    ifndef HID_USAGE_PAGE_GENERIC
@@ -2080,13 +2079,13 @@ LRESULT CALLBACK fgWindowProc( HWND hWnd, UINT uMsg, WPARAM wParam,
 #    ifndef HID_USAGE_GENERIC_MOUSE
 #        define HID_USAGE_GENERIC_MOUSE ((USHORT)0x02)
 #    endif
-            Rid[0].usUsagePage = HID_USAGE_PAGE_GENERIC;
-            Rid[0].usUsage = HID_USAGE_GENERIC_MOUSE;
-            Rid[0].dwFlags = RIDEV_INPUTSINK;
-            Rid[0].hwndTarget = window->Window.Handle;
-            RegisterRawInputDevices(Rid, 1, sizeof(Rid[0]));
+            rawInputDevice.usUsagePage = HID_USAGE_PAGE_GENERIC;
+            rawInputDevice.usUsage = HID_USAGE_GENERIC_MOUSE;
+            rawInputDevice.dwFlags = RIDEV_INPUTSINK;
+            rawInputDevice.hwndTarget = window->Window.Handle;
+            RegisterRawInputDevices(&rawInputDevice, 1, sizeof(rawInputDevice));
         }
-	// QB64-PE: custom code end
+        // QB64-PE: custom code end
 
 #if defined(_WIN32_WCE)
         window->State.MouseX = 320-HIWORD( lParam );

--- a/setup_mingw.cmd
+++ b/setup_mingw.cmd
@@ -65,19 +65,19 @@ rem MINGW_DIR is actually the internal directory name inside the zip file
 rem It needs to be updated whenever the toolchains are updated
 if "%ARCH%" == "ARM" (
     if %BITS% == 64 (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20241203/llvm-mingw-20241203-ucrt-aarch64.zip"
-        set MINGW_DIR=llvm-mingw-20241203-ucrt-aarch64
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-aarch64.zip"
+        set MINGW_DIR=llvm-mingw-20250114-ucrt-aarch64
     ) else (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20241203/llvm-mingw-20241203-ucrt-armv7.zip"
-        set MINGW_DIR=llvm-mingw-20241203-ucrt-armv7
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-armv7.zip"
+        set MINGW_DIR=llvm-mingw-20250114-ucrt-armv7
     )
 ) else (
     if %BITS% == 64 (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20241203/llvm-mingw-20241203-ucrt-x86_64.zip"
-        set MINGW_DIR=llvm-mingw-20241203-ucrt-x86_64
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-x86_64.zip"
+        set MINGW_DIR=llvm-mingw-20250114-ucrt-x86_64
     ) else (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20241203/llvm-mingw-20241203-ucrt-i686.zip"
-        set MINGW_DIR=llvm-mingw-20241203-ucrt-i686
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-i686.zip"
+        set MINGW_DIR=llvm-mingw-20250114-ucrt-i686
     )
 )
 


### PR DESCRIPTION
This PR resolves `_MOUSEMOVEMENTX` and `_MOUSEMOVEMENTY` returning `0` on Windows on ARM with C++ optimizations enabled.