### PR TITLE
Fix IDE error when loading large source file

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -12689,6 +12689,10 @@ SUB ideshowtext
                 manualList = -1
                 listOfCustomKeywords$ = LEFT$(listOfCustomKeywords$, customKeywordsLength)
                 FOR y = 1 TO iden
+                    DO UNTIL y < UBOUND(InvalidLine)
+                        REDIM _PRESERVE InvalidLine(UBOUND(InvalidLine) + 1000) AS _BYTE
+                    LOOP
+
                     IF InvalidLine(y) <> 0 THEN _CONTINUE
                     a$ = UCASE$(_TRIM$(idegetline(y)))
                     sf = 0


### PR DESCRIPTION
The IDE would crash when a large source file was loaded and the syntax highlighter had to build the list of sub/functions on its own, due to errors in the loaded file preventing compilation from going through.