### PR TITLE
Add Windows on ARM CI support using LLVM-MingW

### DIFF
--- a/.ci/bootstrap.bat
+++ b/.ci/bootstrap.bat
@@ -2,11 +2,15 @@
 SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 
 pushd .
+
 IF "%PLATFORM%"=="x64" (
     call setup_mingw.cmd 64
-) else (
+) ELSE IF "%PLATFORM%"=="arm64" (
+    call setup_mingw.cmd 64
+) ELSE (
     call setup_mingw.cmd 32
 )
+
 popd
 
 echo Bootstrapping QB64-PE

--- a/.github/workflows/build-process.yml
+++ b/.github/workflows/build-process.yml
@@ -21,6 +21,9 @@ jobs:
           - os: windows-2022
             platform: x86
             prefix: win
+          - os: windows-11-arm
+            platform: arm64
+            prefix: win
 
     runs-on: ${{ matrix.os }}
 
@@ -118,6 +121,7 @@ jobs:
           tests/results/
           qb64pe_win-x86*.7z
           qb64pe_win-x64*.7z
+          qb64pe_win-arm64*.7z
           qb64pe_lnx*.tar.gz
           qb64pe_osx*.tar.gz
 
@@ -129,6 +133,7 @@ jobs:
         files: |
           qb64pe_win-x86*.7z
           qb64pe_win-x64*.7z
+          qb64pe_win-arm64*.7z
           qb64pe_lnx*.tar.gz
           qb64pe_osx*.tar.gz
       env:

--- a/setup_mingw.cmd
+++ b/setup_mingw.cmd
@@ -65,19 +65,19 @@ rem MINGW_DIR is actually the internal directory name inside the zip file
 rem It needs to be updated whenever the toolchains are updated
 if "%ARCH%" == "ARM" (
     if %BITS% == 64 (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250402/llvm-mingw-20250402-ucrt-aarch64.zip"
-        set MINGW_DIR=llvm-mingw-20250402-ucrt-aarch64
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250514/llvm-mingw-20250514-ucrt-aarch64.zip"
+        set MINGW_DIR=llvm-mingw-20250514-ucrt-aarch64
     ) else (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250402/llvm-mingw-20250402-ucrt-armv7.zip"
-        set MINGW_DIR=llvm-mingw-20250402-ucrt-armv7
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250514/llvm-mingw-20250514-ucrt-armv7.zip"
+        set MINGW_DIR=llvm-mingw-20250514-ucrt-armv7
     )
 ) else (
     if %BITS% == 64 (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250402/llvm-mingw-20250402-ucrt-x86_64.zip"
-        set MINGW_DIR=llvm-mingw-20250402-ucrt-x86_64
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250514/llvm-mingw-20250514-ucrt-x86_64.zip"
+        set MINGW_DIR=llvm-mingw-20250514-ucrt-x86_64
     ) else (
-        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250402/llvm-mingw-20250402-ucrt-i686.zip"
-        set MINGW_DIR=llvm-mingw-20250402-ucrt-i686
+        set URL="https://github.com/mstorsjo/llvm-mingw/releases/download/20250514/llvm-mingw-20250514-ucrt-i686.zip"
+        set MINGW_DIR=llvm-mingw-20250514-ucrt-i686
     )
 )
 

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -113,7 +113,12 @@ DIM SHARED UseGL 'declared SUB _GL (no params)
 
 DIM SHARED WindowTitle AS STRING
 
-IF OS_BITS = 32 THEN WindowTitle = "QB64 Phoenix Edition (x32)" ELSE WindowTitle = "QB64 Phoenix Edition (x64)"
+IF INSTR(_OS$, "ARM") THEN
+    WindowTitle = "QB64 Phoenix Edition " + _IIF(OS_BITS = 32, "(ARM)", "(ARM64)")
+ELSE
+    WindowTitle = "QB64 Phoenix Edition " + _IIF(OS_BITS = 32, "(x86)", "(x64)")
+END IF
+
 _TITLE WindowTitle
 
 CONST METACOMMAND_STRING_ENCLOSING_PAIR = "''"


### PR DESCRIPTION
This PR adds support for building QB64-PE on Windows on ARM via GitHub Actions. This enables full native compilation of QB64-PE on Windows on ARM devices using LLVM-MingW.

Closes #313.