### PR TITLE
Fixes and Additions

### DIFF
--- a/source/utilities/terminal.bas
+++ b/source/utilities/terminal.bas
@@ -5,7 +5,7 @@
 ' The user can replace the result with their own configuration, this is just a
 ' best effort to find a working default.
 FUNCTION findWorkingTerminal$ ()
-    DIM Exes$(7), Formats$(7)
+    DIM Exes$(8), Formats$(8)
     Exes$(1) = "gnome-terminal": Formats$(1) = "-- $$ $@"
     Exes$(2) = "konsole": Formats$(2) = "-e $$ $@"
     Exes$(3) = "lxterminal": Formats$(3) = "-e $$ $@"
@@ -13,6 +13,7 @@ FUNCTION findWorkingTerminal$ ()
     Exes$(5) = "xfce4-terminal": Formats$(5) = "-x $$ $@"
     Exes$(6) = "urxvt": Formats$(6) = "-e $$ $@"
     Exes$(7) = "xterm": Formats$(7) = "-e $$ $@"
+    Exes$(8) = "ptyxis": Formats$(8) = "-- $$ $@"
 
     FOR i = 1 TO UBOUND(Exes$)
         ret& = SHELL("command -v " + CHR$(34) + Exes$(i) + CHR$(34) + " >/dev/null 2>&1")


### PR DESCRIPTION
- Moved $USELIBRARY evaluation from main pass to pre-pass (required to be able to use lib defined UDTs as SUB/FUNC parameters). Bug was revealed by @a740g 's QBDS libraries.
- Added Linux `ptyxis` terminal defaults in `findWorkingTerminal$ ()` function.