### PR TITLE
Restore IDE behavior when Autobrackets is disabled

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -4399,6 +4399,8 @@ FUNCTION ide2 (ignore)
         a$ = idegetline(idecy)
         IF LEN(a$) < idecx - 1 THEN a$ = a$ + SPACE$(idecx - 1 - LEN(a$))
 
+
+     IF AutoCloseBrackets THEN 'enable new behavior if autoclosebrackets is in use
         skipInsert = 0
         IF ideinsert = 0 THEN 'Insert mode
             nextChar$ = MID$(a$, idecx, 1)
@@ -4436,6 +4438,20 @@ FUNCTION ide2 (ignore)
             END IF
             idesetline idecy, a$
         END IF
+      ELSE 'otherwise go back to the old behavior
+        'Replace old code back
+
+        IF ideinsert THEN
+            a2$ = RIGHT$(a$, LEN(a$) - idecx + 1)
+            IF LEN(a2$) THEN a2$ = RIGHT$(a$, LEN(a$) - idecx)
+            a$ = LEFT$(a$, idecx - 1) + K$ + a2$
+        ELSE
+            a$ = LEFT$(a$, idecx - 1) + K$ + RIGHT$(a$, LEN(a$) - idecx + 1)
+        END IF
+
+        idesetline idecy, a$
+        'end of old code
+       END IF
 
         idecx = idecx + LEN(K$)
         specialchar:


### PR DESCRIPTION
With the change to autobrackets a while back, the IDE suddenly started to just skip over end bracket type symbols if one were to type them and the next character was an end bracket.  This makes sense with the autobracket enabled, but when it's turned off, those keystrokes should be processed as before, without skipping that next character.

This just ties the behavior to that toggle variable to where it skips the character when the autobrackets is enabled, but restores the old behavior when it's not.