### PR TITLE
Fixes an IDE module error

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -13122,7 +13122,7 @@ SUB ideshowtext
 
                 COLOR 13
 
-                IF InvalidLine(l) THEN COLOR 7: GOTO SkipSyntaxHighlighter
+                IF l > iden _ORELSE InvalidLine(l) THEN COLOR 7: GOTO SkipSyntaxHighlighter
 
                 IF (LEN(oldChar$) > 0 OR m = 1) AND inquote = 0 AND isKeyword = 0 THEN
                     IF INSTR(initialNum.char$, thisChar$) > 0 AND oldChar$ <> ")" AND (INSTR(char.sep$, oldChar$) > 0 OR oldChar$ = "?") THEN


### PR DESCRIPTION
The fix is very simple, but the bug was rather subtle in nature and hard to hunt down.

If there was a program with a line count close below the next 1000s boundary and a search was performed, then if the found position was close to the program end and the IDE window height was bigger than the remaining program lines after the found match, then empty line padding could lead to a "subscribt out of range" error in an internal array in case the number of empty padding lines was bigger than the difference of the next 1000s boundary minus total program lines.

So 4 almost impossible conditions played into this bug:
- our internal array growing logic in steps of 1000
- the total line count of the currently edited program
- the IDE height the user chose to use
- the probability of getting a search hit near the program end

It was like winning the Jackpot for someone to run into this bug.