### PR TITLE
Image library enhancements

### DIFF
--- a/internal/c/parts/video/image/build.mk
+++ b/internal/c/parts/video/image/build.mk
@@ -14,7 +14,7 @@ IMAGE_SRCS := \
 IMAGE_OBJS := $(patsubst %.cpp,$(PATH_INTERNAL_C)/parts/video/image/%.o,$(IMAGE_SRCS))
 
 $(PATH_INTERNAL_C)/parts/video/image/%.o: $(PATH_INTERNAL_C)/parts/video/image/%.cpp
-	$(CXX) -O2 $(CXXFLAGS) -DDEPENDENCY_CONSOLE_ONLY -Wall $< -c -o $@
+	$(CXX) -O3 $(CXXFLAGS) -DDEPENDENCY_CONSOLE_ONLY -Wall $< -c -o $@
 
 IMAGE_LIB := $(PATH_INTERNAL_C)/parts/video/image/image.a
 

--- a/internal/c/parts/video/image/image.cpp
+++ b/internal/c/parts/video/image/image.cpp
@@ -46,11 +46,11 @@ extern const uint8_t charset8x8[256][8][8];   // used by func__saveimage
 extern const uint8_t charset8x16[256][16][8]; // used by func__saveimage
 
 /// @brief Pixel scaler algorithms
-enum class ImageScaler { NONE = 0, SXBR2, MMPX2, HQ2XA, HQ2XB, HQ3XA, HQ3XB };
+enum class ImageScaler { NONE = 0, SXBR2, SXBR3, SXBR4, MMPX2, HQ2XA, HQ2XB, HQ3XA, HQ3XB };
 /// @brief This is the scaling factors for ImageScaler enum
-static const int g_ImageScaleFactor[] = {1, 2, 2, 2, 2, 3, 3};
+static const int g_ImageScaleFactor[] = {1, 2, 3, 4, 2, 2, 2, 3, 3};
 /// @brief Pixel scaler names for ImageScaler enum
-static const char *g_ImageScalerName[] = {"NONE", "SXBR2", "MMPX2", "HQ2XA", "HQ2XB", "HQ3XA", "HQ3XB"};
+static const char *g_ImageScalerName[] = {"NONE", "SXBR2", "SXBR3", "SXBR4", "MMPX2", "HQ2XA", "HQ2XB", "HQ3XA", "HQ3XB"};
 
 /// @brief Runs a pixel scaler algorithm on raw image pixels. It will free 'data' if scaling occurs!
 /// @param data In + Out: The source raw image data in RGBA format
@@ -70,6 +70,14 @@ static uint32_t *image_scale(uint32_t *data, int32_t *xOut, int32_t *yOut, Image
             switch (scaler) {
             case ImageScaler::SXBR2:
                 scaleSuperXBR2(data, *xOut, *yOut, pixels);
+                break;
+
+            case ImageScaler::SXBR3:
+                scaleSuperXBR3(data, *xOut, *yOut, pixels);
+                break;
+
+            case ImageScaler::SXBR4:
+                scaleSuperXBR4(data, *xOut, *yOut, pixels);
                 break;
 
             case ImageScaler::MMPX2:

--- a/internal/c/parts/video/image/image.cpp
+++ b/internal/c/parts/video/image/image.cpp
@@ -60,8 +60,8 @@ static const char *g_ImageScalerName[] = {"NONE", "SXBR2", "SXBR3", "SXBR4", "MM
 /// @return A pointer to the scaled image or 'data' if there is no change
 static uint32_t *image_scale(uint32_t *data, int32_t *xOut, int32_t *yOut, ImageScaler scaler) {
     if (scaler > ImageScaler::NONE) {
-        auto newX = *xOut * g_ImageScaleFactor[(int)(scaler)];
-        auto newY = *yOut * g_ImageScaleFactor[(int)(scaler)];
+        auto newX = *xOut * g_ImageScaleFactor[size_t(scaler)];
+        auto newY = *yOut * g_ImageScaleFactor[size_t(scaler)];
 
         auto pixels = (uint32_t *)malloc(sizeof(uint32_t) * newX * newY);
         if (pixels) {
@@ -131,8 +131,8 @@ static uint32_t *image_svg_load(NSVGimage *image, int32_t *xOut, int32_t *yOut, 
         return nullptr;
     }
 
-    auto w = (int32_t)image->width * g_ImageScaleFactor[(int)(scaler)];
-    auto h = (int32_t)image->height * g_ImageScaleFactor[(int)(scaler)];
+    auto w = (int32_t)image->width * g_ImageScaleFactor[size_t(scaler)];
+    auto h = (int32_t)image->height * g_ImageScaleFactor[size_t(scaler)];
 
     auto pixels = (uint32_t *)malloc(sizeof(uint32_t) * w * h);
     if (!pixels) {
@@ -141,7 +141,7 @@ static uint32_t *image_svg_load(NSVGimage *image, int32_t *xOut, int32_t *yOut, 
         return nullptr;
     }
 
-    nsvgRasterize(rast, image, 0, 0, g_ImageScaleFactor[(int)(scaler)], reinterpret_cast<unsigned char *>(pixels), w, h, sizeof(uint32_t) * w);
+    nsvgRasterize(rast, image, 0, 0, g_ImageScaleFactor[size_t(scaler)], reinterpret_cast<unsigned char *>(pixels), w, h, sizeof(uint32_t) * w);
     nsvgDeleteRasterizer(rast);
     nsvgDelete(image);
 
@@ -187,7 +187,7 @@ static uint32_t *image_svg_load_from_file(const char *fileName, int32_t *xOut, i
         return nullptr;
     }
 
-    if (fread(svgString, 1, size, fp) != size) {
+    if (long(fread(svgString, sizeof(uint8_t), size, fp)) != size) {
         free(svgString);
         fclose(fp);
         return nullptr;
@@ -459,7 +459,7 @@ static uint8_t *image_extract_8bpp(const uint32_t *src, int32_t w, int32_t h, ui
 
     auto uniqueColors = 0; // as long as this is < 256 we will keep going until we are done
     size_t size = w * h;
-    for (auto i = 0; i < size; i++) {
+    for (size_t i = 0; i < size; i++) {
         auto srcColor = src[i]; // get the 32bpp pixel
 
         // Check if the src color exists in our palette
@@ -587,11 +587,11 @@ int32_t func__loadimage(qbs *qbsFileName, int32_t bpp, qbs *qbsRequirements, int
         }
 
         // Parse scaler string
-        for (auto i = 0; i < _countof(g_ImageScalerName); i++) {
+        for (size_t i = 0; i < _countof(g_ImageScalerName); i++) {
             image_log_info("Checking for: %s", g_ImageScalerName[i]);
             if (requirements.find(g_ImageScalerName[i]) != std::string::npos) {
                 scaler = (ImageScaler)i;
-                image_log_info("%s scaler selected", g_ImageScalerName[(int)scaler]);
+                image_log_info("%s scaler selected", g_ImageScalerName[size_t(scaler)]);
                 break;
             }
         }
@@ -612,7 +612,7 @@ int32_t func__loadimage(qbs *qbsFileName, int32_t bpp, qbs *qbsRequirements, int
 
     // Convert RGBA to BGRA
     size_t size = x * y;
-    for (auto i = 0; i < size; i++)
+    for (size_t i = 0; i < size; i++)
         pixels[i] = image_swap_red_blue(pixels[i]);
 
     int32_t i; // Image handle to be returned
@@ -756,17 +756,17 @@ void sub__saveimage(qbs *qbsFileName, int32_t imageHandle, qbs *qbsRequirements,
 
         image_log_info("Parsing requirements string: %s", requirements.c_str());
 
-        for (auto i = 0; i < _countof(formatName); i++) {
+        for (size_t i = 0; i < _countof(formatName); i++) {
             image_log_info("Checking for: %s", formatName[i]);
             if (requirements.find(formatName[i]) != std::string::npos) {
                 format = (SaveFormat)i;
-                image_log_info("Found: %s", formatName[(int)format]);
+                image_log_info("Found: %s", formatName[size_t(format)]);
                 break;
             }
         }
     }
 
-    image_log_info("Format selected: %s", formatName[(int)format]);
+    image_log_info("Format selected: %s", formatName[size_t(format)]);
 
     std::string fileName(reinterpret_cast<char *>(qbsFileName->chr), qbsFileName->len);
     filepath_fix_directory(fileName);
@@ -778,7 +778,7 @@ void sub__saveimage(qbs *qbsFileName, int32_t imageHandle, qbs *qbsRequirements,
 
         image_log_info("File extension: %s", fileExtension.c_str());
 
-        int i;
+        size_t i;
         for (i = 0; i < _countof(formatName); i++) {
             std::string formatExtension;
 
@@ -790,23 +790,23 @@ void sub__saveimage(qbs *qbsFileName, int32_t imageHandle, qbs *qbsRequirements,
             if (fileExtension == formatExtension) {
                 image_log_info("Extension (%s) matches with format %i", formatExtension.c_str(), i);
                 format = (SaveFormat)i;
-                image_log_info("Format selected by extension: %s", formatName[(int)format]);
+                image_log_info("Format selected by extension: %s", formatName[size_t(format)]);
                 break;
             }
         }
 
         if (i >= _countof(formatName)) { // no matches
-            image_log_info("No matching extension. Adding .%s", formatName[(int)format]);
+            image_log_info("No matching extension. Adding .%s", formatName[size_t(format)]);
 
             fileName.append(".");
-            fileName.append(formatName[(int)format]);
+            fileName.append(formatName[size_t(format)]);
         }
     } else {
         // Simply add the selected format's extension
-        image_log_info("Adding extension: .%s", formatName[(int)format]);
+        image_log_info("Adding extension: .%s", formatName[size_t(format)]);
 
         fileName.append(".");
-        fileName.append(formatName[(int)format]);
+        fileName.append(formatName[size_t(format)]);
     }
 
     // This will hold our raw RGBA pixel data
@@ -886,7 +886,7 @@ void sub__saveimage(qbs *qbsFileName, int32_t imageHandle, qbs *qbsRequirements,
         }
     }
 
-    image_log_info("Saving to: %s (%i x %i), %llu pixels, %s", fileName.c_str(), width, height, pixels.size(), formatName[(int)format]);
+    image_log_info("Saving to: %s (%i x %i), %llu pixels, %s", fileName.c_str(), width, height, pixels.size(), formatName[size_t(format)]);
 
     switch (format) {
     case SaveFormat::PNG: {

--- a/internal/c/parts/video/image/nanosvg/nanosvg.h
+++ b/internal/c/parts/video/image/nanosvg/nanosvg.h
@@ -1265,7 +1265,7 @@ static unsigned int nsvg__parseColorRGB(const char* str)
 				while (*str && nsvg__isdigit(*str)) str++;	// skip fractional part
 			}
 			if (*str == '%') str++; else break;
-			while (nsvg__isspace(*str)) str++;
+			while (*str && nsvg__isspace(*str)) str++;
 			if (*str == delimiter[i]) str++;
 			else break;
 		}

--- a/internal/c/parts/video/image/pixelscalers/hqx.cpp
+++ b/internal/c/parts/video/image/pixelscalers/hqx.cpp
@@ -140,17 +140,15 @@ static const uint32_t HQX_VMASK = 0x000000FF;
 // All hq-related fcts used to be member fcts of otherwise empty classes.
 // Turned into stand-alone fcts.
 
-static inline uint32_t ARGBtoAYUV(uint32_t value) {
-    uint32_t A, R, G, B, Y, U, V;
+static inline constexpr uint32_t ARGBtoAYUV(uint32_t value) {
+    uint32_t A = value >> 24;
+    uint32_t R = (value >> 16) & 0xFF;
+    uint32_t G = (value >> 8) & 0xFF;
+    uint32_t B = value & 0xFF;
 
-    A = value >> 24;
-    R = (value >> 16) & 0xFF;
-    G = (value >> 8) & 0xFF;
-    B = value & 0xFF;
-
-    Y = (uint32_t)(0.299 * R + 0.587 * G + 0.114 * B);
-    U = (uint32_t)(-0.169 * R - 0.331 * G + 0.5 * B) + 128;
-    V = (uint32_t)(0.5 * R - 0.419 * G - 0.081 * B) + 128;
+    uint32_t Y = (uint32_t)(0.299 * R + 0.587 * G + 0.114 * B);
+    uint32_t U = (uint32_t)(-0.169 * R - 0.331 * G + 0.5 * B) + 128;
+    uint32_t V = (uint32_t)(0.5 * R - 0.419 * G - 0.081 * B) + 128;
     return (A << 24) + (Y << 16) + (U << 8) + V;
 }
 

--- a/internal/c/parts/video/image/pixelscalers/mmpx.cpp
+++ b/internal/c/parts/video/image/pixelscalers/mmpx.cpp
@@ -4,40 +4,37 @@
     https://casual-effects.com/research/McGuire2021PixelArt/index.html
 */
 
+#include <algorithm>
 #include <cstdbool>
 #include <cstdint>
 
-static inline uint32_t luma(uint32_t color) {
+static inline constexpr uint32_t luma(uint32_t color) {
     const uint32_t alpha = (color & 0xFF000000) >> 24;
     return (((color & 0x00FF0000) >> 16) + ((color & 0x0000FF00) >> 8) + (color & 0x000000FF) + 1) * (256 - alpha);
 }
 
-static inline bool all_eq2(uint32_t B, uint32_t A0, uint32_t A1) {
+static inline constexpr bool all_eq2(uint32_t B, uint32_t A0, uint32_t A1) {
     return ((B ^ A0) | (B ^ A1)) == 0;
 }
 
-static inline bool all_eq3(uint32_t B, uint32_t A0, uint32_t A1, uint32_t A2) {
+static inline constexpr bool all_eq3(uint32_t B, uint32_t A0, uint32_t A1, uint32_t A2) {
     return ((B ^ A0) | (B ^ A1) | (B ^ A2)) == 0;
 }
 
-static inline bool all_eq4(uint32_t B, uint32_t A0, uint32_t A1, uint32_t A2, uint32_t A3) {
+static inline constexpr bool all_eq4(uint32_t B, uint32_t A0, uint32_t A1, uint32_t A2, uint32_t A3) {
     return ((B ^ A0) | (B ^ A1) | (B ^ A2) | (B ^ A3)) == 0;
 }
 
-static inline bool any_eq3(uint32_t B, uint32_t A0, uint32_t A1, uint32_t A2) {
+static inline constexpr bool any_eq3(uint32_t B, uint32_t A0, uint32_t A1, uint32_t A2) {
     return B == A0 || B == A1 || B == A2;
 }
 
-static inline bool none_eq2(uint32_t B, uint32_t A0, uint32_t A1) {
+static inline constexpr bool none_eq2(uint32_t B, uint32_t A0, uint32_t A1) {
     return (B != A0) && (B != A1);
 }
 
-static inline bool none_eq4(uint32_t B, uint32_t A0, uint32_t A1, uint32_t A2, uint32_t A3) {
+static inline constexpr bool none_eq4(uint32_t B, uint32_t A0, uint32_t A1, uint32_t A2, uint32_t A3) {
     return B != A0 && B != A1 && B != A2 && B != A3;
-}
-
-static inline int mmpx_clamp(int v, int min, int max) {
-    return v < min ? min : min > max ? max : v;
 }
 
 struct Meta {
@@ -51,8 +48,8 @@ struct Meta {
 static inline uint32_t src(const struct Meta *meta, int x, int y) {
     // Clamp to border
     if ((uint32_t)x > (uint32_t)meta->srcMaxX || (uint32_t)y > (uint32_t)meta->srcMaxY) {
-        x = mmpx_clamp(x, 0, meta->srcMaxX);
-        y = mmpx_clamp(y, 0, meta->srcMaxY);
+        x = std::clamp<int>(x, 0, meta->srcMaxX);
+        y = std::clamp<int>(y, 0, meta->srcMaxY);
     }
 
     return meta->srcBuffer[y * meta->srcWidth + x];

--- a/internal/c/parts/video/image/pixelscalers/pixelscalers.h
+++ b/internal/c/parts/video/image/pixelscalers/pixelscalers.h
@@ -8,3 +8,5 @@ void hq3xA(uint32_t *img, int w, int h, uint32_t *out);
 void hq3xB(uint32_t *img, int w, int h, uint32_t *out);
 void mmpx_scale2x(const uint32_t *srcBuffer, uint32_t *dst, uint32_t srcWidth, uint32_t srcHeight);
 void scaleSuperXBR2(uint32_t *data, int w, int h, uint32_t *out);
+void scaleSuperXBR3(uint32_t *data, int w, int h, uint32_t *out);
+void scaleSuperXBR4(uint32_t *data, int w, int h, uint32_t *out);

--- a/internal/c/parts/video/image/pixelscalers/sxbr.cpp
+++ b/internal/c/parts/video/image/pixelscalers/sxbr.cpp
@@ -1,398 +1,744 @@
-/*
+/*****************************************************************************************************\
+* This is a re-implementation of the XBRZ pixel scaler for QB64-PE in C.
+*
+* Bibliography:
+* https://sourceforge.net/projects/xbrz/
+* https://intrepidis.blogspot.com/2014/02/xbrz-in-java.html
+* https://github.com/MiYanni/xBRZ.NET
+* https://github.com/will-wyx/xbrz
+* https://github.com/stanio/xbrz-java
+* https://github.com/daelsepara/PixelFilterJS
+* https://github.com/EasingSoft/UltraScaler
+\*****************************************************************************************************/
 
-Copyright (c) 2016 Hyllian - sergiogdb@gmail.com
+#include <limits.h>
+#include <math.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+typedef struct ScalerCfg {
+    double luminanceWeight;
+    double equalColorTolerance;
+    double centerDirectionBias;
+    double dominantDirectionThreshold;
+    double steepDirectionThreshold;
+} ScalerCfg;
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+static const ScalerCfg default_scaler_cfg = {
+    .luminanceWeight = 1.0, .equalColorTolerance = 30.0, .centerDirectionBias = 4.0, .dominantDirectionThreshold = 3.6, .steepDirectionThreshold = 2.2};
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-
-Adapted from
-    https://pastebin.com/cbH8ZQQT
-and mated to a driver based on
-    https://github.com/brunexgeek/hqx
-by Philipp K. Janert, September 2022
-
-*/
-
-//// *** Super-xBR code begins here - MIT LICENSE *** ///
-
-// PKJ:
-#include <algorithm>
-#include <cmath>
-#include <cstdint>
-
-#define u32 uint32_t
-
-#define R(_col) ((_col >> 0) & 0xFF)
-#define G(_col) ((_col >> 8) & 0xFF)
-#define B(_col) ((_col >> 16) & 0xFF)
-#define A(_col) ((_col >> 24) & 0xFF)
-
-#define wgt1 0.129633f
-#define wgt2 0.175068f
-#define w1 (-wgt1)
-#define w2 (wgt1 + 0.5f)
-#define w3 (-wgt2)
-#define w4 (wgt2 + 0.5f)
-
-static inline float sxbr_df(float A, float B) {
-    return abs(A - B);
+static inline uint8_t getAlpha(uint32_t pix) {
+    return (uint8_t)(pix >> 24);
 }
 
-static inline constexpr float min4(float a, float b, float c, float d) {
-    return std::min(std::min(a, b), std::min(c, d));
+static inline uint8_t getRed(uint32_t pix) {
+    return (uint8_t)((pix >> 16) & 0xFFu);
 }
 
-static inline constexpr float max4(float a, float b, float c, float d) {
-    return std::max(std::max(a, b), std::max(c, d));
+static inline uint8_t getGreen(uint32_t pix) {
+    return (uint8_t)((pix >> 8) & 0xFFu);
 }
 
-/*
-                         P1
-|P0|B |C |P1|         C     F4          |a0|b1|c2|d3|
-|D |E |F |F4|      B     F     I4       |b0|c1|d2|e3|   |e1|i1|i2|e2|
-|G |H |I |I4|   P0    E  A  I     P3    |c0|d1|e2|f3|   |e3|i3|i4|e4|
-|P2|H5|I5|P3|      D     H     I5       |d0|e1|f2|g3|
-                      G     H5
-                         P2
-
-sx, sy
--1  -1 | -2  0   (x+y) (x-y)    -3  1  (x+y-1)  (x-y+1)
--1   0 | -1 -1                  -2  0
--1   1 |  0 -2                  -1 -1
--1   2 |  1 -3                   0 -2
-
- 0  -1 | -1  1   (x+y) (x-y)      ...     ...     ...
- 0   0 |  0  0
- 0   1 |  1 -1
- 0   2 |  2 -2
-
- 1  -1 |  0  2   ...
- 1   0 |  1  1
- 1   1 |  2  0
- 1   2 |  3 -1
-
- 2  -1 |  1  3   ...
- 2   0 |  2  2
- 2   1 |  3  1
- 2   2 |  4  0
-
-
-*/
-
-static inline float diagonal_edge(float mat[][4], float *wp) {
-    float dw1 = wp[0] * (sxbr_df(mat[0][2], mat[1][1]) + sxbr_df(mat[1][1], mat[2][0]) + sxbr_df(mat[1][3], mat[2][2]) + sxbr_df(mat[2][2], mat[3][1])) +
-                wp[1] * (sxbr_df(mat[0][3], mat[1][2]) + sxbr_df(mat[2][1], mat[3][0])) +
-                wp[2] * (sxbr_df(mat[0][3], mat[2][1]) + sxbr_df(mat[1][2], mat[3][0])) + wp[3] * sxbr_df(mat[1][2], mat[2][1]) +
-                wp[4] * (sxbr_df(mat[0][2], mat[2][0]) + sxbr_df(mat[1][3], mat[3][1])) +
-                wp[5] * (sxbr_df(mat[0][1], mat[1][0]) + sxbr_df(mat[2][3], mat[3][2]));
-
-    float dw2 = wp[0] * (sxbr_df(mat[0][1], mat[1][2]) + sxbr_df(mat[1][2], mat[2][3]) + sxbr_df(mat[1][0], mat[2][1]) + sxbr_df(mat[2][1], mat[3][2])) +
-                wp[1] * (sxbr_df(mat[0][0], mat[1][1]) + sxbr_df(mat[2][2], mat[3][3])) +
-                wp[2] * (sxbr_df(mat[0][0], mat[2][2]) + sxbr_df(mat[1][1], mat[3][3])) + wp[3] * sxbr_df(mat[1][1], mat[2][2]) +
-                wp[4] * (sxbr_df(mat[1][0], mat[3][2]) + sxbr_df(mat[0][1], mat[2][3])) +
-                wp[5] * (sxbr_df(mat[0][2], mat[1][3]) + sxbr_df(mat[2][0], mat[3][1]));
-
-    return (dw1 - dw2);
+static inline uint8_t getBlue(uint32_t pix) {
+    return (uint8_t)(pix & 0xFFu);
 }
 
-// Not used yet...
-static inline float cross_edge(float mat[][4], float *wp) {
-    float hvw1 = wp[3] * (sxbr_df(mat[1][1], mat[2][1]) + sxbr_df(mat[1][2], mat[2][2])) +
-                 wp[0] * (sxbr_df(mat[0][1], mat[1][1]) + sxbr_df(mat[2][1], mat[3][1]) + sxbr_df(mat[0][2], mat[1][2]) + sxbr_df(mat[2][2], mat[3][2])) +
-                 wp[2] * (sxbr_df(mat[0][1], mat[2][1]) + sxbr_df(mat[1][1], mat[3][1]) + sxbr_df(mat[0][2], mat[2][2]) + sxbr_df(mat[1][2], mat[3][2]));
-
-    float hvw2 = wp[3] * (sxbr_df(mat[1][1], mat[1][2]) + sxbr_df(mat[2][1], mat[2][2])) +
-                 wp[0] * (sxbr_df(mat[1][0], mat[1][1]) + sxbr_df(mat[2][0], mat[2][1]) + sxbr_df(mat[1][2], mat[1][3]) + sxbr_df(mat[2][2], mat[2][3])) +
-                 wp[2] * (sxbr_df(mat[1][0], mat[1][2]) + sxbr_df(mat[1][1], mat[1][3]) + sxbr_df(mat[2][0], mat[2][2]) + sxbr_df(mat[2][1], mat[2][3]));
-
-    return (hvw1 - hvw2);
+static inline uint32_t makePixel(uint8_t a, uint8_t r, uint8_t g, uint8_t b) {
+    return (uint32_t)(a << 24 | r << 16 | g << 8 | b);
 }
 
-///////////////////////// Super-xBR scaling
-// perform super-xbr (fast shader version) scaling by factor f=2 only.
-template <int f> static void scaleSuperXBRT(u32 *data, u32 *out, int w, int h) {
-    int outw = w * f, outh = h * f;
+static inline void fillBlock(uint32_t *trg, int pitch, uint32_t col, int blockWidth, int blockHeight) {
+    int pitchWords = pitch >> 2;
 
-    float wp[6] = {2.0f, 1.0f, -1.0f, 4.0f, -1.0f, 1.0f};
-
-    // First Pass
-    for (int y = 0; y < outh; ++y) {
-        for (int x = 0; x < outw; ++x) {
-            float r[4][4], g[4][4], b[4][4], a[4][4], Y[4][4];
-            int cx = x / f, cy = y / f; // central pixels on original images
-            // sample supporting pixels in original image
-            for (int sx = -1; sx <= 2; ++sx) {
-                for (int sy = -1; sy <= 2; ++sy) {
-                    // clamp pixel locations
-                    int csy = std::clamp(sy + cy, 0, h - 1);
-                    int csx = std::clamp(sx + cx, 0, w - 1);
-                    // sample & add weighted components
-                    u32 sample = data[csy * w + csx];
-                    r[sx + 1][sy + 1] = (float)R(sample);
-                    g[sx + 1][sy + 1] = (float)G(sample);
-                    b[sx + 1][sy + 1] = (float)B(sample);
-                    a[sx + 1][sy + 1] = (float)A(sample);
-                    Y[sx + 1][sy + 1] = (float)(0.2126 * r[sx + 1][sy + 1] + 0.7152 * g[sx + 1][sy + 1] + 0.0722 * b[sx + 1][sy + 1]);
-                }
-            }
-            float min_r_sample = min4(r[1][1], r[2][1], r[1][2], r[2][2]);
-            float min_g_sample = min4(g[1][1], g[2][1], g[1][2], g[2][2]);
-            float min_b_sample = min4(b[1][1], b[2][1], b[1][2], b[2][2]);
-            float min_a_sample = min4(a[1][1], a[2][1], a[1][2], a[2][2]);
-            float max_r_sample = max4(r[1][1], r[2][1], r[1][2], r[2][2]);
-            float max_g_sample = max4(g[1][1], g[2][1], g[1][2], g[2][2]);
-            float max_b_sample = max4(b[1][1], b[2][1], b[1][2], b[2][2]);
-            float max_a_sample = max4(a[1][1], a[2][1], a[1][2], a[2][2]);
-            float d_edge = diagonal_edge(Y, &wp[0]);
-            float r1, g1, b1, a1, r2, g2, b2, a2, rf, gf, bf, af;
-            r1 = (float)w1 * (r[0][3] + r[3][0]) + (float)w2 * (r[1][2] + r[2][1]);
-            g1 = (float)w1 * (g[0][3] + g[3][0]) + (float)w2 * (g[1][2] + g[2][1]);
-            b1 = (float)w1 * (b[0][3] + b[3][0]) + (float)w2 * (b[1][2] + b[2][1]);
-            a1 = (float)w1 * (a[0][3] + a[3][0]) + (float)w2 * (a[1][2] + a[2][1]);
-            r2 = (float)w1 * (r[0][0] + r[3][3]) + (float)w2 * (r[1][1] + r[2][2]);
-            g2 = (float)w1 * (g[0][0] + g[3][3]) + (float)w2 * (g[1][1] + g[2][2]);
-            b2 = (float)w1 * (b[0][0] + b[3][3]) + (float)w2 * (b[1][1] + b[2][2]);
-            a2 = (float)w1 * (a[0][0] + a[3][3]) + (float)w2 * (a[1][1] + a[2][2]);
-            // generate and write result
-            if (d_edge <= 0.0f) {
-                rf = r1;
-                gf = g1;
-                bf = b1;
-                af = a1;
-            } else {
-                rf = r2;
-                gf = g2;
-                bf = b2;
-                af = a2;
-            }
-            // anti-ringing, clamp.
-            rf = std::clamp(rf, min_r_sample, max_r_sample);
-            gf = std::clamp(gf, min_g_sample, max_g_sample);
-            bf = std::clamp(bf, min_b_sample, max_b_sample);
-            af = std::clamp(af, min_a_sample, max_a_sample);
-            int ri = std::clamp(static_cast<int>(ceilf(rf)), 0, 255);
-            int gi = std::clamp(static_cast<int>(ceilf(gf)), 0, 255);
-            int bi = std::clamp(static_cast<int>(ceilf(bf)), 0, 255);
-            int ai = std::clamp(static_cast<int>(ceilf(af)), 0, 255);
-            out[y * outw + x] = out[y * outw + x + 1] = out[(y + 1) * outw + x] = data[cy * w + cx];
-            out[(y + 1) * outw + x + 1] = (ai << 24) | (bi << 16) | (gi << 8) | ri;
-            ++x;
-        }
-        ++y;
-    }
-
-    // Second Pass
-    wp[0] = 2.0f;
-    wp[1] = 0.0f;
-    wp[2] = 0.0f;
-    wp[3] = 0.0f;
-    wp[4] = 0.0f;
-    wp[5] = 0.0f;
-
-    for (int y = 0; y < outh; ++y) {
-        for (int x = 0; x < outw; ++x) {
-            float r[4][4], g[4][4], b[4][4], a[4][4], Y[4][4];
-            // sample supporting pixels in original image
-            for (int sx = -1; sx <= 2; ++sx) {
-                for (int sy = -1; sy <= 2; ++sy) {
-                    // clamp pixel locations
-                    int csy = std::clamp(sx - sy + y, 0, f * h - 1);
-                    int csx = std::clamp(sx + sy + x, 0, f * w - 1);
-                    // sample & add weighted components
-                    u32 sample = out[csy * outw + csx];
-                    r[sx + 1][sy + 1] = (float)R(sample);
-                    g[sx + 1][sy + 1] = (float)G(sample);
-                    b[sx + 1][sy + 1] = (float)B(sample);
-                    a[sx + 1][sy + 1] = (float)A(sample);
-                    Y[sx + 1][sy + 1] = (float)(0.2126 * r[sx + 1][sy + 1] + 0.7152 * g[sx + 1][sy + 1] + 0.0722 * b[sx + 1][sy + 1]);
-                }
-            }
-            float min_r_sample = min4(r[1][1], r[2][1], r[1][2], r[2][2]);
-            float min_g_sample = min4(g[1][1], g[2][1], g[1][2], g[2][2]);
-            float min_b_sample = min4(b[1][1], b[2][1], b[1][2], b[2][2]);
-            float min_a_sample = min4(a[1][1], a[2][1], a[1][2], a[2][2]);
-            float max_r_sample = max4(r[1][1], r[2][1], r[1][2], r[2][2]);
-            float max_g_sample = max4(g[1][1], g[2][1], g[1][2], g[2][2]);
-            float max_b_sample = max4(b[1][1], b[2][1], b[1][2], b[2][2]);
-            float max_a_sample = max4(a[1][1], a[2][1], a[1][2], a[2][2]);
-            float d_edge = diagonal_edge(Y, &wp[0]);
-            float r1, g1, b1, a1, r2, g2, b2, a2, rf, gf, bf, af;
-            r1 = (float)w3 * (r[0][3] + r[3][0]) + (float)w4 * (r[1][2] + r[2][1]);
-            g1 = (float)w3 * (g[0][3] + g[3][0]) + (float)w4 * (g[1][2] + g[2][1]);
-            b1 = (float)w3 * (b[0][3] + b[3][0]) + (float)w4 * (b[1][2] + b[2][1]);
-            a1 = (float)w3 * (a[0][3] + a[3][0]) + (float)w4 * (a[1][2] + a[2][1]);
-            r2 = (float)w3 * (r[0][0] + r[3][3]) + (float)w4 * (r[1][1] + r[2][2]);
-            g2 = (float)w3 * (g[0][0] + g[3][3]) + (float)w4 * (g[1][1] + g[2][2]);
-            b2 = (float)w3 * (b[0][0] + b[3][3]) + (float)w4 * (b[1][1] + b[2][2]);
-            a2 = (float)w3 * (a[0][0] + a[3][3]) + (float)w4 * (a[1][1] + a[2][2]);
-            // generate and write result
-            if (d_edge <= 0.0f) {
-                rf = r1;
-                gf = g1;
-                bf = b1;
-                af = a1;
-            } else {
-                rf = r2;
-                gf = g2;
-                bf = b2;
-                af = a2;
-            }
-            // anti-ringing, clamp.
-            rf = std::clamp(rf, min_r_sample, max_r_sample);
-            gf = std::clamp(gf, min_g_sample, max_g_sample);
-            bf = std::clamp(bf, min_b_sample, max_b_sample);
-            af = std::clamp(af, min_a_sample, max_a_sample);
-            int ri = std::clamp(static_cast<int>(ceilf(rf)), 0, 255);
-            int gi = std::clamp(static_cast<int>(ceilf(gf)), 0, 255);
-            int bi = std::clamp(static_cast<int>(ceilf(bf)), 0, 255);
-            int ai = std::clamp(static_cast<int>(ceilf(af)), 0, 255);
-            out[y * outw + x + 1] = (ai << 24) | (bi << 16) | (gi << 8) | ri;
-
-            for (int sx = -1; sx <= 2; ++sx) {
-                for (int sy = -1; sy <= 2; ++sy) {
-                    // clamp pixel locations
-                    int csy = std::clamp(sx - sy + 1 + y, 0, f * h - 1);
-                    int csx = std::clamp(sx + sy - 1 + x, 0, f * w - 1);
-                    // sample & add weighted components
-                    u32 sample = out[csy * outw + csx];
-                    r[sx + 1][sy + 1] = (float)R(sample);
-                    g[sx + 1][sy + 1] = (float)G(sample);
-                    b[sx + 1][sy + 1] = (float)B(sample);
-                    a[sx + 1][sy + 1] = (float)A(sample);
-                    Y[sx + 1][sy + 1] = (float)(0.2126 * r[sx + 1][sy + 1] + 0.7152 * g[sx + 1][sy + 1] + 0.0722 * b[sx + 1][sy + 1]);
-                }
-            }
-            d_edge = diagonal_edge(Y, &wp[0]);
-            r1 = (float)w3 * (r[0][3] + r[3][0]) + (float)w4 * (r[1][2] + r[2][1]);
-            g1 = (float)w3 * (g[0][3] + g[3][0]) + (float)w4 * (g[1][2] + g[2][1]);
-            b1 = (float)w3 * (b[0][3] + b[3][0]) + (float)w4 * (b[1][2] + b[2][1]);
-            a1 = (float)w3 * (a[0][3] + a[3][0]) + (float)w4 * (a[1][2] + a[2][1]);
-            r2 = (float)w3 * (r[0][0] + r[3][3]) + (float)w4 * (r[1][1] + r[2][2]);
-            g2 = (float)w3 * (g[0][0] + g[3][3]) + (float)w4 * (g[1][1] + g[2][2]);
-            b2 = (float)w3 * (b[0][0] + b[3][3]) + (float)w4 * (b[1][1] + b[2][2]);
-            a2 = (float)w3 * (a[0][0] + a[3][3]) + (float)w4 * (a[1][1] + a[2][2]);
-            // generate and write result
-            if (d_edge <= 0.0f) {
-                rf = r1;
-                gf = g1;
-                bf = b1;
-                af = a1;
-            } else {
-                rf = r2;
-                gf = g2;
-                bf = b2;
-                af = a2;
-            }
-            // anti-ringing, clamp.
-            rf = std::clamp(rf, min_r_sample, max_r_sample);
-            gf = std::clamp(gf, min_g_sample, max_g_sample);
-            bf = std::clamp(bf, min_b_sample, max_b_sample);
-            af = std::clamp(af, min_a_sample, max_a_sample);
-            ri = std::clamp(static_cast<int>(ceilf(rf)), 0, 255);
-            gi = std::clamp(static_cast<int>(ceilf(gf)), 0, 255);
-            bi = std::clamp(static_cast<int>(ceilf(bf)), 0, 255);
-            ai = std::clamp(static_cast<int>(ceilf(af)), 0, 255);
-            out[(y + 1) * outw + x] = (ai << 24) | (bi << 16) | (gi << 8) | ri;
-            ++x;
-        }
-        ++y;
-    }
-
-    // Third Pass
-    wp[0] = 2.0f;
-    wp[1] = 1.0f;
-    wp[2] = -1.0f;
-    wp[3] = 4.0f;
-    wp[4] = -1.0f;
-    wp[5] = 1.0f;
-
-    for (int y = outh - 1; y >= 0; --y) {
-        for (int x = outw - 1; x >= 0; --x) {
-            float r[4][4], g[4][4], b[4][4], a[4][4], Y[4][4];
-            for (int sx = -2; sx <= 1; ++sx) {
-                for (int sy = -2; sy <= 1; ++sy) {
-                    // clamp pixel locations
-                    int csy = std::clamp(sy + y, 0, f * h - 1);
-                    int csx = std::clamp(sx + x, 0, f * w - 1);
-                    // sample & add weighted components
-                    u32 sample = out[csy * outw + csx];
-                    r[sx + 2][sy + 2] = (float)R(sample);
-                    g[sx + 2][sy + 2] = (float)G(sample);
-                    b[sx + 2][sy + 2] = (float)B(sample);
-                    a[sx + 2][sy + 2] = (float)A(sample);
-                    Y[sx + 2][sy + 2] = (float)(0.2126 * r[sx + 2][sy + 2] + 0.7152 * g[sx + 2][sy + 2] + 0.0722 * b[sx + 2][sy + 2]);
-                }
-            }
-            float min_r_sample = min4(r[1][1], r[2][1], r[1][2], r[2][2]);
-            float min_g_sample = min4(g[1][1], g[2][1], g[1][2], g[2][2]);
-            float min_b_sample = min4(b[1][1], b[2][1], b[1][2], b[2][2]);
-            float min_a_sample = min4(a[1][1], a[2][1], a[1][2], a[2][2]);
-            float max_r_sample = max4(r[1][1], r[2][1], r[1][2], r[2][2]);
-            float max_g_sample = max4(g[1][1], g[2][1], g[1][2], g[2][2]);
-            float max_b_sample = max4(b[1][1], b[2][1], b[1][2], b[2][2]);
-            float max_a_sample = max4(a[1][1], a[2][1], a[1][2], a[2][2]);
-            float d_edge = diagonal_edge(Y, &wp[0]);
-            float r1, g1, b1, a1, r2, g2, b2, a2, rf, gf, bf, af;
-            r1 = (float)w1 * (r[0][3] + r[3][0]) + (float)w2 * (r[1][2] + r[2][1]);
-            g1 = (float)w1 * (g[0][3] + g[3][0]) + (float)w2 * (g[1][2] + g[2][1]);
-            b1 = (float)w1 * (b[0][3] + b[3][0]) + (float)w2 * (b[1][2] + b[2][1]);
-            a1 = (float)w1 * (a[0][3] + a[3][0]) + (float)w2 * (a[1][2] + a[2][1]);
-            r2 = (float)w1 * (r[0][0] + r[3][3]) + (float)w2 * (r[1][1] + r[2][2]);
-            g2 = (float)w1 * (g[0][0] + g[3][3]) + (float)w2 * (g[1][1] + g[2][2]);
-            b2 = (float)w1 * (b[0][0] + b[3][3]) + (float)w2 * (b[1][1] + b[2][2]);
-            a2 = (float)w1 * (a[0][0] + a[3][3]) + (float)w2 * (a[1][1] + a[2][2]);
-            // generate and write result
-            if (d_edge <= 0.0f) {
-                rf = r1;
-                gf = g1;
-                bf = b1;
-                af = a1;
-            } else {
-                rf = r2;
-                gf = g2;
-                bf = b2;
-                af = a2;
-            }
-            // anti-ringing, clamp.
-            rf = std::clamp(rf, min_r_sample, max_r_sample);
-            gf = std::clamp(gf, min_g_sample, max_g_sample);
-            bf = std::clamp(bf, min_b_sample, max_b_sample);
-            af = std::clamp(af, min_a_sample, max_a_sample);
-            int ri = std::clamp(static_cast<int>(ceilf(rf)), 0, 255);
-            int gi = std::clamp(static_cast<int>(ceilf(gf)), 0, 255);
-            int bi = std::clamp(static_cast<int>(ceilf(bf)), 0, 255);
-            int ai = std::clamp(static_cast<int>(ceilf(af)), 0, 255);
-            out[y * outw + x] = (ai << 24) | (bi << 16) | (gi << 8) | ri;
+    for (int y = 0; y < blockHeight; ++y, trg += pitchWords) {
+        for (int x = 0; x < blockWidth; ++x) {
+            trg[x] = col;
         }
     }
 }
 
-//// *** Super-xBR code ends here - MIT LICENSE *** ///
+static inline void colorGradientARGB(unsigned int m, unsigned int n, uint32_t *pixBack, uint32_t pixFront) {
+    unsigned int weightFront = getAlpha(pixFront) * m;
+    unsigned int weightBack = getAlpha(*pixBack) * (n - m);
+    unsigned int weightSum = weightFront + weightBack;
+
+    if (weightSum == 0) {
+        return;
+    }
+
+    uint8_t resultAlpha = (uint8_t)(weightSum / n);
+    uint8_t resultRed = (uint8_t)((getRed(pixFront) * weightFront + getRed(*pixBack) * weightBack) / weightSum);
+    uint8_t resultGreen = (uint8_t)((getGreen(pixFront) * weightFront + getGreen(*pixBack) * weightBack) / weightSum);
+    uint8_t resultBlue = (uint8_t)((getBlue(pixFront) * weightFront + getBlue(*pixBack) * weightBack) / weightSum);
+
+    *pixBack = makePixel(resultAlpha, resultRed, resultGreen, resultBlue);
+}
+
+typedef enum RotationDegree { ROT_0 = 0, ROT_90, ROT_180, ROT_270 } RotationDegree;
+
+typedef struct OutputMatrix {
+    uint32_t *out;
+    int outWidth;
+    RotationDegree rotDeg;
+    int N;
+} OutputMatrix;
+
+static inline uint32_t *outputMatrixRef(OutputMatrix *matrix, int I, int J) {
+    int N = matrix->N;
+    int I_old, J_old;
+
+    switch (matrix->rotDeg) {
+    case ROT_90:
+        I_old = N - 1 - J;
+        J_old = I;
+        break;
+
+    case ROT_180:
+        I_old = N - 1 - I;
+        J_old = N - 1 - J;
+        break;
+
+    case ROT_270:
+        I_old = J;
+        J_old = N - 1 - I;
+        break;
+
+    case ROT_0:
+    default:
+        I_old = I;
+        J_old = J;
+    }
+
+    return matrix->out + J_old + I_old * matrix->outWidth;
+}
+
+static inline double square(double value) {
+    return value * value;
+}
+
+static inline double distYCbCr(uint32_t pix1, uint32_t pix2, double luminanceWeight) {
+    if (pix1 == pix2) {
+        return 0.0;
+    }
+
+    int r_diff = (int)getRed(pix1) - (int)getRed(pix2);
+    int g_diff = (int)getGreen(pix1) - (int)getGreen(pix2);
+    int b_diff = (int)getBlue(pix1) - (int)getBlue(pix2);
+
+    const double k_b = 0.0593;
+    const double k_r = 0.2627;
+    const double k_g = 1 - k_b - k_r;
+
+    const double scale_b = 0.5 / (1.0 - k_b);
+    const double scale_r = 0.5 / (1.0 - k_r);
+
+    double y = k_r * r_diff + k_g * g_diff + k_b * b_diff;
+    double c_b = scale_b * (b_diff - y);
+    double c_r = scale_r * (r_diff - y);
+
+    return sqrt(square(luminanceWeight * y) + square(c_b) + square(c_r));
+}
+
+static inline double colorDistanceARGB(uint32_t pix1, uint32_t pix2, double luminanceWeight) {
+    double a1 = getAlpha(pix1) / 255.0;
+    double a2 = getAlpha(pix2) / 255.0;
+    double d = distYCbCr(pix1, pix2, luminanceWeight);
+
+    if (a1 < a2) {
+        return a1 * d + 255 * (a2 - a1);
+    } else {
+        return a2 * d + 255 * (a1 - a2);
+    }
+}
+
+typedef enum BlendType { BLEND_NONE = 0, BLEND_NORMAL, BLEND_DOMINANT } BlendType;
+
+typedef struct BlendResult {
+    BlendType blend_f, blend_g, blend_j, blend_k;
+} BlendResult;
+
+typedef struct Kernel_3x3 {
+    uint32_t a, b, c, d, e, f, g, h, i;
+} Kernel_3x3;
+
+typedef struct Kernel_4x4 {
+    uint32_t a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p;
+} Kernel_4x4;
+
+static inline BlendResult preProcessCorners(const Kernel_4x4 *ker, const ScalerCfg *cfg) {
+    BlendResult result = {BLEND_NONE, BLEND_NONE, BLEND_NONE, BLEND_NONE};
+
+    if ((ker->f == ker->g && ker->j == ker->k) || (ker->f == ker->j && ker->g == ker->k)) {
+        return result;
+    }
+
+    double jg = colorDistanceARGB(ker->i, ker->f, cfg->luminanceWeight) + colorDistanceARGB(ker->f, ker->c, cfg->luminanceWeight) +
+                colorDistanceARGB(ker->n, ker->k, cfg->luminanceWeight) + colorDistanceARGB(ker->k, ker->h, cfg->luminanceWeight) +
+                cfg->centerDirectionBias * colorDistanceARGB(ker->j, ker->g, cfg->luminanceWeight);
+
+    double fk = colorDistanceARGB(ker->e, ker->j, cfg->luminanceWeight) + colorDistanceARGB(ker->j, ker->o, cfg->luminanceWeight) +
+                colorDistanceARGB(ker->b, ker->g, cfg->luminanceWeight) + colorDistanceARGB(ker->g, ker->l, cfg->luminanceWeight) +
+                cfg->centerDirectionBias * colorDistanceARGB(ker->f, ker->k, cfg->luminanceWeight);
+
+    if (jg < fk) {
+        bool dominantGradient = cfg->dominantDirectionThreshold * jg < fk;
+
+        if (ker->f != ker->g && ker->f != ker->j) {
+            result.blend_f = dominantGradient ? BLEND_DOMINANT : BLEND_NORMAL;
+        }
+
+        if (ker->k != ker->j && ker->k != ker->g) {
+            result.blend_k = dominantGradient ? BLEND_DOMINANT : BLEND_NORMAL;
+        }
+    } else if (fk < jg) {
+        bool dominantGradient = cfg->dominantDirectionThreshold * fk < jg;
+
+        if (ker->j != ker->f && ker->j != ker->k) {
+            result.blend_j = dominantGradient ? BLEND_DOMINANT : BLEND_NORMAL;
+        }
+
+        if (ker->g != ker->f && ker->g != ker->k) {
+            result.blend_g = dominantGradient ? BLEND_DOMINANT : BLEND_NORMAL;
+        }
+    }
+
+    return result;
+}
+
+static inline uint32_t get_b(RotationDegree rotDeg, const Kernel_3x3 *ker) {
+    switch (rotDeg) {
+    case ROT_90:
+        return ker->d;
+    case ROT_180:
+        return ker->h;
+    case ROT_270:
+        return ker->f;
+    case ROT_0:
+    default:
+        return ker->b;
+    }
+}
+
+static inline uint32_t get_c(RotationDegree rotDeg, const Kernel_3x3 *ker) {
+    switch (rotDeg) {
+    case ROT_90:
+        return ker->a;
+    case ROT_180:
+        return ker->g;
+    case ROT_270:
+        return ker->i;
+    case ROT_0:
+    default:
+        return ker->c;
+    }
+}
+
+static inline uint32_t get_d(RotationDegree rotDeg, const Kernel_3x3 *ker) {
+    switch (rotDeg) {
+    case ROT_90:
+        return ker->h;
+    case ROT_180:
+        return ker->f;
+    case ROT_270:
+        return ker->b;
+    case ROT_0:
+    default:
+        return ker->d;
+    }
+}
+
+static inline uint32_t get_e(RotationDegree rotDeg, const Kernel_3x3 *ker) {
+    (void)rotDeg;
+    return ker->e;
+}
+
+static inline uint32_t get_f(RotationDegree rotDeg, const Kernel_3x3 *ker) {
+    switch (rotDeg) {
+    case ROT_90:
+        return ker->b;
+    case ROT_180:
+        return ker->d;
+    case ROT_270:
+        return ker->h;
+    case ROT_0:
+    default:
+        return ker->f;
+    }
+}
+
+static inline uint32_t get_g(RotationDegree rotDeg, const Kernel_3x3 *ker) {
+    switch (rotDeg) {
+    case ROT_90:
+        return ker->i;
+    case ROT_180:
+        return ker->c;
+    case ROT_270:
+        return ker->a;
+    case ROT_0:
+    default:
+        return ker->g;
+    }
+}
+
+static inline uint32_t get_h(RotationDegree rotDeg, const Kernel_3x3 *ker) {
+    switch (rotDeg) {
+    case ROT_90:
+        return ker->f;
+    case ROT_180:
+        return ker->b;
+    case ROT_270:
+        return ker->d;
+    case ROT_0:
+    default:
+        return ker->h;
+    }
+}
+
+static inline uint32_t get_i(RotationDegree rotDeg, const Kernel_3x3 *ker) {
+    switch (rotDeg) {
+    case ROT_90:
+        return ker->c;
+    case ROT_180:
+        return ker->a;
+    case ROT_270:
+        return ker->g;
+    case ROT_0:
+    default:
+        return ker->i;
+    }
+}
+
+static inline BlendType getTopR(uint8_t b) {
+    return (BlendType)(0x3 & (b >> 2));
+}
+
+static inline BlendType getBottomR(uint8_t b) {
+    return (BlendType)(0x3 & (b >> 4));
+}
+
+static inline BlendType getBottomL(uint8_t b) {
+    return (BlendType)(0x3 & (b >> 6));
+}
+
+static inline void clearAddTopL(uint8_t *b, BlendType bt) {
+    *b = (uint8_t)bt;
+}
+
+static inline void addTopR(uint8_t *b, BlendType bt) {
+    *b |= (bt << 2);
+}
+
+static inline void addBottomR(uint8_t *b, BlendType bt) {
+    *b |= (bt << 4);
+}
+
+static inline void addBottomL(uint8_t *b, BlendType bt) {
+    *b |= (bt << 6);
+}
+
+static inline bool blendingNeeded(uint8_t b) {
+    return b != 0;
+}
+
+static inline uint8_t rotateBlendInfo(RotationDegree rotDeg, uint8_t b) {
+    switch (rotDeg) {
+    case ROT_90:
+        return ((b << 2) | (b >> 6)) & 0xff;
+    case ROT_180:
+        return ((b << 4) | (b >> 4)) & 0xff;
+    case ROT_270:
+        return ((b << 6) | (b >> 2)) & 0xff;
+    case ROT_0:
+    default:
+        return b;
+    }
+}
+
+typedef struct ScalerTypeVTable {
+    int scale;
+    void (*blendLineShallow)(uint32_t, OutputMatrix *);
+    void (*blendLineSteep)(uint32_t, OutputMatrix *);
+    void (*blendLineSteepAndShallow)(uint32_t, OutputMatrix *);
+    void (*blendLineDiagonal)(uint32_t, OutputMatrix *);
+    void (*blendCorner)(uint32_t, OutputMatrix *);
+} ScalerTypeVTable;
+
+static inline void scaler2x_blendLineShallow(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(1, 4, outputMatrixRef(out, 2 - 1, 0), col);
+    colorGradientARGB(3, 4, outputMatrixRef(out, 2 - 1, 1), col);
+}
+
+static inline void scaler2x_blendLineSteep(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(1, 4, outputMatrixRef(out, 0, 2 - 1), col);
+    colorGradientARGB(3, 4, outputMatrixRef(out, 1, 2 - 1), col);
+}
+
+static inline void scaler2x_blendLineSteepAndShallow(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(1, 4, outputMatrixRef(out, 1, 0), col);
+    colorGradientARGB(1, 4, outputMatrixRef(out, 0, 1), col);
+    colorGradientARGB(5, 6, outputMatrixRef(out, 1, 1), col);
+}
+
+static inline void scaler2x_blendLineDiagonal(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(1, 2, outputMatrixRef(out, 1, 1), col);
+}
+
+static inline void scaler2x_blendCorner(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(21, 100, outputMatrixRef(out, 1, 1), col);
+}
+
+static ScalerTypeVTable scaler2x_vtable = {.scale = 2,
+                                           .blendLineShallow = scaler2x_blendLineShallow,
+                                           .blendLineSteep = scaler2x_blendLineSteep,
+                                           .blendLineSteepAndShallow = scaler2x_blendLineSteepAndShallow,
+                                           .blendLineDiagonal = scaler2x_blendLineDiagonal,
+                                           .blendCorner = scaler2x_blendCorner};
+
+static inline void scaler3x_blendLineShallow(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(1, 4, outputMatrixRef(out, 3 - 1, 0), col);
+    colorGradientARGB(1, 4, outputMatrixRef(out, 3 - 2, 2), col);
+
+    colorGradientARGB(3, 4, outputMatrixRef(out, 3 - 1, 1), col);
+    *outputMatrixRef(out, 3 - 1, 2) = col;
+}
+
+static inline void scaler3x_blendLineSteep(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(1, 4, outputMatrixRef(out, 0, 3 - 1), col);
+    colorGradientARGB(1, 4, outputMatrixRef(out, 2, 3 - 2), col);
+
+    colorGradientARGB(3, 4, outputMatrixRef(out, 1, 3 - 1), col);
+    *outputMatrixRef(out, 2, 3 - 1) = col;
+}
+
+static inline void scaler3x_blendLineSteepAndShallow(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(1, 4, outputMatrixRef(out, 2, 0), col);
+    colorGradientARGB(1, 4, outputMatrixRef(out, 0, 2), col);
+    colorGradientARGB(3, 4, outputMatrixRef(out, 2, 1), col);
+    colorGradientARGB(3, 4, outputMatrixRef(out, 1, 2), col);
+    *outputMatrixRef(out, 2, 2) = col;
+}
+
+static inline void scaler3x_blendLineDiagonal(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(1, 8, outputMatrixRef(out, 1, 2), col);
+    colorGradientARGB(1, 8, outputMatrixRef(out, 2, 1), col);
+    colorGradientARGB(7, 8, outputMatrixRef(out, 2, 2), col);
+}
+
+static inline void scaler3x_blendCorner(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(45, 100, outputMatrixRef(out, 2, 2), col);
+}
+
+static ScalerTypeVTable scaler3x_vtable = {.scale = 3,
+                                           .blendLineShallow = scaler3x_blendLineShallow,
+                                           .blendLineSteep = scaler3x_blendLineSteep,
+                                           .blendLineSteepAndShallow = scaler3x_blendLineSteepAndShallow,
+                                           .blendLineDiagonal = scaler3x_blendLineDiagonal,
+                                           .blendCorner = scaler3x_blendCorner};
+
+static inline void scaler4x_blendLineShallow(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(1, 4, outputMatrixRef(out, 4 - 1, 0), col);
+    colorGradientARGB(1, 4, outputMatrixRef(out, 4 - 2, 2), col);
+
+    colorGradientARGB(3, 4, outputMatrixRef(out, 4 - 1, 1), col);
+    colorGradientARGB(3, 4, outputMatrixRef(out, 4 - 2, 3), col);
+
+    *outputMatrixRef(out, 4 - 1, 2) = col;
+    *outputMatrixRef(out, 4 - 1, 3) = col;
+}
+
+static inline void scaler4x_blendLineSteep(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(1, 4, outputMatrixRef(out, 0, 4 - 1), col);
+    colorGradientARGB(1, 4, outputMatrixRef(out, 2, 4 - 2), col);
+
+    colorGradientARGB(3, 4, outputMatrixRef(out, 1, 4 - 1), col);
+    colorGradientARGB(3, 4, outputMatrixRef(out, 3, 4 - 2), col);
+
+    *outputMatrixRef(out, 2, 4 - 1) = col;
+    *outputMatrixRef(out, 3, 4 - 1) = col;
+}
+
+static inline void scaler4x_blendLineSteepAndShallow(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(3, 4, outputMatrixRef(out, 3, 1), col);
+    colorGradientARGB(3, 4, outputMatrixRef(out, 1, 3), col);
+    colorGradientARGB(1, 4, outputMatrixRef(out, 3, 0), col);
+    colorGradientARGB(1, 4, outputMatrixRef(out, 0, 3), col);
+
+    colorGradientARGB(1, 3, outputMatrixRef(out, 2, 2), col);
+
+    *outputMatrixRef(out, 3, 3) = col;
+    *outputMatrixRef(out, 3, 2) = col;
+    *outputMatrixRef(out, 2, 3) = col;
+}
+
+static inline void scaler4x_blendLineDiagonal(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(1, 2, outputMatrixRef(out, 4 - 1, 4 / 2), col);
+    colorGradientARGB(1, 2, outputMatrixRef(out, 4 - 2, 4 / 2 + 1), col);
+    *outputMatrixRef(out, 4 - 1, 4 - 1) = col;
+}
+
+static inline void scaler4x_blendCorner(uint32_t col, OutputMatrix *out) {
+    colorGradientARGB(68, 100, outputMatrixRef(out, 3, 3), col);
+    colorGradientARGB(9, 100, outputMatrixRef(out, 3, 2), col);
+    colorGradientARGB(9, 100, outputMatrixRef(out, 2, 3), col);
+}
+
+static ScalerTypeVTable scaler4x_vtable = {.scale = 4,
+                                           .blendLineShallow = scaler4x_blendLineShallow,
+                                           .blendLineSteep = scaler4x_blendLineSteep,
+                                           .blendLineSteepAndShallow = scaler4x_blendLineSteepAndShallow,
+                                           .blendLineDiagonal = scaler4x_blendLineDiagonal,
+                                           .blendCorner = scaler4x_blendCorner};
+
+typedef struct OobReaderTransparent {
+    const uint32_t *s_m1;
+    const uint32_t *s_0;
+    const uint32_t *s_p1;
+    const uint32_t *s_p2;
+    int s_width;
+} OobReaderTransparent;
+
+static inline OobReaderTransparent oobReaderTransparentCreate(const uint32_t *src, int srcWidth, int srcHeight, int y) {
+    return (OobReaderTransparent){.s_m1 = (0 <= y - 1 && y - 1 < srcHeight) ? src + srcWidth * (y - 1) : NULL,
+                                  .s_0 = (0 <= y && y < srcHeight) ? src + srcWidth * y : NULL,
+                                  .s_p1 = (0 <= y + 1 && y + 1 < srcHeight) ? src + srcWidth * (y + 1) : NULL,
+                                  .s_p2 = (0 <= y + 2 && y + 2 < srcHeight) ? src + srcWidth * (y + 2) : NULL,
+                                  .s_width = srcWidth};
+}
+
+static inline void oobReaderTransparentReadDhlp(const OobReaderTransparent *reader, Kernel_4x4 *ker, int x) {
+    if (0 <= x + 2 && x + 2 < reader->s_width) {
+        ker->d = reader->s_m1 ? reader->s_m1[x + 2] : 0;
+        ker->h = reader->s_0 ? reader->s_0[x + 2] : 0;
+        ker->l = reader->s_p1 ? reader->s_p1[x + 2] : 0;
+        ker->p = reader->s_p2 ? reader->s_p2[x + 2] : 0;
+    } else {
+        ker->d = 0;
+        ker->h = 0;
+        ker->l = 0;
+        ker->p = 0;
+    }
+}
+
+static inline bool pixelEqual(uint32_t pix1, uint32_t pix2, const ScalerCfg *cfg) {
+    return colorDistanceARGB(pix1, pix2, cfg->luminanceWeight) < cfg->equalColorTolerance;
+}
+
+static inline bool doLineBlend(uint8_t blend, uint32_t e, uint32_t g, uint32_t c, uint32_t i, uint32_t h, uint32_t f, const ScalerCfg *cfg) {
+    if (getBottomR(blend) >= BLEND_DOMINANT) {
+        return true;
+    }
+
+    if (getTopR(blend) != BLEND_NONE && !pixelEqual(e, g, cfg)) {
+        return false;
+    }
+
+    if (getBottomL(blend) != BLEND_NONE && !pixelEqual(e, c, cfg)) {
+        return false;
+    }
+
+    if (!pixelEqual(e, i, cfg) && pixelEqual(g, h, cfg) && pixelEqual(h, i, cfg) && pixelEqual(i, f, cfg) && pixelEqual(f, c, cfg)) {
+        return false;
+    }
+
+    return true;
+}
+
+static inline void blendPixel(ScalerTypeVTable *scaler, RotationDegree rotDeg, const Kernel_3x3 *ker, uint32_t *target, int trgWidth, uint8_t blendInfo,
+                              const ScalerCfg *cfg) {
+    uint32_t b = get_b(rotDeg, ker);
+    uint32_t c = get_c(rotDeg, ker);
+    uint32_t d = get_d(rotDeg, ker);
+    uint32_t e = get_e(rotDeg, ker);
+    uint32_t f = get_f(rotDeg, ker);
+    uint32_t g = get_g(rotDeg, ker);
+    uint32_t h = get_h(rotDeg, ker);
+    uint32_t i = get_i(rotDeg, ker);
+
+    uint8_t blend = rotateBlendInfo(rotDeg, blendInfo);
+
+    if (getBottomR(blend) >= BLEND_NORMAL) {
+        bool doBlend = doLineBlend(blend, e, g, c, i, h, f, cfg);
+
+        uint32_t px = colorDistanceARGB(e, f, cfg->luminanceWeight) <= colorDistanceARGB(e, h, cfg->luminanceWeight) ? f : h;
+
+        OutputMatrix out_matrix = {target, trgWidth, rotDeg, scaler->scale};
+
+        if (doBlend) {
+            double fg = colorDistanceARGB(f, g, cfg->luminanceWeight);
+            double hc = colorDistanceARGB(h, c, cfg->luminanceWeight);
+
+            bool haveShallowLine = cfg->steepDirectionThreshold * fg <= hc && e != g && d != g;
+            bool haveSteepLine = cfg->steepDirectionThreshold * hc <= fg && e != c && b != c;
+
+            if (haveShallowLine) {
+                if (haveSteepLine) {
+                    scaler->blendLineSteepAndShallow(px, &out_matrix);
+                } else {
+                    scaler->blendLineShallow(px, &out_matrix);
+                }
+            } else {
+                if (haveSteepLine) {
+                    scaler->blendLineSteep(px, &out_matrix);
+                } else {
+                    scaler->blendLineDiagonal(px, &out_matrix);
+                }
+            }
+        } else {
+            scaler->blendCorner(px, &out_matrix);
+        }
+    }
+}
+
+static void scaleImage(ScalerTypeVTable *scaler, uint32_t *src, uint32_t *trg, int srcWidth, int srcHeight, const ScalerCfg *cfg, int yFirst, int yLast) {
+    yFirst = (yFirst > 0) ? yFirst : 0;
+    yLast = (yLast < srcHeight) ? yLast : srcHeight;
+
+    if (yFirst >= yLast || srcWidth <= 0) {
+        return;
+    }
+
+    int trgWidth = srcWidth * scaler->scale;
+    uint8_t *preProcBuf = (uint8_t *)(trg + yLast * scaler->scale * trgWidth) - srcWidth;
+
+    {
+        OobReaderTransparent oobReader_y_m1 = oobReaderTransparentCreate(src, srcWidth, srcHeight, yFirst - 1);
+
+        Kernel_4x4 ker4 = {0};
+        oobReaderTransparentReadDhlp(&oobReader_y_m1, &ker4, -4);
+        ker4.a = ker4.d;
+        ker4.e = ker4.h;
+        ker4.i = ker4.l;
+        ker4.m = ker4.p;
+
+        oobReaderTransparentReadDhlp(&oobReader_y_m1, &ker4, -3);
+        ker4.b = ker4.d;
+        ker4.f = ker4.h;
+        ker4.j = ker4.l;
+        ker4.n = ker4.p;
+
+        oobReaderTransparentReadDhlp(&oobReader_y_m1, &ker4, -2);
+        ker4.c = ker4.d;
+        ker4.g = ker4.h;
+        ker4.k = ker4.l;
+        ker4.o = ker4.p;
+
+        oobReaderTransparentReadDhlp(&oobReader_y_m1, &ker4, -1);
+
+        {
+            BlendResult res = preProcessCorners(&ker4, cfg);
+            clearAddTopL(&preProcBuf[0], res.blend_k);
+        }
+
+        for (int x = 0; x < srcWidth; ++x) {
+            ker4.a = ker4.b;
+            ker4.e = ker4.f;
+            ker4.i = ker4.j;
+            ker4.m = ker4.n;
+            ker4.b = ker4.c;
+            ker4.f = ker4.g;
+            ker4.j = ker4.k;
+            ker4.n = ker4.o;
+            ker4.c = ker4.d;
+            ker4.g = ker4.h;
+            ker4.k = ker4.l;
+            ker4.o = ker4.p;
+
+            oobReaderTransparentReadDhlp(&oobReader_y_m1, &ker4, x);
+
+            BlendResult res = preProcessCorners(&ker4, cfg);
+            addTopR(&preProcBuf[x], res.blend_j);
+
+            if (x + 1 < srcWidth) {
+                clearAddTopL(&preProcBuf[x + 1], res.blend_k);
+            }
+        }
+    }
+
+    for (int y = yFirst; y < yLast; ++y) {
+        uint32_t *out = trg + scaler->scale * y * trgWidth;
+
+        OobReaderTransparent oobReader_y = oobReaderTransparentCreate(src, srcWidth, srcHeight, y);
+
+        Kernel_4x4 ker4 = {0};
+        oobReaderTransparentReadDhlp(&oobReader_y, &ker4, -4);
+        ker4.a = ker4.d;
+        ker4.e = ker4.h;
+        ker4.i = ker4.l;
+        ker4.m = ker4.p;
+
+        oobReaderTransparentReadDhlp(&oobReader_y, &ker4, -3);
+        ker4.b = ker4.d;
+        ker4.f = ker4.h;
+        ker4.j = ker4.l;
+        ker4.n = ker4.p;
+
+        oobReaderTransparentReadDhlp(&oobReader_y, &ker4, -2);
+        ker4.c = ker4.d;
+        ker4.g = ker4.h;
+        ker4.k = ker4.l;
+        ker4.o = ker4.p;
+
+        oobReaderTransparentReadDhlp(&oobReader_y, &ker4, -1);
+
+        uint8_t blend_xy1 = 0;
+        {
+            BlendResult res = preProcessCorners(&ker4, cfg);
+            clearAddTopL(&blend_xy1, res.blend_k);
+            addBottomL(&preProcBuf[0], res.blend_g);
+        }
+
+        for (int x = 0; x < srcWidth; ++x, out += scaler->scale) {
+            ker4.a = ker4.b;
+            ker4.e = ker4.f;
+            ker4.i = ker4.j;
+            ker4.m = ker4.n;
+            ker4.b = ker4.c;
+            ker4.f = ker4.g;
+            ker4.j = ker4.k;
+            ker4.n = ker4.o;
+            ker4.c = ker4.d;
+            ker4.g = ker4.h;
+            ker4.k = ker4.l;
+            ker4.o = ker4.p;
+
+            oobReaderTransparentReadDhlp(&oobReader_y, &ker4, x);
+
+            uint8_t blend_xy = preProcBuf[x];
+            {
+                BlendResult res = preProcessCorners(&ker4, cfg);
+                addBottomR(&blend_xy, res.blend_f);
+                addTopR(&blend_xy1, res.blend_j);
+                preProcBuf[x] = blend_xy1;
+
+                if (x + 1 < srcWidth) {
+                    clearAddTopL(&blend_xy1, res.blend_k);
+                    addBottomL(&preProcBuf[x + 1], res.blend_g);
+                }
+            }
+
+            fillBlock(out, trgWidth * sizeof(uint32_t), ker4.f, scaler->scale, scaler->scale);
+
+            Kernel_3x3 ker3 = {ker4.a, ker4.b, ker4.c, ker4.e, ker4.f, ker4.g, ker4.i, ker4.j, ker4.k};
+
+            if (blendingNeeded(blend_xy)) {
+                blendPixel(scaler, ROT_0, &ker3, out, trgWidth, blend_xy, cfg);
+                blendPixel(scaler, ROT_90, &ker3, out, trgWidth, blend_xy, cfg);
+                blendPixel(scaler, ROT_180, &ker3, out, trgWidth, blend_xy, cfg);
+                blendPixel(scaler, ROT_270, &ker3, out, trgWidth, blend_xy, cfg);
+            }
+        }
+    }
+}
 
 void scaleSuperXBR2(uint32_t *data, int w, int h, uint32_t *out) {
-    scaleSuperXBRT<2>(data, out, w, h);
+    scaleImage(&scaler2x_vtable, data, out, w, h, &default_scaler_cfg, 0, INT_MAX);
 }
 
 void scaleSuperXBR3(uint32_t *data, int w, int h, uint32_t *out) {
-    scaleSuperXBRT<3>(data, out, w, h);
+    scaleImage(&scaler3x_vtable, data, out, w, h, &default_scaler_cfg, 0, INT_MAX);
 }
 
 void scaleSuperXBR4(uint32_t *data, int w, int h, uint32_t *out) {
-    scaleSuperXBRT<4>(data, out, w, h);
+    scaleImage(&scaler4x_vtable, data, out, w, h, &default_scaler_cfg, 0, INT_MAX);
 }

--- a/internal/c/parts/video/image/pixelscalers/sxbr.cpp
+++ b/internal/c/parts/video/image/pixelscalers/sxbr.cpp
@@ -388,3 +388,11 @@ template <int f> static void scaleSuperXBRT(u32 *data, u32 *out, int w, int h) {
 void scaleSuperXBR2(uint32_t *data, int w, int h, uint32_t *out) {
     scaleSuperXBRT<2>(data, out, w, h);
 }
+
+void scaleSuperXBR3(uint32_t *data, int w, int h, uint32_t *out) {
+    scaleSuperXBRT<3>(data, out, w, h);
+}
+
+void scaleSuperXBR4(uint32_t *data, int w, int h, uint32_t *out) {
+    scaleSuperXBRT<4>(data, out, w, h);
+}

--- a/internal/c/parts/video/image/pixelscalers/sxbr.cpp
+++ b/internal/c/parts/video/image/pixelscalers/sxbr.cpp
@@ -54,16 +54,12 @@ static inline float sxbr_df(float A, float B) {
     return abs(A - B);
 }
 
-static inline float min4(float a, float b, float c, float d) {
+static inline constexpr float min4(float a, float b, float c, float d) {
     return std::min(std::min(a, b), std::min(c, d));
 }
 
-static inline float max4(float a, float b, float c, float d) {
+static inline constexpr float max4(float a, float b, float c, float d) {
     return std::max(std::max(a, b), std::max(c, d));
-}
-
-template <class T> T clamp(T x, T floor, T ceil) {
-    return std::max(std::min(x, ceil), floor);
 }
 
 /*
@@ -130,7 +126,7 @@ static inline float cross_edge(float mat[][4], float *wp) {
 
 ///////////////////////// Super-xBR scaling
 // perform super-xbr (fast shader version) scaling by factor f=2 only.
-template <int f> void scaleSuperXBRT(u32 *data, u32 *out, int w, int h) {
+template <int f> static void scaleSuperXBRT(u32 *data, u32 *out, int w, int h) {
     int outw = w * f, outh = h * f;
 
     float wp[6] = {2.0f, 1.0f, -1.0f, 4.0f, -1.0f, 1.0f};
@@ -144,8 +140,8 @@ template <int f> void scaleSuperXBRT(u32 *data, u32 *out, int w, int h) {
             for (int sx = -1; sx <= 2; ++sx) {
                 for (int sy = -1; sy <= 2; ++sy) {
                     // clamp pixel locations
-                    int csy = clamp(sy + cy, 0, h - 1);
-                    int csx = clamp(sx + cx, 0, w - 1);
+                    int csy = std::clamp(sy + cy, 0, h - 1);
+                    int csx = std::clamp(sx + cx, 0, w - 1);
                     // sample & add weighted components
                     u32 sample = data[csy * w + csx];
                     r[sx + 1][sy + 1] = (float)R(sample);
@@ -186,14 +182,14 @@ template <int f> void scaleSuperXBRT(u32 *data, u32 *out, int w, int h) {
                 af = a2;
             }
             // anti-ringing, clamp.
-            rf = clamp(rf, min_r_sample, max_r_sample);
-            gf = clamp(gf, min_g_sample, max_g_sample);
-            bf = clamp(bf, min_b_sample, max_b_sample);
-            af = clamp(af, min_a_sample, max_a_sample);
-            int ri = clamp(static_cast<int>(ceilf(rf)), 0, 255);
-            int gi = clamp(static_cast<int>(ceilf(gf)), 0, 255);
-            int bi = clamp(static_cast<int>(ceilf(bf)), 0, 255);
-            int ai = clamp(static_cast<int>(ceilf(af)), 0, 255);
+            rf = std::clamp(rf, min_r_sample, max_r_sample);
+            gf = std::clamp(gf, min_g_sample, max_g_sample);
+            bf = std::clamp(bf, min_b_sample, max_b_sample);
+            af = std::clamp(af, min_a_sample, max_a_sample);
+            int ri = std::clamp(static_cast<int>(ceilf(rf)), 0, 255);
+            int gi = std::clamp(static_cast<int>(ceilf(gf)), 0, 255);
+            int bi = std::clamp(static_cast<int>(ceilf(bf)), 0, 255);
+            int ai = std::clamp(static_cast<int>(ceilf(af)), 0, 255);
             out[y * outw + x] = out[y * outw + x + 1] = out[(y + 1) * outw + x] = data[cy * w + cx];
             out[(y + 1) * outw + x + 1] = (ai << 24) | (bi << 16) | (gi << 8) | ri;
             ++x;
@@ -216,8 +212,8 @@ template <int f> void scaleSuperXBRT(u32 *data, u32 *out, int w, int h) {
             for (int sx = -1; sx <= 2; ++sx) {
                 for (int sy = -1; sy <= 2; ++sy) {
                     // clamp pixel locations
-                    int csy = clamp(sx - sy + y, 0, f * h - 1);
-                    int csx = clamp(sx + sy + x, 0, f * w - 1);
+                    int csy = std::clamp(sx - sy + y, 0, f * h - 1);
+                    int csx = std::clamp(sx + sy + x, 0, f * w - 1);
                     // sample & add weighted components
                     u32 sample = out[csy * outw + csx];
                     r[sx + 1][sy + 1] = (float)R(sample);
@@ -258,21 +254,21 @@ template <int f> void scaleSuperXBRT(u32 *data, u32 *out, int w, int h) {
                 af = a2;
             }
             // anti-ringing, clamp.
-            rf = clamp(rf, min_r_sample, max_r_sample);
-            gf = clamp(gf, min_g_sample, max_g_sample);
-            bf = clamp(bf, min_b_sample, max_b_sample);
-            af = clamp(af, min_a_sample, max_a_sample);
-            int ri = clamp(static_cast<int>(ceilf(rf)), 0, 255);
-            int gi = clamp(static_cast<int>(ceilf(gf)), 0, 255);
-            int bi = clamp(static_cast<int>(ceilf(bf)), 0, 255);
-            int ai = clamp(static_cast<int>(ceilf(af)), 0, 255);
+            rf = std::clamp(rf, min_r_sample, max_r_sample);
+            gf = std::clamp(gf, min_g_sample, max_g_sample);
+            bf = std::clamp(bf, min_b_sample, max_b_sample);
+            af = std::clamp(af, min_a_sample, max_a_sample);
+            int ri = std::clamp(static_cast<int>(ceilf(rf)), 0, 255);
+            int gi = std::clamp(static_cast<int>(ceilf(gf)), 0, 255);
+            int bi = std::clamp(static_cast<int>(ceilf(bf)), 0, 255);
+            int ai = std::clamp(static_cast<int>(ceilf(af)), 0, 255);
             out[y * outw + x + 1] = (ai << 24) | (bi << 16) | (gi << 8) | ri;
 
             for (int sx = -1; sx <= 2; ++sx) {
                 for (int sy = -1; sy <= 2; ++sy) {
                     // clamp pixel locations
-                    int csy = clamp(sx - sy + 1 + y, 0, f * h - 1);
-                    int csx = clamp(sx + sy - 1 + x, 0, f * w - 1);
+                    int csy = std::clamp(sx - sy + 1 + y, 0, f * h - 1);
+                    int csx = std::clamp(sx + sy - 1 + x, 0, f * w - 1);
                     // sample & add weighted components
                     u32 sample = out[csy * outw + csx];
                     r[sx + 1][sy + 1] = (float)R(sample);
@@ -304,14 +300,14 @@ template <int f> void scaleSuperXBRT(u32 *data, u32 *out, int w, int h) {
                 af = a2;
             }
             // anti-ringing, clamp.
-            rf = clamp(rf, min_r_sample, max_r_sample);
-            gf = clamp(gf, min_g_sample, max_g_sample);
-            bf = clamp(bf, min_b_sample, max_b_sample);
-            af = clamp(af, min_a_sample, max_a_sample);
-            ri = clamp(static_cast<int>(ceilf(rf)), 0, 255);
-            gi = clamp(static_cast<int>(ceilf(gf)), 0, 255);
-            bi = clamp(static_cast<int>(ceilf(bf)), 0, 255);
-            ai = clamp(static_cast<int>(ceilf(af)), 0, 255);
+            rf = std::clamp(rf, min_r_sample, max_r_sample);
+            gf = std::clamp(gf, min_g_sample, max_g_sample);
+            bf = std::clamp(bf, min_b_sample, max_b_sample);
+            af = std::clamp(af, min_a_sample, max_a_sample);
+            ri = std::clamp(static_cast<int>(ceilf(rf)), 0, 255);
+            gi = std::clamp(static_cast<int>(ceilf(gf)), 0, 255);
+            bi = std::clamp(static_cast<int>(ceilf(bf)), 0, 255);
+            ai = std::clamp(static_cast<int>(ceilf(af)), 0, 255);
             out[(y + 1) * outw + x] = (ai << 24) | (bi << 16) | (gi << 8) | ri;
             ++x;
         }
@@ -332,8 +328,8 @@ template <int f> void scaleSuperXBRT(u32 *data, u32 *out, int w, int h) {
             for (int sx = -2; sx <= 1; ++sx) {
                 for (int sy = -2; sy <= 1; ++sy) {
                     // clamp pixel locations
-                    int csy = clamp(sy + y, 0, f * h - 1);
-                    int csx = clamp(sx + x, 0, f * w - 1);
+                    int csy = std::clamp(sy + y, 0, f * h - 1);
+                    int csx = std::clamp(sx + x, 0, f * w - 1);
                     // sample & add weighted components
                     u32 sample = out[csy * outw + csx];
                     r[sx + 2][sy + 2] = (float)R(sample);
@@ -374,14 +370,14 @@ template <int f> void scaleSuperXBRT(u32 *data, u32 *out, int w, int h) {
                 af = a2;
             }
             // anti-ringing, clamp.
-            rf = clamp(rf, min_r_sample, max_r_sample);
-            gf = clamp(gf, min_g_sample, max_g_sample);
-            bf = clamp(bf, min_b_sample, max_b_sample);
-            af = clamp(af, min_a_sample, max_a_sample);
-            int ri = clamp(static_cast<int>(ceilf(rf)), 0, 255);
-            int gi = clamp(static_cast<int>(ceilf(gf)), 0, 255);
-            int bi = clamp(static_cast<int>(ceilf(bf)), 0, 255);
-            int ai = clamp(static_cast<int>(ceilf(af)), 0, 255);
+            rf = std::clamp(rf, min_r_sample, max_r_sample);
+            gf = std::clamp(gf, min_g_sample, max_g_sample);
+            bf = std::clamp(bf, min_b_sample, max_b_sample);
+            af = std::clamp(af, min_a_sample, max_a_sample);
+            int ri = std::clamp(static_cast<int>(ceilf(rf)), 0, 255);
+            int gi = std::clamp(static_cast<int>(ceilf(gf)), 0, 255);
+            int bi = std::clamp(static_cast<int>(ceilf(bf)), 0, 255);
+            int ai = std::clamp(static_cast<int>(ceilf(af)), 0, 255);
             out[y * outw + x] = (ai << 24) | (bi << 16) | (gi << 8) | ri;
         }
     }

--- a/internal/c/parts/video/image/pixelscalers/sxbr.cpp
+++ b/internal/c/parts/video/image/pixelscalers/sxbr.cpp
@@ -118,10 +118,6 @@ static inline double square(double value) {
 }
 
 static inline double distYCbCr(uint32_t pix1, uint32_t pix2, double luminanceWeight) {
-    if (pix1 == pix2) {
-        return 0.0;
-    }
-
     int r_diff = (int)getRed(pix1) - (int)getRed(pix2);
     int g_diff = (int)getGreen(pix1) - (int)getGreen(pix2);
     int b_diff = (int)getBlue(pix1) - (int)getBlue(pix2);

--- a/internal/c/parts/video/image/sg_curico/sg_curico.cpp
+++ b/internal/c/parts/video/image/sg_curico/sg_curico.cpp
@@ -16,10 +16,10 @@
 
 #include "libqb-common.h"
 
-#include "sg_curico.h"
 #include "../stb/stb_image.h"
 #include "../stb/stb_image_write.h"
 #include "image.h"
+#include "sg_curico.h"
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
@@ -182,7 +182,7 @@ class CurIcoImage {
               xPelsPerMeter(0), yPelsPerMeter(0), clrUsed(0), clrImportant(0) {}
 
         static auto GetStructSize() noexcept {
-            return 40;
+            return 40u;
         } // sizeof(BmpInfoHeader)
 
         void ReadFromStream(Stream &stream) {
@@ -393,7 +393,7 @@ class CurIcoImage {
             directory[i].ReadFromStream(input); // load the directory entry
 
             image_log_info("Width = %u, height = %u, colorCount = %u, bytesInRes = %u, imageOffset = %u", directory[i].width, directory[i].height,
-                              directory[i].colorCount, directory[i].bytesInRes, directory[i].imageOffset);
+                           directory[i].colorCount, directory[i].bytesInRes, directory[i].imageOffset);
         }
 
         size_t imageIndex = 0; // use the first image in the directory by default
@@ -469,8 +469,8 @@ class CurIcoImage {
             BmpInfoHeader bmpInfoHeader;
             bmpInfoHeader.ReadFromStream(input);
 
-            image_log_info("Width = %u, height = %u, bitCount = %u, planes = %u, compression = %u, sizeImage = %u", bmpInfoHeader.width,
-                              bmpInfoHeader.height, bmpInfoHeader.bitCount, bmpInfoHeader.planes, bmpInfoHeader.compression, bmpInfoHeader.sizeImage);
+            image_log_info("Width = %u, height = %u, bitCount = %u, planes = %u, compression = %u, sizeImage = %u", bmpInfoHeader.width, bmpInfoHeader.height,
+                           bmpInfoHeader.bitCount, bmpInfoHeader.planes, bmpInfoHeader.compression, bmpInfoHeader.sizeImage);
 
             auto width = ::abs(bmpInfoHeader.width);
             auto height = ::abs(bmpInfoHeader.height) >> 1;               // height is always multiplied by 2 due to the mask
@@ -726,7 +726,7 @@ uint32_t *curico_load_file(const char *filename, int *x, int *y, int *components
 
     rewind(pFile);
 
-    if (fread(&buffer[0], sizeof(uint8_t), len, pFile) != len || ferror(pFile)) {
+    if (long(fread(&buffer[0], sizeof(uint8_t), len, pFile)) != len || ferror(pFile)) {
         image_log_error("Failed to read %s", filename);
         fclose(pFile);
         return nullptr;

--- a/internal/c/parts/video/image/sg_curico/sg_curico.cpp
+++ b/internal/c/parts/video/image/sg_curico/sg_curico.cpp
@@ -686,8 +686,6 @@ uint32_t *curico_load_memory(const void *data, size_t dataSize, int *x, int *y, 
             free(out_data);
             out_data = nullptr;
         }
-
-        return nullptr;
     }
 
     return out_data;

--- a/internal/c/parts/video/image/sg_curico/sg_curico.cpp
+++ b/internal/c/parts/video/image/sg_curico/sg_curico.cpp
@@ -200,36 +200,32 @@ class CurIcoImage {
         }
     };
 
-    class Color {
-      public:
-        union BGRA32 {
-            struct Tuple {
+    // QB64 BGRA friendly color class
+    struct Color {
+        union {
+            struct {
                 uint8_t b;
                 uint8_t g;
                 uint8_t r;
                 uint8_t a;
-            } tuple;
+            };
 
             uint32_t value;
-        } color;
+        };
 
         Color() {
-            color.value = 0;
+            value = 0;
         }
 
         Color(uint32_t value) {
-            color.value = value;
+            this->value = value;
         }
 
         Color(uint8_t b, uint8_t g, uint8_t r, uint8_t a = 0xFFu) {
-            SetFromComponents(b, g, r, a);
-        }
-
-        void SetFromComponents(uint8_t b, uint8_t g, uint8_t r, uint8_t a = 0xFFu) {
-            color.tuple.b = b;
-            color.tuple.g = g;
-            color.tuple.r = r;
-            color.tuple.a = a;
+            this->b = b;
+            this->g = g;
+            this->r = r;
+            this->a = a;
         }
     };
 
@@ -270,16 +266,16 @@ class CurIcoImage {
             Resize(size);
 
             for (size_t i = 0; i < palette.size(); i++) {
-                Color entry;
+                Color color;
 
                 // WARNING: The loading order is important
-                entry.color.tuple.r = input.Read<uint8_t>();
-                entry.color.tuple.g = input.Read<uint8_t>();
-                entry.color.tuple.b = input.Read<uint8_t>();
-                entry.color.tuple.a = input.Read<uint8_t>();
-                entry.color.tuple.a = 0xff;
+                color.r = input.Read<uint8_t>();
+                color.g = input.Read<uint8_t>();
+                color.b = input.Read<uint8_t>();
+                color.a = input.Read<uint8_t>();
+                color.a = 0xff;
 
-                palette[i] = entry;
+                palette[i] = color;
             }
         }
     };
@@ -508,7 +504,7 @@ class CurIcoImage {
 
                 for (auto y = 0; y < height; y++) {
                     for (auto x = 0; x < width; x++) {
-                        *dst = palette.GetColor(((src[x >> 3] >> (7 - (x & 7))) & 1)).color.value;
+                        *dst = palette.GetColor(((src[x >> 3] >> (7 - (x & 7))) & 1)).value;
                         ++dst;
                     }
                     src += stride;
@@ -530,7 +526,7 @@ class CurIcoImage {
 
                 for (auto y = 0; y < height; y++) {
                     for (auto x = 0; x < width; x++) {
-                        *dst = palette.GetColor((src[x >> 1] >> ((!(x & 1)) << 2)) & 0xF).color.value;
+                        *dst = palette.GetColor((src[x >> 1] >> ((!(x & 1)) << 2)) & 0xF).value;
                         ++dst;
                     }
                     src += stride;
@@ -552,7 +548,7 @@ class CurIcoImage {
 
                 for (auto y = 0; y < height; y++) {
                     for (auto x = 0; x < width; x++) {
-                        *dst = palette.GetColor(src[x]).color.value;
+                        *dst = palette.GetColor(src[x]).value;
                         ++dst;
                     }
                     src += stride;

--- a/internal/c/parts/video/image/sg_pcx/sg_pcx.cpp
+++ b/internal/c/parts/video/image/sg_pcx/sg_pcx.cpp
@@ -6,8 +6,10 @@
 // https://github.com/mackron/dr_pcx
 //-----------------------------------------------------------------------------------------------------
 
-#include "sg_pcx.h"
+#include "libqb-common.h"
+
 #include "image.h"
+#include "sg_pcx.h"
 #include <algorithm>
 #include <cstring>
 #include <memory>
@@ -633,7 +635,7 @@ uint32_t *pcx_load_file(const char *filename, int *x, int *y, int *components) {
 
     rewind(pFile);
 
-    if (fread(&buffer[0], sizeof(uint8_t), len, pFile) != len || ferror(pFile)) {
+    if (long(fread(&buffer[0], sizeof(uint8_t), len, pFile)) != len || ferror(pFile)) {
         image_log_error("Failed to read %s", filename);
         fclose(pFile);
         return nullptr;

--- a/internal/c/parts/video/image/sg_pcx/sg_pcx.cpp
+++ b/internal/c/parts/video/image/sg_pcx/sg_pcx.cpp
@@ -605,8 +605,6 @@ uint32_t *pcx_load_memory(const void *data, size_t dataSize, int *x, int *y, int
             free(out_data);
             out_data = nullptr;
         }
-
-        return nullptr;
     }
 
     return out_data;

--- a/internal/c/parts/video/image/sg_pcx/sg_pcx.cpp
+++ b/internal/c/parts/video/image/sg_pcx/sg_pcx.cpp
@@ -1,9 +1,12 @@
 //-----------------------------------------------------------------------------------------------------
 // PCX Loader for QB64-PE by a740g
 //
-// Uses code and ideas from:
+// Bibliography:
 // https://github.com/EzArIk/PcxFileType
 // https://github.com/mackron/dr_pcx
+// http://fileformats.archiveteam.org/wiki/PCX
+// https://en.wikipedia.org/wiki/PCX
+// https://moddingwiki.shikadi.net/wiki/PCX_Format
 //-----------------------------------------------------------------------------------------------------
 
 #include "libqb-common.h"
@@ -183,36 +186,31 @@ class PCXImage {
     };
 
     // QB64 BGRA friendly color class
-    class Color {
-      public:
-        union BGRA32 {
-            struct Tuple {
+    struct Color {
+        union {
+            struct {
                 uint8_t b;
                 uint8_t g;
                 uint8_t r;
                 uint8_t a;
-            } tuple;
+            };
 
             uint32_t value;
-        } color;
+        };
 
         Color() {
-            color.value = 0;
+            value = 0;
         }
 
         Color(uint32_t value) {
-            color.value = value;
+            this->value = value;
         }
 
         Color(uint8_t b, uint8_t g, uint8_t r, uint8_t a = 0xFFu) {
-            SetFromComponents(b, g, r, a);
-        }
-
-        void SetFromComponents(uint8_t b, uint8_t g, uint8_t r, uint8_t a = 0xFFu) {
-            color.tuple.b = b;
-            color.tuple.g = g;
-            color.tuple.r = r;
-            color.tuple.a = a;
+            this->b = b;
+            this->g = g;
+            this->r = r;
+            this->a = a;
         }
     };
 
@@ -290,14 +288,14 @@ class PCXImage {
                 break;
 
             default:
-                throw std::runtime_error("Unsupported EGAPalette type: " + std::to_string(static_cast<uint8_t>(type)));
+                throw std::runtime_error("Unsupported EGAPalette type: " + std::to_string(uint8_t(type)));
             }
 
             m_palette.resize(16);
 
             for (auto i = 0; i < 16; i++)
-                m_palette[i].SetFromComponents((uint8_t)((egaPalette[i] >> 16) & 0xff), (uint8_t)((egaPalette[i] >> 8) & 0xff),
-                                               (uint8_t)((egaPalette[i]) & 0xff)); // NOTE: The color order the array is RGB
+                m_palette[i] = Color(uint8_t((egaPalette[i] >> 16) & 0xff), uint8_t((egaPalette[i] >> 8) & 0xff),
+                                     uint8_t((egaPalette[i]) & 0xff)); // NOTE: The color order the array is RGB
         }
 
         void LoadFromColorMap(const std::vector<uint8_t> &colorMap) {
@@ -306,15 +304,15 @@ class PCXImage {
 
             auto index = 0;
             for (auto i = 0; i < 16; i++) {
-                Color entry;
+                Color color;
 
                 // WARNING: Load order is important
-                entry.color.tuple.b = colorMap[index++];
-                entry.color.tuple.g = colorMap[index++];
-                entry.color.tuple.r = colorMap[index++];
-                entry.color.tuple.a = 255;
+                color.b = colorMap[index++];
+                color.g = colorMap[index++];
+                color.r = colorMap[index++];
+                color.a = 255;
 
-                m_palette[i] = entry;
+                m_palette[i] = color;
             }
         }
 
@@ -325,15 +323,15 @@ class PCXImage {
             m_palette.resize(size);
 
             for (size_t i = 0; i < m_palette.size(); ++i) {
-                Color entry;
+                Color color;
 
                 // WARNING: Read order is important
-                entry.color.tuple.b = input.Read<uint8_t>();
-                entry.color.tuple.g = input.Read<uint8_t>();
-                entry.color.tuple.r = input.Read<uint8_t>();
-                entry.color.tuple.a = 255;
+                color.b = input.Read<uint8_t>();
+                color.g = input.Read<uint8_t>();
+                color.r = input.Read<uint8_t>();
+                color.a = 255;
 
-                m_palette[i] = entry;
+                m_palette[i] = color;
             }
         }
     };
@@ -358,7 +356,7 @@ class PCXImage {
                 auto code = m_stream.Read<uint8_t>();
 
                 if ((code & RLEMask) == RLEMask) {
-                    m_count = static_cast<uint32_t>(code & (RLEMask ^ 0xff));
+                    m_count = uint32_t(code & (RLEMask ^ 0xff));
                     m_rleValue = m_stream.Read<uint8_t>();
 
                     m_count--;
@@ -392,7 +390,7 @@ class PCXImage {
             if (!(bitsPerPixel == 1 || bitsPerPixel == 2 || bitsPerPixel == 4 || bitsPerPixel == 8))
                 throw std::runtime_error("bitsPerPixel must be 1, 2, 4 or 8. Got: " + std::to_string(bitsPerPixel));
 
-            m_bitMask = (uint32_t)((1 << (int)m_bitsPerPixel) - 1);
+            m_bitMask = uint32_t((1 << (int)m_bitsPerPixel) - 1);
         }
 
         uint32_t ReadIndex() {
@@ -404,8 +402,8 @@ class PCXImage {
             }
 
             // NOTE: Reads from the most significant bits
-            uint32_t index = (m_byteRead >> (int)(8 - m_bitsPerPixel)) & m_bitMask;
-            m_byteRead <<= (int)m_bitsPerPixel;
+            uint32_t index = (m_byteRead >> int(8 - m_bitsPerPixel)) & m_bitMask;
+            m_byteRead <<= int(m_bitsPerPixel);
             m_bitsRemaining -= m_bitsPerPixel;
 
             return index;
@@ -457,29 +455,31 @@ class PCXImage {
         auto pixelsPerLine = header.bytesPerLine * 8 /*bitsPerByte*/ / header.bitsPerPixel;
 
         // Bits per pixel, including all bit planes
-        auto bitsPerPixel = header.bitsPerPixel * header.nPlanes;
+        auto bpp = header.bitsPerPixel * header.nPlanes;
 
-        if (bitsPerPixel != 1 && bitsPerPixel != 2 && bitsPerPixel != 4 && bitsPerPixel != 8 && bitsPerPixel != 24) {
-            image_log_error("Unsupported PCX bit depth: %d", bitsPerPixel);
+        if (bpp != 1 && bpp != 2 && bpp != 4 && bpp != 8 && bpp != 24 && bpp != 32) {
+            image_log_error("Unsupported PCX bit depth: %d", bpp);
 
             return;
         }
 
+        image_log_trace("Loading: %i x %i pixels @ %i bpp, %i planes, %i bits / plane", width, height, bpp, int(header.nPlanes), int(header.bitsPerPixel));
+
         // Load the palette
         Palette palette;
 
-        if (bitsPerPixel == 1) {
+        if (bpp == 1) {
             // HACK: Monochrome images don't always include a reasonable palette in v3.0.
             // Default them to black and white in all cases
 
             palette.LoadFromEGAPalette(Palette::EGAPalette::MONO);
-        } else if (bitsPerPixel < 8) {
+        } else if (bpp < 8) {
             // 16-color palette in the ColorMap portion of the header
 
             switch (header.version) {
             case Version::Version2_5:
             case Version::Version2_8_DefaultPalette: {
-                switch (bitsPerPixel) {
+                switch (bpp) {
                 // 4-color CGA palette
                 case 2:
                     palette.LoadFromEGAPalette(Palette::EGAPalette::CGA);
@@ -502,7 +502,7 @@ class PCXImage {
                 break;
             }
             }
-        } else if (bitsPerPixel == 8) {
+        } else if (bpp == 8) {
             // 256-color palette is saved at the end of the file, with one byte marker
 
             auto dataPosition = input.GetPosition();
@@ -519,7 +519,7 @@ class PCXImage {
 
             input.Seek(dataPosition);
         } else {
-            // Dummy palette for 24-bit images
+            // Dummy palette for 32-bit and 24-bit images
 
             palette.Resize(256);
         }
@@ -544,7 +544,7 @@ class PCXImage {
             auto dstRow = &(*out_data)[y * width];
             indexBuffer.assign(width, 0);
 
-            auto offset = 0;
+            size_t offset = 0;
 
             // Decode the RLE byte stream
             byteReader.Reset();
@@ -558,21 +558,27 @@ class PCXImage {
                     auto index = indexReader->ReadIndex();
 
                     // Account for padding bytes
-                    if (x < width)
-                        indexBuffer[x] = indexBuffer[x] | (index << (plane * header.bitsPerPixel));
+                    if (x < width) {
+                        indexBuffer[x] |= (index << (plane * header.bitsPerPixel));
+                    }
                 }
             }
 
             for (int x = 0; x < width; x++) {
                 uint32_t index = indexBuffer[x];
-                Color color;
 
-                if (bitsPerPixel == 24)
-                    color.SetFromComponents(image_get_bgra_blue(index), image_get_bgra_green(index), image_get_bgra_red(index));
-                else
-                    color = palette.GetColor(index);
+                switch (bpp) {
+                case 32:
+                    dstRow[offset] = index;
+                    break;
 
-                dstRow[offset] = color.color.value;
+                case 24:
+                    dstRow[offset] = Color(image_get_bgra_blue(index), image_get_bgra_green(index), image_get_bgra_red(index)).value;
+                    break;
+
+                default:
+                    dstRow[offset] = palette.GetColor(index).value;
+                }
 
                 ++offset;
             }


### PR DESCRIPTION
This PR does the following:

- Adds 3x and 4x XBR family pixel scalers.
- Adds support for ImageMagick-generated 32bpp PCX files (see @SteveMcNeill's post [here](https://qb64phoenix.com/forum/showthread.php?tid=3470&pid=32118#pid32118)).
- Cleans up and refactors bits of `image.cpp`, `sg_pcx.cpp`, `sg_curico.cpp`, `mmpx.cpp`, and `hqx.cpp` and suppresses some C++ compiler warnings.