### PR TITLE
Disables mouse event suppression on macOS when the mouse is hidden and moved

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -28826,9 +28826,8 @@ int main(int argc, char *argv[]) {
     singlespace = qbs_new_cmem(1, 0);
     singlespace->chr[0] = 32;
 
-    // store _CWD$ for recall using _STARTDIR$ in g_startDir
-    g_startDir = qbs_new(0, 0);
-    qbs_set(g_startDir, func__cwd());
+    // Store _CWD$ for recall using _STARTDIR$
+    FS_SaveStartDirectory();
 
 // switch to directory of this EXE file
 // http://stackoverflow.com/questions/1023306/finding-current-executables-path-without-proc-self-exe

--- a/internal/c/libqb/include/filesystem.h
+++ b/internal/c/libqb/include/filesystem.h
@@ -8,9 +8,7 @@
 
 struct qbs;
 
-/// @brief This is a global variable that is set on startup and holds the directory that was current when the program was loaded
-extern qbs *g_startDir;
-
+void FS_SaveStartDirectory();
 bool FS_DirectoryExists(const char *path);
 bool FS_FileExists(const char *path);
 

--- a/internal/c/libqb/include/mac-mouse-support.h
+++ b/internal/c/libqb/include/mac-mouse-support.h
@@ -4,6 +4,7 @@
 void macMouseInit();
 void macMouseDone();
 void macMouseUpdatePosition(int x, int y);
+void macMouseAssociateMouseAndMouseCursorPosition(bool connected);
 #else
 static inline void macMouseInit() {}
 
@@ -12,5 +13,9 @@ static inline void macMouseDone() {}
 static inline void macMouseUpdatePosition(int x, int y) {
     (void)x;
     (void)y;
+}
+
+static inline void macMouseAssociateMouseAndMouseCursorPosition(bool connected) {
+    (void)connected;
 }
 #endif

--- a/internal/c/libqb/src/filesystem.cpp
+++ b/internal/c/libqb/src/filesystem.cpp
@@ -34,10 +34,10 @@
 #endif
 
 /// @brief This is a global variable that is set on startup and holds the directory that was current when the program was loaded
-qbs *g_startDir = nullptr;
+static qbs *g_startDir = nullptr;
 
-/// @brief Gets the current working directory
-/// @return A qbs containing the current working directory or an empty string on error
+/// @brief Gets the current working directory.
+/// @return A qbs containing the current working directory or an empty string on error.
 qbs *func__cwd() {
     if (is_error_pending()) {
         return qbs_new(0, 1);
@@ -50,16 +50,22 @@ qbs *func__cwd() {
 
     for (;;) {
         if (getcwd(&path[0], path.size())) {
-            auto size = strlen(path.c_str());
-            qbsFinal = qbs_new(size, 1);
-            memcpy(qbsFinal->chr, &path[0], size);
+            path.resize(strlen(path.c_str()));
+
+            if (path.empty() || path.back() != FS_PATH_SEPARATOR) {
+                path.append(1, FS_PATH_SEPARATOR);
+            }
+
+            qbsFinal = qbs_new(path.length(), 1);
+            memcpy(qbsFinal->chr, &path[0], path.length());
 
             return qbsFinal;
         } else {
-            if (errno == ERANGE)
+            if (errno == ERANGE) {
                 path.resize(path.size() << 1, '\0'); // buffer size was not sufficient; try again with a larger buffer
-            else
+            } else {
                 break; // some other error occurred
+            }
         }
     }
 
@@ -69,9 +75,9 @@ qbs *func__cwd() {
     return qbsFinal;
 }
 
-/// @brief Returns true if the specified directory exists
-/// @param path The directory to check for
-/// @return True if the directory exists
+/// @brief Returns true if the specified directory exists.
+/// @param path The directory to check for.
+/// @return True if the directory exists.
 bool FS_DirectoryExists(const char *path) {
 #ifdef QB64_WINDOWS
     auto x = GetFileAttributesA(path);
@@ -104,9 +110,9 @@ enum class FS_KnownDirectory {
 };
 
 #ifdef QB64_WINDOWS
-/// @brief Returns the full path for a known directory
-/// @param kD Is a value from FS_KnownDirectory (above)
-/// @return The full path that ends with the system path separator
+/// @brief Returns the full path for a known directory.
+/// @param kD Is a value from FS_KnownDirectory (above).
+/// @return The full path that ends with the system path separator.
 static std::string FS_GetKnownDirectory(FS_KnownDirectory kD) {
     std::string path(FS_PATHNAME_LENGTH_MAX, '\0'); // allocate something that is sufficiently large
 
@@ -198,15 +204,16 @@ static std::string FS_GetKnownDirectory(FS_KnownDirectory kD) {
 
     // Add the trailing slash
     path.resize(strlen(path.c_str()));
-    if (path.back() != FS_PATH_SEPARATOR)
+    if (path.empty() || path.back() != FS_PATH_SEPARATOR) {
         path.append(1, FS_PATH_SEPARATOR);
+    }
 
     return path;
 }
 #else
-/// @brief Returns the full path for a known directory
-/// @param kD Is a value from FS_KnownDirectory (above)
-/// @return The full path that ends with the system path separator
+/// @brief Returns the full path for a known directory.
+/// @param kD Is a value from FS_KnownDirectory (above).
+/// @return The full path that ends with the system path separator.
 static std::string FS_GetKnownDirectory(FS_KnownDirectory kD) {
     std::string path;
     auto envVar = getenv("HOME");
@@ -358,20 +365,21 @@ static std::string FS_GetKnownDirectory(FS_KnownDirectory kD) {
 
     // Add the trailing slash
     path.resize(strlen(path.c_str()));
-    if (path.back() != FS_PATH_SEPARATOR)
+    if (path.empty() || path.back() != FS_PATH_SEPARATOR) {
         path.append(1, FS_PATH_SEPARATOR);
+    }
 
     return path;
 }
 #endif
 
-/// @brief Returns common paths such as My Documents, My Pictures, My Music, Desktop
-/// @param qbsContext Is the directory type
-/// @return A qbs containing the directory or an empty string on error
+/// @brief Returns common paths such as My Documents, My Pictures, My Music, Desktop.
+/// @param qbsContext Is the directory type.
+/// @return A qbs containing the directory or an empty string on error.
 qbs *func__dir(qbs *qbsContext) {
     std::string path, context(reinterpret_cast<char *>(qbsContext->chr), qbsContext->len);
 
-    std::transform(context.begin(), context.end(), context.begin(), [](unsigned char c) { return std::toupper(c); });
+    std::transform(context.begin(), context.end(), context.begin(), ::toupper);
 
     // The following is largely unchanged from what we previously had
     if (context.compare("TEXT") == 0 || context.compare("DOCUMENT") == 0 || context.compare("DOCUMENTS") == 0 || context.compare("MY DOCUMENTS") == 0) {
@@ -418,25 +426,24 @@ qbs *func__dir(qbs *qbsContext) {
         path = FS_GetKnownDirectory(FS_KnownDirectory::DESKTOP); // anything else defaults to the desktop where the user can easily see stuff
     }
 
-    auto size = path.size();
-    auto qbsFinal = qbs_new(size, 1);
-    memcpy(qbsFinal->chr, &path[0], size);
+    auto qbsFinal = qbs_new(path.length(), 1);
+    memcpy(qbsFinal->chr, &path[0], path.length());
 
     return qbsFinal;
 }
 
-/// @brief Returns true if a directory specified exists
-/// @param path The directory path
-/// @return True if the directory exists
+/// @brief Returns true if a directory specified exists.
+/// @param path The directory path.
+/// @return True if the directory exists.
 int32_t func__direxists(qbs *path) {
     std::string pathName(reinterpret_cast<char *>(path->chr), path->len);
 
     return FS_DirectoryExists(filepath_fix_directory(pathName)) ? QB_TRUE : QB_FALSE;
 }
 
-/// @brief Returns true if a file specified exists
-/// @param path The file path to check for
-/// @return True if the file exists
+/// @brief Returns true if a file specified exists.
+/// @param path The file path to check for.
+/// @return True if the file exists.
 bool FS_FileExists(const char *path) {
 #ifdef QB64_WINDOWS
     auto x = GetFileAttributesA(path);
@@ -449,23 +456,35 @@ bool FS_FileExists(const char *path) {
 #endif
 }
 
-/// @brief Returns true if a file specified exists
-/// @param path The file path to check for
-/// @return True if the file exists
+/// @brief Returns true if a file specified exists.
+/// @param path The file path to check for.
+/// @return True if the file exists.
 int32_t func__fileexists(qbs *path) {
     std::string pathName(reinterpret_cast<char *>(path->chr), path->len);
 
     return FS_FileExists(filepath_fix_directory(pathName)) ? QB_TRUE : QB_FALSE;
 }
 
-/// @brief Return the startup directory
-/// @return A qbs containing the directory path
-qbs *func__startdir() {
-    return qbs_set(qbs_new(0, 1), g_startDir);
+/// @brief Saves the current directory as the startup directory.
+void FS_SaveStartDirectory() {
+    if (!g_startDir) {
+        g_startDir = qbs_new(0, 0);
+        qbs_set(g_startDir, func__cwd());
+    }
 }
 
-/// @brief Changes the current directory
-/// @param str The directory path to change to
+/// @brief Return the startup directory.
+/// @return A qbs containing the directory path.
+qbs *func__startdir() {
+    if (g_startDir) {
+        return qbs_set(qbs_new(0, 1), g_startDir);
+    }
+
+    return qbs_new(0, 1);
+}
+
+/// @brief Changes the current directory.
+/// @param str The directory path to change to.
 void sub_chdir(qbs *str) {
     if (is_error_pending()) {
         return;
@@ -477,17 +496,17 @@ void sub_chdir(qbs *str) {
         error(QB_ERROR_PATH_NOT_FOUND); // assume errno == ENOENT; path not found
 }
 
-/// @brief Checks if s is an empty string (either NULL or zero length)
-/// @param s A null-terminated string or NULL
-/// @return False is we have a valid string > length 0
+/// @brief Checks if s is an empty string (either NULL or zero length).
+/// @param s A null-terminated string or NULL.
+/// @return False is we have a valid string > length 0.
 static inline bool FS_IsStringEmpty(const char *s) {
     return s == nullptr || s[0] == '\0';
 }
 
-/// @brief This is a basic pattern matching function used by FS_GetDirectoryEntryName()
-/// @param fileSpec The pattern to match
-/// @param fileName The filename to match
-/// @return True if it is a match, false otherwise
+/// @brief This is a basic pattern matching function used by FS_GetDirectoryEntryName().
+/// @param fileSpec The pattern to match.
+/// @param fileName The filename to match.
+/// @return True if it is a match, false otherwise.
 static inline bool FS_IsPatternMatching(const char *fileSpec, const char *fileName) {
     auto spec = fileSpec;
     auto name = fileName;
@@ -534,9 +553,9 @@ static inline bool FS_IsPatternMatching(const char *fileSpec, const char *fileNa
     return true;
 }
 
-/// @brief Returns true if fileSpec has any wildcards
-/// @param fileSpec The string to check
-/// @return True if * or ? are found
+/// @brief Returns true if fileSpec has any wildcards.
+/// @param fileSpec The string to check.
+/// @return True if * or ? are found.
 static inline bool FS_HasPattern(const char *fileSpec) {
     return fileSpec != nullptr && (strchr(fileSpec, '*') || strchr(fileSpec, '?'));
 }
@@ -557,10 +576,10 @@ struct DirectoryContext {
     }
 };
 
-/// @brief An MS BASIC PDS DIR$ style function
-/// @param ctx The directory context
-/// @param fileSpec This can be a path with wildcard for the final level (i.e. C:/Windows/*.* or /usr/lib/* etc.)
-/// @return Returns a file or directory name matching fileSpec or an empty string when there is nothing left
+/// @brief An MS BASIC PDS DIR$ style function.
+/// @param ctx The directory context.
+/// @param fileSpec This can be a path with wildcard for the final level (i.e. C:/Windows/*.* or /usr/lib/* etc.).
+/// @return Returns a file or directory name matching fileSpec or an empty string when there is nothing left.
 static const char *FS_GetDirectoryEntryName(DirectoryContext *ctx, const char *fileSpec) {
     ctx->entry[0] = '\0'; // set to an empty string
 
@@ -634,10 +653,10 @@ static const char *FS_GetDirectoryEntryName(DirectoryContext *ctx, const char *f
     return ctx->entry;
 }
 
-/// @brief This mimics MS BASIC PDS 7.1 & VBDOS 1.0 DIR$() function
-/// @param qbsFileSpec This can be a path with wildcard for the final level (i.e. C:/Windows/*.* or /usr/lib/* etc.)
-/// @param passed Flags for optional parameters
-/// @return Returns a qbs with the directory entry name or an empty string if there are no more entries
+/// @brief This mimics MS BASIC PDS 7.1 & VBDOS 1.0 DIR$() function.
+/// @param qbsFileSpec This can be a path with wildcard for the final level (i.e. C:/Windows/*.* or /usr/lib/* etc.).
+/// @param passed Flags for optional parameters.
+/// @return Returns a qbs with the directory entry name or an empty string if there are no more entries.
 qbs *func__files(qbs *qbsFileSpec, int32_t passed) {
     static DirectoryContext directoryContext;
     static std::string directory;
@@ -697,9 +716,9 @@ qbs *func__files(qbs *qbsFileSpec, int32_t passed) {
     return qbsFinal;
 }
 
-/// @brief Returns the free volume space for a given directory
-/// @param path A directory that resides on the volume we want the free space for
-/// @return The free space in bytes
+/// @brief Returns the free volume space for a given directory.
+/// @param path A directory that resides on the volume we want the free space for.
+/// @return The free space in bytes.
 static uint64_t FS_GetFreeDiskSpace(const char *path) {
 #ifdef QB64_WINDOWS
     ULARGE_INTEGER freeBytesAvailable;
@@ -718,9 +737,9 @@ static uint64_t FS_GetFreeDiskSpace(const char *path) {
     return 0; // zero if something failed
 }
 
-/// @brief Gets the fully qualified name (FQN)
-/// @param path The path name to get the FQN for
-/// @return The FQN
+/// @brief Gets the fully qualified name (FQN).
+/// @param path The path name to get the FQN for.
+/// @return The FQN.
 static std::string FS_GetFQN(const char *path) {
     std::string FQN = path; // fallback
 
@@ -746,9 +765,9 @@ static std::string FS_GetFQN(const char *path) {
     return FQN;
 }
 
-/// @brief Gets the fully qualified name (FQN)
-/// @param qbsPathName The path name to get the FQN for
-/// @return The FQN
+/// @brief Gets the fully qualified name (FQN).
+/// @param qbsPathName The path name to get the FQN for.
+/// @return The FQN.
 qbs *func__fullpath(qbs *qbsPathName) {
     if (is_error_pending() || !qbsPathName->len) {
         return qbs_new(0, 1);
@@ -773,9 +792,9 @@ qbs *func__fullpath(qbs *qbsPathName) {
     return temp;
 }
 
-/// @brief Gets the short name for a file / directory (if possible)
-/// @param path The file / directory to get the short name for
-/// @return The short name
+/// @brief Gets the short name for a file / directory (if possible).
+/// @param path The file / directory to get the short name for.
+/// @return The short name.
 static std::string FS_GetShortName(const char *path) {
 #ifdef QB64_WINDOWS
     DWORD size = GetShortPathNameA(path, nullptr, 0); // get the required buffer size
@@ -793,9 +812,9 @@ static std::string FS_GetShortName(const char *path) {
     return path; // return the path as-is for *nix or if GetShortPathNameA failed
 }
 
-/// @brief Prints a list of files in the current directory using a file specification
-/// @param str Is a string containing a path (it can include wildcards)
-/// @param passed Optional parameters
+/// @brief Prints a list of files in the current directory using a file specification.
+/// @param str Is a string containing a path (it can include wildcards).
+/// @param passed Optional parameters.
 void sub_files(qbs *str, int32_t passed) {
     static qbs *strz = nullptr;
 
@@ -803,8 +822,9 @@ void sub_files(qbs *str, int32_t passed) {
         return;
     }
 
-    if (!strz)
+    if (!strz) {
         strz = qbs_new(0, 0);
+    }
 
     std::string fileSpec, directory, pathName;
 
@@ -889,8 +909,8 @@ void sub_files(qbs *str, int32_t passed) {
     qbs_print(strz, 1);
 }
 
-/// @brief Deletes files from disk
-/// @param str The file(s) to delete (may contain wildcard at the final level)
+/// @brief Deletes files from disk.
+/// @param str The file(s) to delete (may contain wildcard at the final level).
 void sub_kill(qbs *str) {
     if (is_error_pending()) {
         return;
@@ -944,8 +964,8 @@ void sub_kill(qbs *str) {
     } while (!FS_IsStringEmpty(entry));
 }
 
-/// @brief Creates a new directory
-/// @param str The directory path name to create
+/// @brief Creates a new directory.
+/// @param str The directory path name to create.
 void sub_mkdir(qbs *str) {
     if (is_error_pending()) {
         return;
@@ -968,9 +988,9 @@ void sub_mkdir(qbs *str) {
     }
 }
 
-/// @brief Renames a file or directory
-/// @param oldname The old file / directory name
-/// @param newname The new file / directory name
+/// @brief Renames a file or directory.
+/// @param oldname The old file / directory name.
+/// @param newname The new file / directory name.
 void sub_name(qbs *oldname, qbs *newname) {
     if (is_error_pending()) {
         return;
@@ -1000,8 +1020,8 @@ void sub_name(qbs *oldname, qbs *newname) {
     }
 }
 
-/// @brief Deletes an empty directory
-/// @param str The path name of the directory to delete
+/// @brief Deletes an empty directory.
+/// @param str The path name of the directory to delete.
 void sub_rmdir(qbs *str) {
     if (is_error_pending()) {
         return;

--- a/internal/c/libqb/src/glut-message.cpp
+++ b/internal/c/libqb/src/glut-message.cpp
@@ -18,7 +18,13 @@
 #include "mac-mouse-support.h"
 
 void glut_message_set_cursor::execute() {
-    glutSetCursor(style);
+    if (style == GLUT_CURSOR_NONE) {
+        glutSetCursor(style);
+        macMouseAssociateMouseAndMouseCursorPosition(false);
+    } else {
+        macMouseAssociateMouseAndMouseCursorPosition(true);
+        glutSetCursor(style);
+    }
 }
 
 void glut_message_warp_pointer::execute() {

--- a/internal/c/libqb/src/graphics.cpp
+++ b/internal/c/libqb/src/graphics.cpp
@@ -112,7 +112,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
         return;
 
     static int32_t dwidth, dheight, swidth, sheight, swidth2, sheight2;
-    static int32_t lhs, rhs, lhs1, lhs2, top, bottom, temp, flats, flatg, final, tile, no_edge_overlap;
+    static int32_t lhs, rhs, lhs1, lhs2, top, bottom, flats, flatg, final, tile, no_edge_overlap;
     flats = 0;
     final = 0;
     tile = 0;
@@ -127,7 +127,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
     static uint32_t *dst_offset32;
     static uint8_t *src_offset;
     static uint32_t *src_offset32;
-    static uint32_t col, destcol, transparent_color;
+    static uint32_t col, destcol;
     static uint8_t *cp;
 
     // hardware support
@@ -380,49 +380,49 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
 
     // convert texture coords to fixed-point & adjust so 0,0 effectively becomes 0.5,0.5 (ie. 32768,32768)
     v = ((int32_t)(sx1 * 65536.0)) + 32768;
-    if (v < 16 | v >= swidth2 - 16)
+    if (v < 16 || v >= swidth2 - 16)
         tile = 1;
-    if (v<nlimit2 | v> limit2) {
+    if (v < nlimit2 || v > limit2) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
     p[1].tx = v;
     v = ((int32_t)(sx2 * 65536.0)) + 32768;
-    if (v < 16 | v >= swidth2 - 16)
+    if (v < 16 || v >= swidth2 - 16)
         tile = 1;
-    if (v<nlimit2 | v> limit2) {
+    if (v < nlimit2 || v > limit2) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
     p[2].tx = v;
     v = ((int32_t)(sx3 * 65536.0)) + 32768;
-    if (v < 16 | v >= swidth2 - 16)
+    if (v < 16 || v >= swidth2 - 16)
         tile = 1;
-    if (v<nlimit2 | v> limit2) {
+    if (v < nlimit2 || v > limit2) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
     p[3].tx = v;
     v = ((int32_t)(sy1 * 65536.0)) + 32768;
-    if (v < 16 | v >= sheight2 - 16)
+    if (v < 16 || v >= sheight2 - 16)
         tile = 1;
-    if (v<nlimit2 | v> limit2) {
+    if (v < nlimit2 || v > limit2) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
     p[1].ty = v;
     v = ((int32_t)(sy2 * 65536.0)) + 32768;
-    if (v < 16 | v >= sheight2 - 16)
+    if (v < 16 || v >= sheight2 - 16)
         tile = 1;
-    if (v<nlimit2 | v> limit2) {
+    if (v < nlimit2 || v > limit2) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
     p[2].ty = v;
     v = ((int32_t)(sy3 * 65536.0)) + 32768;
-    if (v < 0 | v >= sheight2 - 16)
+    if (v < 0 || v >= sheight2 - 16)
         tile = 1;
-    if (v<nlimit2 | v> limit2) {
+    if (v < nlimit2 || v > limit2) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
@@ -496,12 +496,12 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
             for (i = 1; i <= 3; i++) {
                 tp = &p[i];
                 v = tp->tx;
-                if (v < 16 | v >= swidth2 - 16) {
+                if (v < 16 || v >= swidth2 - 16) {
                     z = 1;
                     break;
                 }
                 v = tp->ty;
-                if (v < 16 | v >= sheight2 - 16) {
+                if (v < 16 || v >= sheight2 - 16) {
                     z = 1;
                     break;
                 }
@@ -512,27 +512,27 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
     }
 
     // validate dest points
-    if (dx1<nlimit | dx1> limit) {
+    if (dx1 < nlimit || dx1 > limit) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
-    if (dx2<nlimit | dx2> limit) {
+    if (dx2 < nlimit || dx2 > limit) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
-    if (dx3<nlimit | dx3> limit) {
+    if (dx3 < nlimit || dx3 > limit) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
-    if (dy1<nlimit | dy1> limit) {
+    if (dy1 < nlimit || dy1 > limit) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
-    if (dy2<nlimit | dy2> limit) {
+    if (dy2 < nlimit || dy2 > limit) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
-    if (dy3<nlimit | dy3> limit) {
+    if (dy3 < nlimit || dy3 > limit) {
         error(QB_ERROR_ILLEGAL_FUNCTION_CALL);
         return;
     }
@@ -567,7 +567,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
             lhs = x;
     }
 
-    if (bottom < 0 | top >= dheight | rhs < 0 | lhs >= dwidth)
+    if (bottom < 0 || top >= dheight || rhs < 0 || lhs >= dwidth)
         return; // clip entire triangle
 
     for (i = 1; i <= 3; i++) {
@@ -786,7 +786,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                     else
                         x2 = g2x / 65536;
 
-                    if (x1 >= dwidth | x2 < 0)
+                    if (x1 >= dwidth || x2 < 0)
                         goto mtri1t_donerow; // crop if(entirely offscreen
 
                     tx = g1tx;
@@ -809,8 +809,8 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                                                     // values
                     roff = ((g2x & 65535) - 32768);
 
-                    if (roff < 0) {                               // not enough of rhs pixel exists to use
-                        if (x2 < dwidth & no_edge_overlap == 0) { // onscreen check
+                    if (roff < 0) {                                // not enough of rhs pixel exists to use
+                        if (x2 < dwidth && no_edge_overlap == 0) { // onscreen check
                             // draw rhs pixel as is
                             //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                             *(dst_offset32 + (y * dwidth + x2)) = src_offset32[((g2ty >> 16) % sheight) * swidth + ((g2tx >> 16) % swidth)];
@@ -818,12 +818,12 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                         }
                         // move left one position
                         x2--;
-                        if (x1 > x2 | x2 < 0)
+                        if (x1 > x2 || x2 < 0)
                             goto mtri1t_donerow; // no more to do
                     } else {
                         if (no_edge_overlap) {
                             x2 = x2 - 1;
-                            if (x1 > x2 | x2 < 0)
+                            if (x1 > x2 || x2 < 0)
                                 goto mtri1t_donerow; // no more to do
                         }
                     }
@@ -1028,7 +1028,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                 else
                     x2 = g2x / 65536;
 
-                if (x1 >= dwidth | x2 < 0)
+                if (x1 >= dwidth || x2 < 0)
                     goto mtri1_donerow; // crop if(entirely offscreen
 
                 tx = g1tx;
@@ -1051,8 +1051,8 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                                                 // values
                 roff = ((g2x & 65535) - 32768);
 
-                if (roff < 0) {                               // not enough of rhs pixel exists to use
-                    if (x2 < dwidth & no_edge_overlap == 0) { // onscreen check
+                if (roff < 0) {                                // not enough of rhs pixel exists to use
+                    if (x2 < dwidth && no_edge_overlap == 0) { // onscreen check
                         // draw rhs pixel as is
                         //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                         *(dst_offset32 + (y * dwidth + x2)) = src_offset32[(g2ty >> 16) * swidth + (g2tx >> 16)];
@@ -1060,12 +1060,12 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                     }
                     // move left one position
                     x2--;
-                    if (x1 > x2 | x2 < 0)
+                    if (x1 > x2 || x2 < 0)
                         goto mtri1_donerow; // no more to do
                 } else {
                     if (no_edge_overlap) {
                         x2 = x2 - 1;
-                        if (x1 > x2 | x2 < 0)
+                        if (x1 > x2 || x2 < 0)
                             goto mtri1_donerow; // no more to do
                     }
                 }
@@ -1271,7 +1271,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                     else
                         x2 = g2x / 65536;
 
-                    if (x1 >= dwidth | x2 < 0)
+                    if (x1 >= dwidth || x2 < 0)
                         goto mtri2t_donerow; // crop if(entirely offscreen
 
                     tx = g1tx;
@@ -1294,8 +1294,8 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                                                     // values
                     roff = ((g2x & 65535) - 32768);
 
-                    if (roff < 0) {                               // not enough of rhs pixel exists to use
-                        if (x2 < dwidth & no_edge_overlap == 0) { // onscreen check
+                    if (roff < 0) {                                // not enough of rhs pixel exists to use
+                        if (x2 < dwidth && no_edge_overlap == 0) { // onscreen check
                             // draw rhs pixel as is
                             //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                             pixel_offset32 = dst_offset32 + (y * dwidth + x2);
@@ -1324,12 +1324,12 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                         }
                         // move left one position
                         x2--;
-                        if (x1 > x2 | x2 < 0)
+                        if (x1 > x2 || x2 < 0)
                             goto mtri2t_donerow; // no more to do
                     } else {
                         if (no_edge_overlap) {
                             x2 = x2 - 1;
-                            if (x1 > x2 | x2 < 0)
+                            if (x1 > x2 || x2 < 0)
                                 goto mtri2t_donerow; // no more to do
                         }
                     }
@@ -1575,7 +1575,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                 else
                     x2 = g2x / 65536;
 
-                if (x1 >= dwidth | x2 < 0)
+                if (x1 >= dwidth || x2 < 0)
                     goto mtri2_donerow; // crop if(entirely offscreen
 
                 tx = g1tx;
@@ -1598,8 +1598,8 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                                                 // values
                 roff = ((g2x & 65535) - 32768);
 
-                if (roff < 0) {                               // not enough of rhs pixel exists to use
-                    if (x2 < dwidth & no_edge_overlap == 0) { // onscreen check
+                if (roff < 0) {                                // not enough of rhs pixel exists to use
+                    if (x2 < dwidth && no_edge_overlap == 0) { // onscreen check
                         // draw rhs pixel as is
                         //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                         pixel_offset32 = dst_offset32 + (y * dwidth + x2);
@@ -1627,12 +1627,12 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                     }
                     // move left one position
                     x2--;
-                    if (x1 > x2 | x2 < 0)
+                    if (x1 > x2 || x2 < 0)
                         goto mtri2_donerow; // no more to do
                 } else {
                     if (no_edge_overlap) {
                         x2 = x2 - 1;
-                        if (x1 > x2 | x2 < 0)
+                        if (x1 > x2 || x2 < 0)
                             goto mtri2_donerow; // no more to do
                     }
                 }
@@ -1777,7 +1777,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
     // assume 1 byte per pixel
     dst_offset = dst->offset;
     src_offset = src->offset;
-    transparent_color = src->transparent_color;
+    auto transparent_color = src->transparent_color;
     if (transparent_color == -1) {
         if (tile) {
 
@@ -1885,7 +1885,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                 else
                     x2 = g2x / 65536;
 
-                if (x1 >= dwidth | x2 < 0)
+                if (x1 >= dwidth || x2 < 0)
                     goto mtri3t_donerow; // crop if(entirely offscreen
 
                 tx = g1tx;
@@ -1908,8 +1908,8 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                                                 // values
                 roff = ((g2x & 65535) - 32768);
 
-                if (roff < 0) {                               // not enough of rhs pixel exists to use
-                    if (x2 < dwidth & no_edge_overlap == 0) { // onscreen check
+                if (roff < 0) {                                // not enough of rhs pixel exists to use
+                    if (x2 < dwidth && no_edge_overlap == 0) { // onscreen check
                         // draw rhs pixel as is
                         //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                         *(dst_offset + (y * dwidth + x2)) = src_offset[((g2ty >> 16) % sheight) * swidth + ((g2tx >> 16) % swidth)];
@@ -1917,12 +1917,12 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                     }
                     // move left one position
                     x2--;
-                    if (x1 > x2 | x2 < 0)
+                    if (x1 > x2 || x2 < 0)
                         goto mtri3t_donerow; // no more to do
                 } else {
                     if (no_edge_overlap) {
                         x2 = x2 - 1;
-                        if (x1 > x2 | x2 < 0)
+                        if (x1 > x2 || x2 < 0)
                             goto mtri3t_donerow; // no more to do
                     }
                 }
@@ -2127,7 +2127,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
             else
                 x2 = g2x / 65536;
 
-            if (x1 >= dwidth | x2 < 0)
+            if (x1 >= dwidth || x2 < 0)
                 goto mtri3_donerow; // crop if(entirely offscreen
 
             tx = g1tx;
@@ -2150,8 +2150,8 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                                             // values
             roff = ((g2x & 65535) - 32768);
 
-            if (roff < 0) {                               // not enough of rhs pixel exists to use
-                if (x2 < dwidth & no_edge_overlap == 0) { // onscreen check
+            if (roff < 0) {                                // not enough of rhs pixel exists to use
+                if (x2 < dwidth && no_edge_overlap == 0) { // onscreen check
                     // draw rhs pixel as is
                     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                     *(dst_offset + (y * dwidth + x2)) = src_offset[(g2ty >> 16) * swidth + (g2tx >> 16)];
@@ -2159,12 +2159,12 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                 }
                 // move left one position
                 x2--;
-                if (x1 > x2 | x2 < 0)
+                if (x1 > x2 || x2 < 0)
                     goto mtri3_donerow; // no more to do
             } else {
                 if (no_edge_overlap) {
                     x2 = x2 - 1;
-                    if (x1 > x2 | x2 < 0)
+                    if (x1 > x2 || x2 < 0)
                         goto mtri3_donerow; // no more to do
                 }
             }
@@ -2370,7 +2370,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                 else
                     x2 = g2x / 65536;
 
-                if (x1 >= dwidth | x2 < 0)
+                if (x1 >= dwidth || x2 < 0)
                     goto mtri4t_donerow; // crop if(entirely offscreen
 
                 tx = g1tx;
@@ -2393,23 +2393,23 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                                                 // values
                 roff = ((g2x & 65535) - 32768);
 
-                if (roff < 0) {                               // not enough of rhs pixel exists to use
-                    if (x2 < dwidth & no_edge_overlap == 0) { // onscreen check
+                if (roff < 0) {                                // not enough of rhs pixel exists to use
+                    if (x2 < dwidth && no_edge_overlap == 0) { // onscreen check
                         // draw rhs pixel as is
                         //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                         col = src_offset[((g2ty >> 16) % sheight) * swidth + ((g2tx >> 16) % swidth)];
-                        if (col != transparent_color)
+                        if (col != uint32_t(transparent_color))
                             *(dst_offset + (y * dwidth + x2)) = col;
                         //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                     }
                     // move left one position
                     x2--;
-                    if (x1 > x2 | x2 < 0)
+                    if (x1 > x2 || x2 < 0)
                         goto mtri4t_donerow; // no more to do
                 } else {
                     if (no_edge_overlap) {
                         x2 = x2 - 1;
-                        if (x1 > x2 | x2 < 0)
+                        if (x1 > x2 || x2 < 0)
                             goto mtri4t_donerow; // no more to do
                     }
                 }
@@ -2419,7 +2419,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                     if (x1 >= 0) {
                         //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                         col = src_offset[((ty >> 16) % sheight) * swidth + ((tx >> 16) % swidth)];
-                        if (col != transparent_color)
+                        if (col != uint32_t(transparent_color))
                             *(dst_offset + (y * dwidth + x1)) = col;
                         //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                     }
@@ -2458,7 +2458,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
 
                     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                     col = src_offset[((ty >> 16) % sheight) * swidth + ((tx >> 16) % swidth)];
-                    if (col != transparent_color)
+                    if (col != uint32_t(transparent_color))
                         *pixel_offset = col;
                     pixel_offset++;
                     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
@@ -2619,7 +2619,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
             else
                 x2 = g2x / 65536;
 
-            if (x1 >= dwidth | x2 < 0)
+            if (x1 >= dwidth || x2 < 0)
                 goto mtri4_donerow; // crop if(entirely offscreen
 
             tx = g1tx;
@@ -2642,23 +2642,23 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                                             // values
             roff = ((g2x & 65535) - 32768);
 
-            if (roff < 0) {                               // not enough of rhs pixel exists to use
-                if (x2 < dwidth & no_edge_overlap == 0) { // onscreen check
+            if (roff < 0) {                                // not enough of rhs pixel exists to use
+                if (x2 < dwidth && no_edge_overlap == 0) { // onscreen check
                     // draw rhs pixel as is
                     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                     col = src_offset[(g2ty >> 16) * swidth + (g2tx >> 16)];
-                    if (col != transparent_color)
+                    if (col != uint32_t(transparent_color))
                         *(dst_offset + (y * dwidth + x2)) = col;
                     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                 }
                 // move left one position
                 x2--;
-                if (x1 > x2 | x2 < 0)
+                if (x1 > x2 || x2 < 0)
                     goto mtri4_donerow; // no more to do
             } else {
                 if (no_edge_overlap) {
                     x2 = x2 - 1;
-                    if (x1 > x2 | x2 < 0)
+                    if (x1 > x2 || x2 < 0)
                         goto mtri4_donerow; // no more to do
                 }
             }
@@ -2668,7 +2668,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
                 if (x1 >= 0) {
                     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                     col = src_offset[(ty >> 16) * swidth + (tx >> 16)];
-                    if (col != transparent_color)
+                    if (col != uint32_t(transparent_color))
                         *(dst_offset + (y * dwidth + x1)) = col;
                     //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                 }
@@ -2707,7 +2707,7 @@ void sub__maptriangle(int32_t cull_options, float sx1, float sy1, float sx2, flo
 
                 //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
                 col = src_offset[(ty >> 16) * swidth + (tx >> 16)];
-                if (col != transparent_color)
+                if (col != uint32_t(transparent_color))
                     *pixel_offset = col;
                 pixel_offset++;
                 //<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<

--- a/internal/c/libqb/src/mac-mouse-support.cpp
+++ b/internal/c/libqb/src/mac-mouse-support.cpp
@@ -75,3 +75,7 @@ void macMouseUpdatePosition(int x, int y) {
     g_MouseX.store(x, std::memory_order_relaxed);
     g_MouseY.store(y, std::memory_order_relaxed);
 }
+
+void macMouseAssociateMouseAndMouseCursorPosition(bool connected) {
+    CGAssociateMouseAndMouseCursorPosition(boolean_t(connected));
+}


### PR DESCRIPTION
This PR fixes a bug on macOS where mouse events are suppressed for 0.25 seconds when `_MOUSEMOVE` is used. The issue is resolved by calling `CGAssociateMouseAndMouseCursorPosition()`. Note that the event suppression bypass only happens when the mouse is hidden.

Additionally, as discussed on Discord, this PR prevents `_FULLPATH$` from throwing an error when an empty string is passed.