### PR TITLE
Fix Makefile escaping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -429,7 +429,7 @@ clean: $(CLEAN_DEP_LIST)
 
 ifeq ($(GENERATE_LICENSE),y)
 LICENSE_FILES := $(patsubst %,licenses/license_%.txt,$(LICENSE_IN_USE))
-LICENSE_DEP := $(LICENSE)
+LICENSE_DEP := license
 endif
 
 # Special care has to be taken for EXE because it is the user-supplied
@@ -444,12 +444,13 @@ ifneq ($(STRIP_SYMBOLS),n)
 endif
 endif
 
-$(LICENSE): $(LICENSE_FILES)
+.PHONY: license
+license: $(LICENSE_FILES)
 ifeq ($(GENERATE_LICENSE),y)
 ifeq ($(OS),win)
-	type $(call FIXPATH,$^) > "$@"
+	type $(call FIXPATH,$^) > $(call ADDQUOTES,$(call ESCAPENAME,$(LICENSE)))
 else
-	cat $^ > "$@"
+	cat $^ > $(call ADDQUOTES,$(call ESCAPENAME,$(LICENSE)))
 endif
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,8 @@ ifeq ($(OS),lnx)
 	MKDIR := mkdir -p
 	OBJCOPY := objcopy
 	FIXPATH = $1
+	ESCAPENAME = $(subst ','\'',$1)
+	ADDQUOTES = '$1'
 	PLATFORM := posix
 	EXTENSION :=
 
@@ -72,6 +74,8 @@ ifeq ($(OS),win)
 	RM := del /Q
 	MKDIR := mkdir
 	FIXPATH = $(subst /,\,$1)
+	ESCAPENAME = $1
+	ADDQUOTES = "$1"
 	PLATFORM := windows
 	EXTENSION := .exe
 
@@ -96,6 +100,8 @@ ifeq ($(OS),osx)
 	RM := rm -fr
 	MKDIR := mkdir -p
 	FIXPATH = $1
+	ESCAPENAME = $(subst ','\'',$1)
+	ADDQUOTES = '$1'
 	BITS := 64
 	PLATFORM := posix
 	EXTENSION :=
@@ -130,7 +136,8 @@ GENERATE_LICENSE ?= n
 LICENSE ?= $(EXE).license.txt
 LICENSE_IN_USE := qb64 tinyfiledialogs
 
-all: $(EXE)
+.PHONY: exe
+all: exe
 
 CLEAN_LIST :=
 CLEAN_DEP_LIST :=
@@ -425,12 +432,15 @@ LICENSE_FILES := $(patsubst %,licenses/license_%.txt,$(LICENSE_IN_USE))
 LICENSE_DEP := $(LICENSE)
 endif
 
-$(EXE): $(EXE_OBJS) $(EXE_LIBS) $(LICENSE_DEP)
-	$(CXX) $(CXXFLAGS) $(EXE_OBJS) -o "$@" $(EXE_LIBS) $(CXXLIBS)
+# Special care has to be taken for EXE because it is the user-supplied
+# executable name - it can contain any valid characters. We have to quote it
+# when passing it on the command-line and additionally have to escape the quote
+exe: $(EXE_OBJS) $(EXE_LIBS) $(LICENSE_DEP)
+	$(CXX) $(CXXFLAGS) $(EXE_OBJS) -o $(call ADDQUOTES,$(call ESCAPENAME,$(EXE))) $(EXE_LIBS) $(CXXLIBS)
 ifneq ($(filter-out osx,$(OS)),)
 ifneq ($(STRIP_SYMBOLS),n)
-	$(OBJCOPY) --only-keep-debug "$@" "$(PATH_INTERNAL_TEMP)/$(notdir $@).sym"
-	$(OBJCOPY) --strip-unneeded "$@"
+	$(OBJCOPY) --only-keep-debug $(call ADDQUOTES,$(call ESCAPENAME,$(EXE))) $(call ADDQUOTES,$(PATH_INTERNAL_TEMP)/$(notdir $(call ESCAPENAME,$(EXE))).sym)
+	$(OBJCOPY) --strip-unneeded $(call ADDQUOTES,$(call ESCAPENAME,$(EXE)))
 endif
 endif
 

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -12516,11 +12516,21 @@ CxxLibsExtra$ = CxxLibsExtra$ + " " + mylib$ + " " + mylibopt$
 
 ' Make and the shell don't like certain characters in the file name, so we
 ' escape them to get them to handle them properly
-escapedExe$ = StrReplace$(path.exe$ + file$ + extension$, " ", "\ ")
-escapedExe$ = StrReplace$(escapedExe$, CHR$(34), "\" + CHR$(34))
+escapedExe$ = path.exe$ + file$ + extension$
+
+' Make escaping
+escapedExe$ = StrReplace$(escapedExe$, _CHR_QUOTE, "\" + _CHR_QUOTE)
 escapedExe$ = StrReplace$(escapedExe$, "$", "$$")
 
-makeline$ = make$ + makedeps$ + " EXE=" + AddQuotes$(escapedExe$)
+IF os$ = "LNX" THEN
+    ' sh escaping
+    escapedExe$ = StrReplace$(escapedExe$, "'", "'\''")
+    escapedExe$ = "'" + escapedExe$ + "'"
+ELSE
+    escapedExe$ = _CHR_QUOTE + escapedExe$ + _CHR_QUOTE
+END IF
+
+makeline$ = make$ + makedeps$ + " EXE=" + escapedExe$
 makeline$ = makeline$ + " " + AddQuotes$("CXXFLAGS_EXTRA=" + CxxFlagsExtra$)
 makeline$ = makeline$ + " " + AddQuotes$("CFLAGS_EXTRA=" + CxxFlagsExtra$)
 makeline$ = makeline$ + " " + AddQuotes$("CXXLIBS_EXTRA=" + CxxLibsExtra$)

--- a/tests/compile_tests/dollar$sign$test/dollar$sign.bas
+++ b/tests/compile_tests/dollar$sign$test/dollar$sign.bas
@@ -1,0 +1,3 @@
+$console:only
+Print "Hello, World"
+System

--- a/tests/compile_tests/dollar$sign$test/dollar$sign.output
+++ b/tests/compile_tests/dollar$sign$test/dollar$sign.output
@@ -1,0 +1,1 @@
+Hello, World

--- a/tests/compile_tests/parens()/parens().bas
+++ b/tests/compile_tests/parens()/parens().bas
@@ -1,0 +1,3 @@
+$Console:Only
+Print "Hello, World"
+System

--- a/tests/compile_tests/parens()/parens().output
+++ b/tests/compile_tests/parens()/parens().output
@@ -1,0 +1,1 @@
+Hello, World


### PR DESCRIPTION
There were several problems identified with the existing escaping for calling `make` - parenthesis at the end would get lost, dollar signs got expanded incorrectly, etc.. This change redoes the escaping and applies it correctly depending on the platform for all three levels of escaping:

1. Makefile command and Shell invocation to run make:
  a. Mac OS and Linux use single quotes. Existing single quotes in the name are turned into `'\''` to escape them.
  b. Windows gets double quotes and no extra escaping.

3. make invocation:
  a. Quotes are escaped with `\"`, Dollar signs with `$$`