### PR TITLE
Support Using System MinGW on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,11 +65,19 @@ ifeq ($(OS),win)
 	PATH_LIBQB := $(PATH_INTERNAL_C)\libqb
 	SHELL := cmd
 	CP := xcopy /E /C /H /R /Y
-	AR := $(PATH_INTERNAL_C)\c_compiler\bin\ar.exe
-	CC := $(PATH_INTERNAL_C)\c_compiler\bin\gcc.exe
-	CXX := $(PATH_INTERNAL_C)\c_compiler\bin\c++.exe
-	OBJCOPY := $(PATH_INTERNAL_C)\c_compiler\bin\objcopy.exe
-	WINDRES := $(PATH_INTERNAL_C)\c_compiler\bin\windres.exe
+	ifdef USE_SYSTEM_MINGW
+		AR := ar.exe
+		CC := gcc.exe
+		CXX := c++.exe
+		OBJCOPY := objcopy.exe
+		WINDRES := windres.exe
+	else
+		AR := $(PATH_INTERNAL_C)\c_compiler\bin\ar.exe
+		CC := $(PATH_INTERNAL_C)\c_compiler\bin\gcc.exe
+		CXX := $(PATH_INTERNAL_C)\c_compiler\bin\c++.exe
+		OBJCOPY := $(PATH_INTERNAL_C)\c_compiler\bin\objcopy.exe
+		WINDRES := $(PATH_INTERNAL_C)\c_compiler\bin\windres.exe
+	endif
 	ICON_OBJ := $(PATH_INTERNAL_TEMP)\icon.o
 	RM := del /Q
 	MKDIR := mkdir

--- a/internal/c/parts/network/http/build.mk
+++ b/internal/c/parts/network/http/build.mk
@@ -6,10 +6,17 @@ CURL_LIB := $(PATH_INTERNAL_C)/parts/network/http/libcurl.a
 
 CURL_MAKE_FLAGS := CFG=-schannel
 CURL_MAKE_FLAGS += "CURL_CFLAG_EXTRAS=-DCURL_STATICLIB -DHTTP_ONLY"
-CURL_MAKE_FLAGS += CC=../../../../c_compiler/bin/gcc.exe
-CURL_MAKE_FLAGS += AR=../../../../c_compiler/bin/ar.exe
-CURL_MAKE_FLAGS += RANLIB=../../../../c_compiler/bin/ranlib.exe
-CURL_MAKE_FLAGS += STRIP=../../../../c_compiler/bin/strip.exe
+ifdef USE_SYSTEM_MINGW
+	CURL_MAKE_FLAGS += CC=gcc.exe
+	CURL_MAKE_FLAGS += AR=ar.exe
+	CURL_MAKE_FLAGS += RANLIB=ranlib.exe
+	CURL_MAKE_FLAGS += STRIP=strip.exe
+else
+	CURL_MAKE_FLAGS += CC=../../../../c_compiler/bin/gcc.exe
+	CURL_MAKE_FLAGS += AR=../../../../c_compiler/bin/ar.exe
+	CURL_MAKE_FLAGS += RANLIB=../../../../c_compiler/bin/ranlib.exe
+	CURL_MAKE_FLAGS += STRIP=../../../../c_compiler/bin/strip.exe
+endif
 CURL_MAKE_FLAGS += libcurl_a_LIBRARY="../libcurl.a"
 CURL_MAKE_FLAGS += ARCH=w$(BITS)
 

--- a/setup_mingw.cmd
+++ b/setup_mingw.cmd
@@ -65,19 +65,19 @@ rem MINGW_DIR is actually the internal directory name inside the zip file
 rem It needs to be updated whenever the toolchains are updated
 if "%ARCH%" == "ARM" (
     if %BITS% == 64 (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-aarch64.zip"
-        set MINGW_DIR=llvm-mingw-20250114-ucrt-aarch64
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250402/llvm-mingw-20250402-ucrt-aarch64.zip"
+        set MINGW_DIR=llvm-mingw-20250402-ucrt-aarch64
     ) else (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-armv7.zip"
-        set MINGW_DIR=llvm-mingw-20250114-ucrt-armv7
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250402/llvm-mingw-20250402-ucrt-armv7.zip"
+        set MINGW_DIR=llvm-mingw-20250402-ucrt-armv7
     )
 ) else (
     if %BITS% == 64 (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-x86_64.zip"
-        set MINGW_DIR=llvm-mingw-20250114-ucrt-x86_64
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250402/llvm-mingw-20250402-ucrt-x86_64.zip"
+        set MINGW_DIR=llvm-mingw-20250402-ucrt-x86_64
     ) else (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250114/llvm-mingw-20250114-ucrt-i686.zip"
-        set MINGW_DIR=llvm-mingw-20250114-ucrt-i686
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250402/llvm-mingw-20250402-ucrt-i686.zip"
+        set MINGW_DIR=llvm-mingw-20250402-ucrt-i686
     )
 )
 

--- a/source/ide/config/cfg_global.bas
+++ b/source/ide/config/cfg_global.bas
@@ -33,6 +33,7 @@ DIM SHARED GenerateLicenseFile AS LONG
 DIM SHARED UseGuiDialogs AS _UNSIGNED LONG
 DIM SHARED DefaultTerminal AS STRING
 DIM SHARED LoggingEnabled AS _UNSIGNED LONG
+DIM SHARED UseSystemMinGW AS LONG
 
 '===== Define and check settings location =====================================
 ConfigFolder$ = "settings" 'relative config location inside the qb64pe main folder

--- a/source/ide/config/cfg_methods.bas
+++ b/source/ide/config/cfg_methods.bas
@@ -605,5 +605,11 @@ SUB ReadInitialConfig
     ExtraLinkerFlags = ReadWriteStringSettingValue$(compilerSettingsSection$, "ExtraLinkerFlags", "")
 
     GenerateLicenseFile = ReadWriteBooleanSettingValue%(compilerSettingsSection$, "GenerateLicenseFile", 0)
+
+    IF os$ = "WIN" THEN
+        UseSystemMinGW = ReadWriteBooleanSettingValue%(compilerSettingsSection$, "UseSystemMinGW", _FALSE)
+    ELSE
+        UseSystemMinGW = _TRUE  ' always use the system compiler on non-Windows platforms
+    END IF
 END SUB
 

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -15689,7 +15689,7 @@ FUNCTION ideCompilerSettingsBox
 
     '-------- init dialog box & objects --------
     i = 0
-    idepar p, 48, 15, "Compiler Settings"
+    idepar p, 48, _IIF(os$ = "WIN", 16, 15), "Compiler Settings"
 
     i = i + 1: ocpChk = i
     o(i).typ = 4 'check box
@@ -15732,9 +15732,17 @@ FUNCTION ideCompilerSettingsBox
     o(i).x = 44: o(i).y = 12
     o(i).txt = idenewtxt(CHR$(31)): o(i).rpt = 10
 
+    IF os$ = "WIN" THEN
+        i = i + 1: uscChk = i
+        o(i).typ = 4 'check box
+        o(i).y = 14
+        o(i).nam = idenewtxt("#Use system compiler")
+        o(i).sel = ABS(UseSystemMinGW)
+    END IF
+
     i = i + 1: okBut = i: caBut = i + 1
     o(i).typ = 3 'action buttons
-    o(i).y = 15
+    o(i).y = _IIF(os$ = "WIN", 16, 15)
     o(i).txt = idenewtxt("#OK" + sep + "#Cancel"): o(i).dft = 1
     '-------- end of init dialog box & objects --------
 
@@ -15863,6 +15871,17 @@ FUNCTION ideCompilerSettingsBox
             v% = VAL(idetxt(o(mppBox).txt))
             IF MaxParallelProcesses <> v% THEN MaxParallelProcesses = v%: optChg% = -1
 
+            IF os$ = "WIN" THEN
+                v% = o(uscChk).sel: IF v% <> 0 THEN v% = _TRUE
+                IF UseSystemMinGW <> v% THEN UseSystemMinGW = v%: optChg% = _TRUE
+
+                ' Show a warning if the user is using the system MinGW compiler
+                IF UseSystemMinGW _ANDALSO optChg% THEN
+                    retval = idemessagebox("Warning", "Using the system MinGW compiler may cause problems.", "#OK")
+                    PCOPY 2, 1
+                END IF
+            END IF
+
             IF optChg% THEN
                 'save changes
                 WriteConfigSetting compilerSettingsSection$, "OptimizeCppProgram", BoolToTFString$(OptimizeCppProgram)
@@ -15873,6 +15892,10 @@ FUNCTION ideCompilerSettingsBox
                 WriteConfigSetting compilerSettingsSection$, "ExtraLinkerFlags", ExtraLinkerFlags$
 
                 WriteConfigSetting compilerSettingsSection$, "MaxParallelProcesses", str2$(MaxParallelProcesses)
+
+                IF os$ = "WIN" THEN
+                    WriteConfigSetting compilerSettingsSection$, "UseSystemMinGW", BoolToTFString$(UseSystemMinGW)
+                END IF
 
                 'clean compiled files, since they may change due to the different settings
                 PurgeTemporaryBuildFiles (os$), (MacOSX)

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -13419,7 +13419,8 @@ SUB CMDLineTemporarySettingsHelp
     PRINT "  -f:ExtraLinkerFlags=[string]          Extra flags for the Linker"
     PRINT "  -f:MaxCompilerProcesses=[integer]     Max C++ Compiler processes to use"
     PRINT "  -f:GenerateLicenseFile=[true|false]   Produce a license.txt file for program"
-    PRINT "  -f:UseSystemCompiler=[true|false]     Use the system C++ compiler instead of the bundled one (Windows only)"
+    PRINT "  -f:UseSystemCompiler=[true|false]     Use the system C++ compiler instead of"
+    PRINT "                                        the bundled one (Windows only)"
     PRINT
     PRINT "Supported (-f) Layout settings:"
     PRINT "  -f:AutoIndent=[true|false]            Auto Indent lines"

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -89,7 +89,6 @@ IF _DIREXISTS("internal") = 0 THEN
 END IF
 
 DIM SHARED Include_GDB_Debugging_Info 'set using "config.ini" or "Compiler settings" dialog
-DIM SHARED UseSystemMinGW AS _BYTE
 
 DIM SHARED DEPENDENCY_LAST
 CONST DEPENDENCY_LOADFONT = 1: DEPENDENCY_LAST = DEPENDENCY_LAST + 1
@@ -13307,6 +13306,8 @@ FUNCTION ParseCMDLineArgs$ ()
                         IF MaxParallelProcesses <= 0 THEN CMDLineSettingsError "MaxCompilerProcesses must be graeter than zero.", 0, 1
                     CASE ":generatelicensefile"
                         IF NOT ParseBooleanSetting&(token$, GenerateLicenseFile) THEN CMDLineSettingsError token$, 1, 1
+                    CASE ":usesystemcompiler"
+                        IF NOT ParseBooleanSetting&(token$, UseSystemMinGW) THEN CMDLineSettingsError token$, 1, 1
                     CASE ":autoindent"
                         IF NOT ParseBooleanSetting&(token$, IDEAutoIndent) THEN CMDLineSettingsError token$, 1, 1
                         DEFAutoIndent = IDEAutoIndent 'for restoring after '$FORMAT:OFF
@@ -13418,6 +13419,7 @@ SUB CMDLineTemporarySettingsHelp
     PRINT "  -f:ExtraLinkerFlags=[string]          Extra flags for the Linker"
     PRINT "  -f:MaxCompilerProcesses=[integer]     Max C++ Compiler processes to use"
     PRINT "  -f:GenerateLicenseFile=[true|false]   Produce a license.txt file for program"
+    PRINT "  -f:UseSystemCompiler=[true|false]     Use the system C++ compiler instead of the bundled one (Windows only)"
     PRINT
     PRINT "Supported (-f) Layout settings:"
     PRINT "  -f:AutoIndent=[true|false]            Auto Indent lines"

--- a/source/utilities/build.bas
+++ b/source/utilities/build.bas
@@ -3,15 +3,13 @@
 ' Removes all the temporary build files (Various .o, .a, and ./internal/temp, among other things)
 '
 SUB PurgeTemporaryBuildFiles (os AS STRING, mac AS LONG)
-    make$ = GetMakeExecutable$
-
     IF os = "WIN" THEN
-        SHELL _HIDE "cmd /c " + make$ + " OS=win clean"
+        SHELL _HIDE "cmd /c " + GetMakeExecutable$ + " OS=win clean"
     ELSEIF os = "LNX" THEN
         IF mac THEN
-            SHELL _HIDE make$ + " OS=osx clean"
+            SHELL _HIDE GetMakeExecutable$ + " OS=osx clean"
         ELSE
-            SHELL _HIDE make$ + " OS=lnx clean"
+            SHELL _HIDE GetMakeExecutable$ + " OS=lnx clean"
         END IF
     END IF
 END SUB
@@ -21,10 +19,14 @@ END SUB
 '
 FUNCTION GetMakeExecutable$ ()
     IF os$ = "WIN" THEN
-        GetMakeExecutable$ = "internal\c\c_compiler\bin\mingw32-make.exe"
+        GetMakeExecutable$ = GetCompilerPath$ + "mingw32-make.exe"
     ELSE
         GetMakeExecutable$ = "make"
     END IF
+END FUNCTION
+
+FUNCTION GetCompilerPath$
+    GetCompilerPath$ = _IIF(UseSystemMinGW, "", "internal\c\c_compiler\bin\")
 END FUNCTION
 
 FUNCTION MakeNMOutputFilename$ (libfile AS STRING, dynamic AS LONG)


### PR DESCRIPTION
This change adds support for using a system-installed compiler on Windows, such as a pre-existing MinGW toolchain (from MSYS2, Winget etc.). This can be helpful in situations where the user either cannot or prefers not to use the compiler bundled with QB64-PE.

A clear warning is displayed when this option is enabled to ensure users understand the implications. This feature is available exclusively on Windows.