### PR TITLE
Fix _MOUSEX and _MOUSEY when the mouse pointer is hidden on macOS

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -28251,7 +28251,7 @@ void GLUT_MOTION_FUNC(int x, int y) {
     int32 xrel, yrel;
 
     // This is used to save the last mouse position which is then paired with the mouse wheel event on macOS
-    macMouseUpdatePosition(x, y);
+    MacMouse_UpdatePosition(x, y);
 
     mouse_message_queue_struct *queue = &mouse_message_queue;
 

--- a/internal/c/libqb/include/mac-mouse-support.h
+++ b/internal/c/libqb/include/mac-mouse-support.h
@@ -1,21 +1,10 @@
 #pragma once
 
 #ifdef QB64_MACOSX
-void macMouseInit();
-void macMouseDone();
-void macMouseUpdatePosition(int x, int y);
-void macMouseAssociateMouseAndMouseCursorPosition(bool connected);
+void MacMouse_UpdatePosition(int x, int y);
 #else
-static inline void macMouseInit() {}
-
-static inline void macMouseDone() {}
-
-static inline void macMouseUpdatePosition(int x, int y) {
+static inline void MacMouse_UpdatePosition(int x, int y) {
     (void)x;
     (void)y;
-}
-
-static inline void macMouseAssociateMouseAndMouseCursorPosition(bool connected) {
-    (void)connected;
 }
 #endif

--- a/internal/c/libqb/src/glut-main-thread.cpp
+++ b/internal/c/libqb/src/glut-main-thread.cpp
@@ -110,8 +110,6 @@ static void initialize_glut(int argc, char **argv) {
 #ifdef CORE_FREEGLUT
     glutMouseWheelFunc(GLUT_MOUSEWHEEL_FUNC);
 #endif
-
-    macMouseInit();
 }
 
 static bool glut_is_started;

--- a/internal/c/libqb/src/glut-message.cpp
+++ b/internal/c/libqb/src/glut-message.cpp
@@ -18,13 +18,7 @@
 #include "mac-mouse-support.h"
 
 void glut_message_set_cursor::execute() {
-    if (style == GLUT_CURSOR_NONE) {
-        glutSetCursor(style);
-        macMouseAssociateMouseAndMouseCursorPosition(false);
-    } else {
-        macMouseAssociateMouseAndMouseCursorPosition(true);
-        glutSetCursor(style);
-    }
+    glutSetCursor(style);
 }
 
 void glut_message_warp_pointer::execute() {
@@ -56,6 +50,5 @@ void glut_message_set_window_title::execute() {
 }
 
 void glut_message_exit_program::execute() {
-    macMouseDone();
     exit(exitCode);
 }

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -9397,7 +9397,7 @@ DO
                 IF (t AND ISPOINTER) THEN t = t - ISPOINTER
                 'attempt conversion...
                 e$ = fixoperationorder$(var$): IF Error_Happened THEN GOTO errmes
-                l$ = l$ + sp2 + "," + sp + tlayout$ + sp + SCase$("As") + sp + SCase$(typ$)
+                l$ = l$ + sp2 + "," + sp + tlayout$ + sp + SCase$("As") + sp + SCase2$(typ$)
                 e$ = evaluatetotyp(e$, t): IF Error_Happened THEN GOTO errmes
                 st$ = typ2ctyp$(t, "")
                 varsize$ = str2((t AND 511) \ 8)
@@ -9504,7 +9504,7 @@ DO
                 IF (t AND ISPOINTER) THEN t = t - ISPOINTER
                 'attempt conversion...
                 e$ = fixoperationorder$(var$): IF Error_Happened THEN GOTO errmes
-                l$ = l$ + sp2 + "," + sp + tlayout$ + sp + SCase$("As") + sp + SCase$(typ$)
+                l$ = l$ + sp2 + "," + sp + tlayout$ + sp + SCase$("As") + sp + SCase2$(typ$)
                 e$ = evaluatetotyp(e$, t): IF Error_Happened THEN GOTO errmes
 
                 c$ = "sub__memfill_"


### PR DESCRIPTION
This partially reverses the approach taken in #602. Using `CGAssociateMouseAndMouseCursorPosition()` was a mistake - it fixed `_MOUSEMOVEMENTX` and `_MOUSEMOVEMENTY` for FPS-style camera movement but broke `_MOUSEX` and `_MOUSEY` by preventing GLUT from triggering the `glutMotionFunc` callback while the mouse pointer was hidden.

To address this, we now use `CGEventSourceSetLocalEventsSuppressionInterval()` to work around macOS’s 0.25-second event suppression. However, this means `_MOUSEMOVEMENTX` and `_MOUSEMOVEMENTY` remain broken because macOS generates artificial movement events when `glutWarpPointer` is used.

For now, this is an acceptable trade-off. A proper long-term fix depends on implementing #608.

Many thanks to `NakedApe` from the QB64-PE forum for pointing out the issue. See [this](https://qb64phoenix.com/forum/showthread.php?tid=3290).