### PR TITLE
_PUTIMAGE text surface support

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -4418,28 +4418,33 @@ resolve_coordinates:
         int32 clipLeadY = 0;
         int32 clipTrailY = 0;
 
+        const int32 srcClipX1 = s->clipping_or_scaling ? s->view_x1 : 0;
+        const int32 srcClipY1 = s->clipping_or_scaling ? s->view_y1 : 0;
+        const int32 srcClipX2 = s->clipping_or_scaling ? s->view_x2 : (sw - 1);
+        const int32 srcClipY2 = s->clipping_or_scaling ? s->view_y2 : (sh - 1);
+
         if (srcCellStepX > 0) {
-            if (sx1 < 0)
-                clipLeadX = -sx1;
-            if (sx2 >= sw)
-                clipTrailX = sx2 - (sw - 1);
+            if (sx1 < srcClipX1)
+                clipLeadX = srcClipX1 - sx1;
+            if (sx2 > srcClipX2)
+                clipTrailX = sx2 - srcClipX2;
         } else {
-            if (sx1 >= sw)
-                clipLeadX = sx1 - (sw - 1);
-            if (sx2 < 0)
-                clipTrailX = -sx2;
+            if (sx1 > srcClipX2)
+                clipLeadX = sx1 - srcClipX2;
+            if (sx2 < srcClipX1)
+                clipTrailX = srcClipX1 - sx2;
         }
 
         if (srcCellStepY > 0) {
-            if (sy1 < 0)
-                clipLeadY = -sy1;
-            if (sy2 >= sh)
-                clipTrailY = sy2 - (sh - 1);
+            if (sy1 < srcClipY1)
+                clipLeadY = srcClipY1 - sy1;
+            if (sy2 > srcClipY2)
+                clipTrailY = sy2 - srcClipY2;
         } else {
-            if (sy1 >= sh)
-                clipLeadY = sy1 - (sh - 1);
-            if (sy2 < 0)
-                clipTrailY = -sy2;
+            if (sy1 > srcClipY2)
+                clipLeadY = sy1 - srcClipY2;
+            if (sy2 < srcClipY1)
+                clipTrailY = srcClipY1 - sy2;
         }
 
         if ((clipLeadX + clipTrailX >= srcCellsW) || (clipLeadY + clipTrailY >= srcCellsH))
@@ -4465,11 +4470,15 @@ resolve_coordinates:
 
         if (d->text) {
             auto dstData = reinterpret_cast<uint16 *>(d->offset);
+            const int32 viewPrintTop = d->top_row - 1;
+            const int32 viewPrintBottom = d->bottom_row - 1;
 
             for (int32 cellY = 0; cellY < clippedCellsH; ++cellY) {
                 const int32 srcY = sy1 + cellY * srcCellStepY;
                 const int32 dstY = dy1 + cellY * dstStepY;
                 if ((dstY < 0) || (dstY >= d->height))
+                    continue;
+                if ((dstY < viewPrintTop) || (dstY > viewPrintBottom))
                     continue;
 
                 for (int32 cellX = 0; cellX < clippedCellsW; ++cellX) {
@@ -4484,6 +4493,11 @@ resolve_coordinates:
                 }
             }
         } else {
+            const int32 dstClipX1 = d->clipping_or_scaling ? d->view_x1 : 0;
+            const int32 dstClipY1 = d->clipping_or_scaling ? d->view_y1 : 0;
+            const int32 dstClipX2 = d->clipping_or_scaling ? d->view_x2 : (d->width - 1);
+            const int32 dstClipY2 = d->clipping_or_scaling ? d->view_y2 : (d->height - 1);
+
             for (int32 cellY = 0; cellY < clippedCellsH; ++cellY) {
                 const int32 srcY = sy1 + cellY * srcCellStepY;
 
@@ -4514,12 +4528,12 @@ resolve_coordinates:
                     if (d->bits_per_pixel == 32) {
                         for (int32 py = 0; py < fontHeight; ++py) {
                             const int32 dstY = dy1 + dstStepY * (cellY * fontHeight + py);
-                            if ((dstY < 0) || (dstY >= d->height))
+                            if ((dstY < dstClipY1) || (dstY > dstClipY2))
                                 continue;
 
                             for (int32 px = 0; px < fontWidth; ++px) {
                                 const int32 dstX = dx1 + dstStepX * (cellX * fontWidth + px);
-                                if ((dstX < 0) || (dstX >= d->width))
+                                if ((dstX < dstClipX1) || (dstX > dstClipX2))
                                     continue;
 
                                 const uint8 bit = glyphBits[py * fontWidth + px];
@@ -4529,12 +4543,12 @@ resolve_coordinates:
                     } else {
                         for (int32 py = 0; py < fontHeight; ++py) {
                             const int32 dstY = dy1 + dstStepY * (cellY * fontHeight + py);
-                            if ((dstY < 0) || (dstY >= d->height))
+                            if ((dstY < dstClipY1) || (dstY > dstClipY2))
                                 continue;
 
                             for (int32 px = 0; px < fontWidth; ++px) {
                                 const int32 dstX = dx1 + dstStepX * (cellX * fontWidth + px);
-                                if ((dstX < 0) || (dstX >= d->width))
+                                if ((dstX < dstClipX1) || (dstX > dstClipX2))
                                     continue;
 
                                 const uint8 bit = glyphBits[py * fontWidth + px];

--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -4387,8 +4387,8 @@ resolve_coordinates:
 
         const int32 srcCellsW = abs(sx2 - sx1) + 1;
         const int32 srcCellsH = abs(sy2 - sy1) + 1;
-        const int32 fontWidth = 8;
-        const int32 fontHeight = (s->font == 8 || s->font == 14) ? s->font : 16;
+        const int32 fontWidth = fontwidth[s->font];
+        const int32 fontHeight = fontheight[s->font];
         const int32 expectedDstW = d->text ? srcCellsW : (srcCellsW * fontWidth);
         const int32 expectedDstH = d->text ? srcCellsH : (srcCellsH * fontHeight);
 
@@ -4513,16 +4513,25 @@ resolve_coordinates:
                     const uint8 bc = uint8(((attr >> 4) & 7) + ((attr >> 7) << 3));
 
                     const uint8 *glyphBits;
-                    switch (fontHeight) {
-                    case 8:
-                        glyphBits = &charset8x8[c][0][0];
-                        break;
-                    case 14:
-                        glyphBits = &charset8x16[c][1][0];
-                        break;
-                    default:
-                        glyphBits = &charset8x16[c][0][0];
-                        break;
+                    uint8 *ttfGlyphData = nullptr;
+
+                    if (s->font >= 32) {
+                        int32 rt_w, rt_h;
+                        if (!FontRenderTextASCII(font[s->font], &c, 1, FONT_RENDER_MONOCHROME, &ttfGlyphData, &rt_w, &rt_h))
+                            continue;
+                        glyphBits = ttfGlyphData;
+                    } else {
+                        switch (fontHeight) {
+                        case 8:
+                            glyphBits = &charset8x8[c][0][0];
+                            break;
+                        case 14:
+                            glyphBits = &charset8x16[c][1][0];
+                            break;
+                        default:
+                            glyphBits = &charset8x16[c][0][0];
+                            break;
+                        }
                     }
 
                     if (d->bits_per_pixel == 32) {
@@ -4555,6 +4564,11 @@ resolve_coordinates:
                                 d->offset[dstY * d->width + dstX] = bit ? fc : bc;
                             }
                         }
+                    }
+
+                    if (ttfGlyphData) {
+                        free(ttfGlyphData);
+                        ttfGlyphData = nullptr;
                     }
                 }
             }

--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -4067,6 +4067,9 @@ void flush_old_hardware_commands() {
     } // next_hardware_command_to_remove&&last_hardware_command_rendered
 } // flush_old_hardware_commands
 
+uint8 charset8x8[256][8][8];
+uint8 charset8x16[256][16][8];
+
 void sub__putimage(double f_dx1, double f_dy1, double f_dx2, double f_dy2, int32 src, int32 dst, double f_sx1, double f_sy1, double f_sx2, double f_sy2,
                    int32 passed) {
 
@@ -4168,10 +4171,6 @@ void sub__putimage(double f_dx1, double f_dy1, double f_dx2, double f_dy2, int32
     } else {
         s = read_page;
     } // src
-    if (s->text) {
-        error(5);
-        return;
-    }
     sbpp = s->bytes_per_pixel;
 
     if (passed & 32) { // dst
@@ -4194,11 +4193,18 @@ void sub__putimage(double f_dx1, double f_dy1, double f_dx2, double f_dy2, int32
     } else {
         d = write_page;
     } // dst
-    if (d->text) {
+    if (!s->text && d->text) {
         error(5);
         return;
     }
     dbpp = d->bytes_per_pixel;
+    if (s->text && !d->text) {
+        // Text glyphs use up to 16 palette indices; destination must be able to represent all of them.
+        if ((d->bits_per_pixel != 32) && (d->bits_per_pixel < 4)) {
+            error(5);
+            return;
+        }
+    }
     if ((sbpp == 4) && (dbpp == 1)) {
         error(5);
         return;
@@ -4357,6 +4363,191 @@ resolve_coordinates:
     } // sx1,sy1
 
     // all co-ordinates resolved (but omitted co-ordinates are set to 0!)
+
+    if (s->text) {
+        int32 srcCellStepX = 1;
+        int32 srcCellStepY = 1;
+        int32 dstStepX = 1;
+        int32 dstStepY = 1;
+
+        if (passed & 64) {
+            if (passed & 512) {
+                srcCellStepX = (sx2 >= sx1) ? 1 : -1;
+                srcCellStepY = (sy2 >= sy1) ? 1 : -1;
+            } else {
+                sx2 = sw - 1;
+                sy2 = sh - 1;
+            }
+        } else {
+            sx1 = 0;
+            sy1 = 0;
+            sx2 = sw - 1;
+            sy2 = sh - 1;
+        }
+
+        const int32 srcCellsW = abs(sx2 - sx1) + 1;
+        const int32 srcCellsH = abs(sy2 - sy1) + 1;
+        const int32 fontWidth = 8;
+        const int32 fontHeight = (s->font == 8 || s->font == 14) ? s->font : 16;
+        const int32 expectedDstW = d->text ? srcCellsW : (srcCellsW * fontWidth);
+        const int32 expectedDstH = d->text ? srcCellsH : (srcCellsH * fontHeight);
+
+        if (passed & 1) {
+            if (passed & 4) {
+                dstStepX = (dx2 >= dx1) ? 1 : -1;
+                dstStepY = (dy2 >= dy1) ? 1 : -1;
+
+                // Text source blit is copy-only (no scaling).
+                if (((abs(dx2 - dx1) + 1) != expectedDstW) || ((abs(dy2 - dy1) + 1) != expectedDstH)) {
+                    error(5);
+                    return;
+                }
+            } else {
+                dx2 = dx1 + expectedDstW - 1;
+                dy2 = dy1 + expectedDstH - 1;
+            }
+        } else {
+            dx1 = 0;
+            dy1 = 0;
+            dx2 = expectedDstW - 1;
+            dy2 = expectedDstH - 1;
+        }
+
+        int32 clipLeadX = 0;
+        int32 clipTrailX = 0;
+        int32 clipLeadY = 0;
+        int32 clipTrailY = 0;
+
+        if (srcCellStepX > 0) {
+            if (sx1 < 0)
+                clipLeadX = -sx1;
+            if (sx2 >= sw)
+                clipTrailX = sx2 - (sw - 1);
+        } else {
+            if (sx1 >= sw)
+                clipLeadX = sx1 - (sw - 1);
+            if (sx2 < 0)
+                clipTrailX = -sx2;
+        }
+
+        if (srcCellStepY > 0) {
+            if (sy1 < 0)
+                clipLeadY = -sy1;
+            if (sy2 >= sh)
+                clipTrailY = sy2 - (sh - 1);
+        } else {
+            if (sy1 >= sh)
+                clipLeadY = sy1 - (sh - 1);
+            if (sy2 < 0)
+                clipTrailY = -sy2;
+        }
+
+        if ((clipLeadX + clipTrailX >= srcCellsW) || (clipLeadY + clipTrailY >= srcCellsH))
+            return;
+
+        sx1 += srcCellStepX * clipLeadX;
+        sy1 += srcCellStepY * clipLeadY;
+        sx2 -= srcCellStepX * clipTrailX;
+        sy2 -= srcCellStepY * clipTrailY;
+
+        const int32 dstUnitX = d->text ? 1 : fontWidth;
+        const int32 dstUnitY = d->text ? 1 : fontHeight;
+        dx1 += dstStepX * clipLeadX * dstUnitX;
+        dy1 += dstStepY * clipLeadY * dstUnitY;
+        dx2 -= dstStepX * clipTrailX * dstUnitX;
+        dy2 -= dstStepY * clipTrailY * dstUnitY;
+
+        const int32 clippedCellsW = abs(sx2 - sx1) + 1;
+        const int32 clippedCellsH = abs(sy2 - sy1) + 1;
+
+        auto srcData = reinterpret_cast<uint16 *>(s->offset);
+        const uint32 textTransparentColor = uint32(s->transparent_color);
+
+        if (d->text) {
+            auto dstData = reinterpret_cast<uint16 *>(d->offset);
+
+            for (int32 cellY = 0; cellY < clippedCellsH; ++cellY) {
+                const int32 srcY = sy1 + cellY * srcCellStepY;
+                const int32 dstY = dy1 + cellY * dstStepY;
+                if ((dstY < 0) || (dstY >= d->height))
+                    continue;
+
+                for (int32 cellX = 0; cellX < clippedCellsW; ++cellX) {
+                    const int32 srcX = sx1 + cellX * srcCellStepX;
+                    const int32 dstX = dx1 + cellX * dstStepX;
+                    if ((dstX < 0) || (dstX >= d->width))
+                        continue;
+
+                    const uint16 cell = srcData[srcY * s->width + srcX];
+                    if (uint32(cell) != textTransparentColor)
+                        dstData[dstY * d->width + dstX] = cell;
+                }
+            }
+        } else {
+            for (int32 cellY = 0; cellY < clippedCellsH; ++cellY) {
+                const int32 srcY = sy1 + cellY * srcCellStepY;
+
+                for (int32 cellX = 0; cellX < clippedCellsW; ++cellX) {
+                    const int32 srcX = sx1 + cellX * srcCellStepX;
+                    const uint16 cell = srcData[srcY * s->width + srcX];
+                    if (uint32(cell) == textTransparentColor)
+                        continue;
+
+                    const uint8 c = uint8(cell & 0xFF);
+                    const uint8 attr = uint8(cell >> 8);
+                    const uint8 fc = uint8(attr & 0x0F);
+                    const uint8 bc = uint8(((attr >> 4) & 7) + ((attr >> 7) << 3));
+
+                    const uint8 *glyphBits;
+                    switch (fontHeight) {
+                    case 8:
+                        glyphBits = &charset8x8[c][0][0];
+                        break;
+                    case 14:
+                        glyphBits = &charset8x16[c][1][0];
+                        break;
+                    default:
+                        glyphBits = &charset8x16[c][0][0];
+                        break;
+                    }
+
+                    if (d->bits_per_pixel == 32) {
+                        for (int32 py = 0; py < fontHeight; ++py) {
+                            const int32 dstY = dy1 + dstStepY * (cellY * fontHeight + py);
+                            if ((dstY < 0) || (dstY >= d->height))
+                                continue;
+
+                            for (int32 px = 0; px < fontWidth; ++px) {
+                                const int32 dstX = dx1 + dstStepX * (cellX * fontWidth + px);
+                                if ((dstX < 0) || (dstX >= d->width))
+                                    continue;
+
+                                const uint8 bit = glyphBits[py * fontWidth + px];
+                                d->offset32[dstY * d->width + dstX] = bit ? s->pal[fc] : s->pal[bc];
+                            }
+                        }
+                    } else {
+                        for (int32 py = 0; py < fontHeight; ++py) {
+                            const int32 dstY = dy1 + dstStepY * (cellY * fontHeight + py);
+                            if ((dstY < 0) || (dstY >= d->height))
+                                continue;
+
+                            for (int32 px = 0; px < fontWidth; ++px) {
+                                const int32 dstX = dx1 + dstStepX * (cellX * fontWidth + px);
+                                if ((dstX < 0) || (dstX >= d->width))
+                                    continue;
+
+                                const uint8 bit = glyphBits[py * fontWidth + px];
+                                d->offset[dstY * d->width + dstX] = bit ? fc : bc;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return;
+    }
 
     if (use_hardware) {
         // calculate omitted co-ordinates
@@ -7077,9 +7268,6 @@ int32 qbg_visual_page;
 uint8 *qbg_visual_page_offset;
 int32 qbg_color_assign[256]; // for modes with quasi palettes!
 uint32 pal_mode10[2][9];
-
-uint8 charset8x8[256][8][8];
-uint8 charset8x16[256][16][8];
 
 int32 lineclip_draw; // 1=draw, 0=don't draw
 int32 lineclip_x1, lineclip_y1, lineclip_x2, lineclip_y2;

--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -19248,9 +19248,23 @@ void sub__clearcolor(uint32 c, int32 i, int32 passed) {
     im = &img[i];
     // text?
     if (im->text) {
-        if ((passed & 1) && (!(passed & 2)))
-            return; // you can disable clearcolor using _CLEARCOLOR _NONE in text modes
-        error(5);
+        if (passed & 1) {
+            if (passed & 2) {
+                error(5);
+                return;
+            } // invalid options
+            im->transparent_color = -1; // _CLEARCOLOR _NONE: disable transparency
+            return;
+        }
+        if (!(passed & 2)) {
+            error(5);
+            return;
+        } // invalid options
+        if (c > 65535) {
+            error(5);
+            return;
+        } // invalid cell value for a text surface
+        im->transparent_color = (int32)c;
         return;
     }
     // palette?
@@ -19534,7 +19548,7 @@ int32 func__clearcolor(int32 i, int32 passed) {
         i = write_page_index;
     }
     if (img[i].text)
-        return -1;
+        return img[i].transparent_color; // -1 = none, 0-65535 = cell value
     if (img[i].compatible_mode == 32)
         return 0;
     return img[i].transparent_color;

--- a/tests/compile_tests/putimage/putimage_test.bas
+++ b/tests/compile_tests/putimage/putimage_test.bas
@@ -42,6 +42,8 @@ TestTextToGraphicsScaleIllegal
 TestTextToGraphics2Illegal
 TestGraphicsToTextIllegal
 
+TestTextToGraphics32TTFFont
+
 _FREEIMAGE srcText
 
 IF stats.failed = 0 THEN
@@ -144,19 +146,22 @@ SUB PrepareGraphicsDestinationIndexed (img AS LONG)
     _DEST oldDest
 END SUB
 
-FUNCTION TextCell~% (img AS LONG, cx AS INTEGER, cy AS INTEGER)
+FUNCTION TextCell~% (img AS LONG, cx AS LONG, cy AS LONG)
+    ' DOES NOT CLIP!
     DIM p AS _MEM: p = _MEMIMAGE(img)
     TextCell = _MEMGET(p, p.OFFSET + ((cy - 1) * _WIDTH(img) + (cx - 1)) * _SIZE_OF_INTEGER, _UNSIGNED INTEGER)
     _MEMFREE p
 END FUNCTION
 
 FUNCTION Pixel32~& (img AS LONG, x AS LONG, y AS LONG)
+    ' DOES NOT CLIP!
     DIM p AS _MEM: p = _MEMIMAGE(img)
     Pixel32 = _MEMGET(p, p.OFFSET + (y * _WIDTH(img) + x) * _SIZE_OF_LONG, _UNSIGNED LONG)
     _MEMFREE p
 END FUNCTION
 
 FUNCTION PixelIndex~%% (img AS LONG, x AS LONG, y AS LONG)
+    ' DOES NOT CLIP!
     DIM p AS _MEM: p = _MEMIMAGE(img)
     PixelIndex = _MEMGET(p, p.OFFSET + (y * _WIDTH(img) + x), _UNSIGNED _BYTE)
     _MEMFREE p
@@ -719,4 +724,43 @@ SUB TestGraphicsToTextIllegal
 
     _FREEIMAGE dst
     _FREEIMAGE src
+END SUB
+
+SUB TestTextToGraphics32TTFFont
+    DIM fnt AS LONG: fnt = _LOADFONT("../font/LiberationMono-Regular.ttf", 16, "monospace")
+    IF fnt <= 0 THEN
+        ReportCheck "text->graphics 32bpp TTF font", _FALSE
+        EXIT SUB
+    END IF
+
+    DIM fW AS INTEGER: fW = _FONTWIDTH(fnt)
+    DIM fH AS INTEGER: fH = _FONTHEIGHT(fnt)
+    DIM src AS LONG: src = _NEWIMAGE(10, 4, 0)
+    DIM oldDest AS LONG: oldDest = _DEST
+
+    _DEST src
+    _FONT fnt
+    COLOR 15, 1
+    CLS
+    LOCATE 1, 1: PRINT "ABCDEFGHIJ";
+    LOCATE 2, 1: PRINT "abcdefghij";
+    _DEST oldDest
+
+    DIM expectedW AS LONG: expectedW = 10 * fW
+    DIM expectedH AS LONG: expectedH = 4 * fH
+    DIM dst AS LONG: dst = _NEWIMAGE(expectedW + 40, expectedH + 40, 32)
+    PrepareGraphicsDestination32 dst
+
+    _PUTIMAGE (20, 20), src, dst
+    '_SAVEIMAGE "TestTextToGraphics32TTFFont", dst
+
+    DIM ok AS _BYTE: ok = _TRUE
+    IF CountNonBlack32(dst, 20, 20, 20 + expectedW - 1, 20 + expectedH - 1) <= 0 THEN ok = _FALSE
+    IF CountNonBlackOutsideRect32(dst, 20, 20, 20 + expectedW - 1, 20 + expectedH - 1) <> 0 THEN ok = _FALSE
+
+    ReportCheck "text->graphics 32bpp TTF font", ok
+
+    _FREEIMAGE src
+    _FREEIMAGE dst
+    _FREEFONT fnt
 END SUB

--- a/tests/compile_tests/putimage/putimage_test.bas
+++ b/tests/compile_tests/putimage/putimage_test.bas
@@ -1,0 +1,722 @@
+OPTION _EXPLICIT
+$CONSOLE:ONLY
+
+CHDIR _STARTDIR$
+
+TYPE TestStats
+    total AS INTEGER
+    failed AS INTEGER
+END TYPE
+
+DIM SHARED stats AS TestStats
+DIM SHARED errCaught AS _BYTE
+
+DIM SHARED srcText AS LONG: srcText = _NEWIMAGE(20, 10, 0)
+PrepareTextSource srcText
+
+TestTextToTextBasic
+TestTextToTextReversed
+TestTextToTextMirrored
+TestTextToTextFlipped
+TestTextToTextClipping
+
+TestTextToGraphics32Basic
+TestTextToGraphics32ViewClip
+TestTextToGraphics32WindowNoScale
+TestTextToGraphics32Reversed
+TestTextToGraphics32Mirrored
+TestTextToGraphics32Flipped
+TestTextToGraphics32Clipping
+
+TestTextToGraphics8Basic
+TestTextToGraphics8Mirrored
+TestTextToGraphics8Flipped
+TestTextToGraphics4Basic
+TestTextToGraphics4Mirrored
+TestTextToGraphics4Flipped
+
+TestTextToTextViewPrint
+TestTextToTextScaleIllegal
+TestTextToGraphicsScaleIllegal
+
+TestTextToGraphics2Illegal
+TestGraphicsToTextIllegal
+
+_FREEIMAGE srcText
+
+IF stats.failed = 0 THEN
+    PRINT "ALL TESTS PASSED"; stats.total
+ELSE
+    PRINT "TESTS FAILED"; stats.failed; "of"; stats.total
+END IF
+
+SYSTEM
+
+err_text_to_gfx2:
+errCaught = _TRUE
+RESUME NEXT
+
+err_gfx_to_text:
+errCaught = _TRUE
+RESUME NEXT
+
+err_text_to_text_scale:
+errCaught = _TRUE
+RESUME NEXT
+
+err_text_to_gfx_scale:
+errCaught = _TRUE
+RESUME NEXT
+
+SUB ReportCheck (testName AS STRING, condition AS INTEGER)
+    _DEST _CONSOLE
+    stats.total = stats.total + 1
+    IF condition THEN
+        PRINT "PASS: "; testName
+    ELSE
+        stats.failed = stats.failed + 1
+        PRINT "FAIL: "; testName
+    END IF
+END SUB
+
+SUB PrepareTextSource (img AS LONG)
+    DIM oldDest AS LONG: oldDest = _DEST
+
+    _DEST img
+    CLS
+
+    COLOR 15, 1
+    LOCATE 1, 1: PRINT "ABCDEFGHIJKLMNOPQRST";
+    COLOR 14, 4
+    LOCATE 2, 1: PRINT "abcdefghijklmnopqrst";
+    COLOR 10, 2
+    LOCATE 3, 1: PRINT "01234567890123456789";
+    COLOR 12, 3
+    LOCATE 4, 1: PRINT "!@#$%^&*()_+[]{}<>?/";
+
+    COLOR 11, 5
+    LOCATE 6, 4: PRINT "BOX";
+    COLOR 15, 6
+    LOCATE 7, 4: PRINT "REV";
+    COLOR 0, 7
+    LOCATE 8, 4: PRINT "INV";
+
+    '_CLEARCOLOR _NONE, img
+    _CLEARCOLOR ASC("?") + 256 * (12 + 16 * 3), img
+
+    _DEST oldDest
+END SUB
+
+SUB PrepareTextDestination (img AS LONG)
+    DIM oldDest AS LONG: oldDest = _DEST
+
+    _DEST img
+    CLS
+
+    COLOR 7, 0
+    DIM y AS LONG
+    FOR y = 1 TO _HEIGHT(img)
+        LOCATE y, 1
+        PRINT STRING$(_WIDTH(img), ".");
+    NEXT
+
+    _DEST oldDest
+END SUB
+
+SUB PrepareGraphicsDestination32 (img AS LONG)
+    DIM oldDest AS LONG: oldDest = _DEST
+
+    _DEST img
+    CLS , _RGB32(0, 0, 0)
+    LINE (0, 0)-(_WIDTH(img) - 1, _HEIGHT(img) - 1), _RGB32(0, 0, 0), BF
+
+    _DEST oldDest
+END SUB
+
+SUB PrepareGraphicsDestinationIndexed (img AS LONG)
+    DIM oldDest AS LONG
+    oldDest = _DEST
+
+    _DEST img
+    CLS , 0
+    LINE (0, 0)-(_WIDTH(img) - 1, _HEIGHT(img) - 1), 0, BF
+
+    _DEST oldDest
+END SUB
+
+FUNCTION TextCell~% (img AS LONG, cx AS INTEGER, cy AS INTEGER)
+    DIM p AS _MEM: p = _MEMIMAGE(img)
+    TextCell = _MEMGET(p, p.OFFSET + ((cy - 1) * _WIDTH(img) + (cx - 1)) * _SIZE_OF_INTEGER, _UNSIGNED INTEGER)
+    _MEMFREE p
+END FUNCTION
+
+FUNCTION Pixel32~& (img AS LONG, x AS LONG, y AS LONG)
+    DIM p AS _MEM: p = _MEMIMAGE(img)
+    Pixel32 = _MEMGET(p, p.OFFSET + (y * _WIDTH(img) + x) * _SIZE_OF_LONG, _UNSIGNED LONG)
+    _MEMFREE p
+END FUNCTION
+
+FUNCTION PixelIndex~%% (img AS LONG, x AS LONG, y AS LONG)
+    DIM p AS _MEM: p = _MEMIMAGE(img)
+    PixelIndex = _MEMGET(p, p.OFFSET + (y * _WIDTH(img) + x), _UNSIGNED _BYTE)
+    _MEMFREE p
+END FUNCTION
+
+FUNCTION CountNonBlack32~& (img AS LONG, x1 AS LONG, y1 AS LONG, x2 AS LONG, y2 AS LONG)
+    DIM x AS LONG
+    DIM y AS LONG
+    DIM c AS _UNSIGNED LONG
+    DIM count AS _UNSIGNED LONG
+
+    FOR y = y1 TO y2
+        FOR x = x1 TO x2
+            c = Pixel32(img, x, y)
+            IF _RED32(c) <> 0 _ORELSE _GREEN32(c) <> 0 _ORELSE _BLUE32(c) <> 0 THEN count = count + 1
+        NEXT
+    NEXT
+
+    CountNonBlack32 = count
+END FUNCTION
+
+FUNCTION CountNonBlackOutsideRect32~& (img AS LONG, x1 AS LONG, y1 AS LONG, x2 AS LONG, y2 AS LONG)
+    DIM x AS LONG
+    DIM y AS LONG
+    DIM c AS _UNSIGNED LONG
+    DIM count AS _UNSIGNED LONG
+
+    FOR y = 0 TO _HEIGHT(img) - 1
+        FOR x = 0 TO _WIDTH(img) - 1
+            IF x >= x1 _ANDALSO x <= x2 _ANDALSO y >= y1 _ANDALSO y <= y2 THEN
+                ' inside rectangle
+            ELSE
+                c = Pixel32(img, x, y)
+                IF _RED32(c) <> 0 _ORELSE _GREEN32(c) <> 0 _ORELSE _BLUE32(c) <> 0 THEN count = count + 1
+            END IF
+        NEXT
+    NEXT
+
+    CountNonBlackOutsideRect32 = count
+END FUNCTION
+
+FUNCTION SumRegion32~&& (img AS LONG, x1 AS LONG, y1 AS LONG, x2 AS LONG, y2 AS LONG)
+    DIM x AS LONG
+    DIM y AS LONG
+    DIM s AS _UNSIGNED _INTEGER64
+
+    FOR y = y1 TO y2
+        FOR x = x1 TO x2
+            s = s + Pixel32(img, x, y)
+        NEXT
+    NEXT
+
+    SumRegion32 = s
+END FUNCTION
+
+FUNCTION CountNonZeroIndexed~& (img AS LONG, x1 AS LONG, y1 AS LONG, x2 AS LONG, y2 AS LONG)
+    DIM x AS LONG
+    DIM y AS LONG
+    DIM count AS _UNSIGNED LONG
+
+    FOR y = y1 TO y2
+        FOR x = x1 TO x2
+            IF PixelIndex(img, x, y) <> 0 THEN count = count + 1
+        NEXT
+    NEXT
+
+    CountNonZeroIndexed = count
+END FUNCTION
+
+FUNCTION RegionsEqualText%% (srcImg AS LONG, srcX AS LONG, srcY AS LONG, dstImg AS LONG, dstX AS LONG, dstY AS LONG, w AS LONG, h AS LONG, dstStepX AS LONG, dstStepY AS LONG)
+    DIM x AS LONG
+    DIM y AS LONG
+    DIM sx AS LONG
+    DIM sy AS LONG
+    DIM dx AS LONG
+    DIM dy AS LONG
+
+    RegionsEqualText = _TRUE
+
+    FOR y = 0 TO h - 1
+        FOR x = 0 TO w - 1
+            sx = srcX + x
+            sy = srcY + y
+            dx = dstX + x * dstStepX
+            dy = dstY + y * dstStepY
+
+            IF TextCell(srcImg, sx, sy) <> TextCell(dstImg, dx, dy) THEN
+                RegionsEqualText = _FALSE
+                EXIT FUNCTION
+            END IF
+        NEXT
+    NEXT
+END FUNCTION
+
+FUNCTION RegionsEqual32%% (srcImg AS LONG, srcX AS LONG, srcY AS LONG, dstImg AS LONG, dstX AS LONG, dstY AS LONG, w AS LONG, h AS LONG, dstStepX AS LONG, dstStepY AS LONG)
+    DIM x AS LONG
+    DIM y AS LONG
+    DIM sx AS LONG
+    DIM sy AS LONG
+    DIM dx AS LONG
+    DIM dy AS LONG
+
+    RegionsEqual32 = _TRUE
+
+    FOR y = 0 TO h - 1
+        FOR x = 0 TO w - 1
+            sx = srcX + x
+            sy = srcY + y
+            dx = dstX + x * dstStepX
+            dy = dstY + y * dstStepY
+
+            IF Pixel32(srcImg, sx, sy) <> Pixel32(dstImg, dx, dy) THEN
+                RegionsEqual32 = _FALSE
+                EXIT FUNCTION
+            END IF
+        NEXT
+    NEXT
+END FUNCTION
+
+FUNCTION RegionsEqualIndexed%% (srcImg AS LONG, srcX AS LONG, srcY AS LONG, dstImg AS LONG, dstX AS LONG, dstY AS LONG, w AS LONG, h AS LONG, dstStepX AS LONG, dstStepY AS LONG)
+    DIM x AS LONG
+    DIM y AS LONG
+    DIM sx AS LONG
+    DIM sy AS LONG
+    DIM dx AS LONG
+    DIM dy AS LONG
+
+    RegionsEqualIndexed = _TRUE
+
+    FOR y = 0 TO h - 1
+        FOR x = 0 TO w - 1
+            sx = srcX + x
+            sy = srcY + y
+            dx = dstX + x * dstStepX
+            dy = dstY + y * dstStepY
+
+            IF PixelIndex(srcImg, sx, sy) <> PixelIndex(dstImg, dx, dy) THEN
+                RegionsEqualIndexed = _FALSE
+                EXIT FUNCTION
+            END IF
+        NEXT
+    NEXT
+END FUNCTION
+
+SUB TestTextToTextBasic
+    DIM dst AS LONG: dst = _NEWIMAGE(30, 16, 0)
+    PrepareTextDestination dst
+
+    _PUTIMAGE (4, 3), srcText, dst
+    '_SAVEIMAGE "TestTextToTextBasic", dst
+
+    DIM ok AS _BYTE: ok = _TRUE
+    IF TextCell(dst, 5, 4) <> TextCell(srcText, 1, 1) THEN ok = _FALSE
+    IF TextCell(dst, 10, 4) <> TextCell(srcText, 6, 1) THEN ok = _FALSE
+    IF TextCell(dst, 7, 6) <> TextCell(srcText, 3, 3) THEN ok = _FALSE
+    IF TextCell(dst, 24, 13) <> TextCell(srcText, 20, 10) THEN ok = _FALSE
+
+    ReportCheck "text->text basic", ok
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToTextReversed
+    DIM dst AS LONG: dst = _NEWIMAGE(30, 16, 0)
+    PrepareTextDestination dst
+
+    _PUTIMAGE (14, 7)-(9, 5), srcText, dst, (5, 2)-(0, 0)
+    '_SAVEIMAGE "TestTextToTextReversed", dst
+
+    DIM ok AS _BYTE: ok = _TRUE
+    IF TextCell(dst, 15, 8) <> TextCell(srcText, 6, 3) THEN ok = _FALSE
+    IF TextCell(dst, 10, 6) <> TextCell(srcText, 1, 1) THEN ok = _FALSE
+    IF TextCell(dst, 14, 8) <> TextCell(srcText, 5, 3) THEN ok = _FALSE
+    IF TextCell(dst, 15, 7) <> TextCell(srcText, 6, 2) THEN ok = _FALSE
+
+    ReportCheck "text->text reversed rect", ok
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToTextMirrored
+    DIM ref AS LONG: ref = _NEWIMAGE(30, 16, 0)
+    PrepareTextDestination ref
+    DIM dst AS LONG: dst = _NEWIMAGE(30, 16, 0)
+    PrepareTextDestination dst
+
+    _PUTIMAGE (5, 3), srcText, ref
+    '_SAVEIMAGE "TestTextToTextMirroredRef", ref
+
+    _PUTIMAGE (24, 3)-(5, 12), srcText, dst, (0, 0)-(19, 9)
+    '_SAVEIMAGE "TestTextToTextMirroredDst", dst
+
+    DIM ok AS _BYTE: ok = RegionsEqualText(ref, 6, 4, dst, 25, 4, 20, 10, -1, 1)
+    IF TextCell(dst, 25, 4) <> TextCell(srcText, 1, 1) THEN ok = _FALSE
+    IF TextCell(dst, 6, 4) <> TextCell(srcText, 20, 1) THEN ok = _FALSE
+
+    ReportCheck "text->text mirrored", ok
+
+    _FREEIMAGE dst
+    _FREEIMAGE ref
+END SUB
+
+SUB TestTextToTextFlipped
+    DIM ref AS LONG: ref = _NEWIMAGE(30, 16, 0)
+    PrepareTextDestination ref
+    DIM dst AS LONG: dst = _NEWIMAGE(30, 16, 0)
+    PrepareTextDestination dst
+
+    _PUTIMAGE (5, 3), srcText, ref
+    '_SAVEIMAGE "TestTextToTextFlippedRef", ref
+
+    _PUTIMAGE (24, 12)-(5, 3), srcText, dst, (0, 0)-(19, 9)
+    '_SAVEIMAGE "TestTextToTextFlippedDst", dst
+
+    DIM ok AS _BYTE: ok = RegionsEqualText(ref, 6, 4, dst, 25, 13, 20, 10, -1, -1)
+    IF TextCell(dst, 6, 4) <> TextCell(srcText, 20, 10) THEN ok = _FALSE
+    IF TextCell(dst, 25, 13) <> TextCell(srcText, 1, 1) THEN ok = _FALSE
+
+    ReportCheck "text->text flipped", ok
+
+    _FREEIMAGE dst
+    _FREEIMAGE ref
+END SUB
+
+SUB TestTextToTextClipping
+    DIM dst AS LONG: dst = _NEWIMAGE(30, 16, 0)
+    PrepareTextDestination dst
+
+    _PUTIMAGE (-3, 0), srcText, dst
+    '_SAVEIMAGE "TestTextToTextClipping", dst
+
+    DIM ok AS _BYTE: ok = _TRUE
+    IF TextCell(dst, 1, 1) <> TextCell(srcText, 4, 1) THEN ok = _FALSE
+    IF TextCell(dst, 2, 1) <> TextCell(srcText, 5, 1) THEN ok = _FALSE
+
+    ReportCheck "text->text clipping", ok
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToGraphics32Basic
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 32)
+    PrepareGraphicsDestination32 dst
+
+    _PUTIMAGE (16, 16), srcText, dst
+    '_SAVEIMAGE "TestTextToGraphics32Basic", dst
+
+    DIM nonBlack AS _UNSIGNED LONG: nonBlack = CountNonBlack32(dst, 16, 16, 16 + 20 * 8 - 1, 16 + 10 * 16 - 1)
+    DIM ok AS _BYTE: ok = (nonBlack > 0)
+    IF Pixel32(dst, 0, 0) <> _RGB32(0, 0, 0) THEN ok = _FALSE
+
+    ReportCheck "text->graphics 32bpp basic", ok
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToGraphics32ViewClip
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 32)
+    PrepareGraphicsDestination32 dst
+
+    _DEST dst
+    VIEW (40, 40)-(120, 120)
+    _PUTIMAGE (0, 0), srcText
+    VIEW
+    '_SAVEIMAGE "TestTextToGraphics32ViewClip", dst
+
+    DIM ok AS _BYTE: ok = _TRUE
+    IF CountNonBlack32(dst, 40, 40, 120, 120) <= 0 THEN ok = _FALSE
+    IF CountNonBlackOutsideRect32(dst, 40, 40, 120, 120) <> 0 THEN ok = _FALSE
+
+    ReportCheck "text->graphics 32bpp VIEW clip", ok
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToGraphics32WindowNoScale
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 32)
+    PrepareGraphicsDestination32 dst
+
+    _DEST dst
+    VIEW (40, 40)-(199, 199)
+    WINDOW SCREEN(0, 0)-(159, 159)
+    _PUTIMAGE (0, 0), srcText
+    WINDOW
+    VIEW
+    '_SAVEIMAGE "TestTextToGraphics32WindowNoScale", dst
+
+    DIM ok AS _BYTE: ok = _TRUE
+    IF CountNonBlack32(dst, 40, 40, 199, 199) <= 0 THEN ok = _FALSE
+    IF CountNonBlackOutsideRect32(dst, 40, 40, 199, 199) <> 0 THEN ok = _FALSE
+
+    ReportCheck "text->graphics 32bpp WINDOW", ok
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToGraphics32Reversed
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 32)
+    PrepareGraphicsDestination32 dst
+    DIM ref AS LONG: ref = _NEWIMAGE(320, 200, 32)
+    PrepareGraphicsDestination32 ref
+
+
+    _PUTIMAGE (100, 80)-(147, 111), srcText, ref, (0, 0)-(5, 1)
+    '_SAVEIMAGE "TestTextToGraphics32ReversedRef", ref
+
+    _PUTIMAGE (200, 120)-(153, 89), srcText, dst, (5, 1)-(0, 0)
+    '_SAVEIMAGE "TestTextToGraphics32ReversedDst", dst
+
+    DIM nonBlackRef AS _UNSIGNED LONG: nonBlackRef = CountNonBlack32(ref, 100, 80, 147, 111)
+    DIM nonBlackDst AS _UNSIGNED LONG: nonBlackDst = CountNonBlack32(dst, 153, 89, 200, 120)
+
+    DIM sumRef AS _UNSIGNED _INTEGER64: sumRef = SumRegion32(ref, 100, 80, 147, 111)
+    DIM sumDst AS _UNSIGNED _INTEGER64: sumDst = SumRegion32(dst, 153, 89, 200, 120)
+
+    DIM ok AS _BYTE: ok = _TRUE
+    IF nonBlackRef <= 0 THEN ok = _FALSE
+    IF nonBlackDst <> nonBlackRef THEN ok = _FALSE
+    IF sumDst <> sumRef THEN ok = _FALSE
+
+    ReportCheck "text->graphics 32bpp reversed rect", ok
+
+    _FREEIMAGE ref
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToGraphics32Mirrored
+    DIM ref AS LONG: ref = _NEWIMAGE(320, 200, 32)
+    PrepareGraphicsDestination32 ref
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 32)
+    PrepareGraphicsDestination32 dst
+
+    _PUTIMAGE (20, 20), srcText, ref
+    '_SAVEIMAGE "TestTextToGraphics32MirroredRef", ref
+
+    _PUTIMAGE (179, 20)-(20, 179), srcText, dst, (0, 0)-(19, 9)
+    '_SAVEIMAGE "TestTextToGraphics32MirroredDst", dst
+
+    DIM ok AS _BYTE: ok = RegionsEqual32(ref, 20, 20, dst, 179, 20, 160, 160, -1, 1)
+
+    ReportCheck "text->graphics 32bpp mirrored", ok
+
+    _FREEIMAGE dst
+    _FREEIMAGE ref
+END SUB
+
+SUB TestTextToGraphics32Flipped
+    DIM ref AS LONG: ref = _NEWIMAGE(320, 200, 32)
+    PrepareGraphicsDestination32 ref
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 32)
+    PrepareGraphicsDestination32 dst
+
+    _PUTIMAGE (20, 20), srcText, ref
+    '_SAVEIMAGE "TestTextToGraphics32FlippedRef", ref
+
+    _PUTIMAGE (179, 179)-(20, 20), srcText, dst, (0, 0)-(19, 9)
+    '_SAVEIMAGE "TestTextToGraphics32FlippedDst", dst
+
+    DIM ok AS _BYTE: ok = RegionsEqual32(ref, 20, 20, dst, 179, 179, 160, 160, -1, -1)
+
+    ReportCheck "text->graphics 32bpp flipped", ok
+
+    _FREEIMAGE dst
+    _FREEIMAGE ref
+END SUB
+
+SUB TestTextToGraphics32Clipping
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 32)
+    PrepareGraphicsDestination32 dst
+
+
+    _PUTIMAGE (-12, -10), srcText, dst
+    '_SAVEIMAGE "TestTextToGraphics32Clipping", dst
+
+    DIM ok AS _BYTE: ok = (CountNonBlack32(dst, 0, 0, 80, 80) > 0)
+
+    ReportCheck "text->graphics 32bpp clipping", ok
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToGraphics8Basic
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 256)
+    PrepareGraphicsDestinationIndexed dst
+
+    _PUTIMAGE (24, 24), srcText, dst
+    '_SAVEIMAGE "TestTextToGraphics8Basic", dst
+
+    DIM ok AS _BYTE: ok = (CountNonZeroIndexed(dst, 24, 24, 24 + 20 * 8 - 1, 24 + 10 * 16 - 1) > 0)
+    ReportCheck "text->graphics 8bpp basic", ok
+
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToGraphics8Mirrored
+    DIM ref AS LONG: ref = _NEWIMAGE(320, 200, 256)
+    PrepareGraphicsDestinationIndexed ref
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 256)
+    PrepareGraphicsDestinationIndexed dst
+
+    _PUTIMAGE (20, 20), srcText, ref
+    '_SAVEIMAGE "TestTextToGraphics8MirroredRef", ref
+
+    _PUTIMAGE (179, 20)-(20, 179), srcText, dst, (0, 0)-(19, 9)
+    '_SAVEIMAGE "TestTextToGraphics8MirroredDst", dst
+
+    DIM ok AS _BYTE: ok = RegionsEqualIndexed(ref, 20, 20, dst, 179, 20, 160, 160, -1, 1)
+
+    ReportCheck "text->graphics 8bpp mirrored", ok
+
+    _FREEIMAGE dst
+    _FREEIMAGE ref
+END SUB
+
+SUB TestTextToGraphics8Flipped
+    DIM ref AS LONG: ref = _NEWIMAGE(320, 200, 256)
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 256)
+
+    PrepareGraphicsDestinationIndexed ref
+    PrepareGraphicsDestinationIndexed dst
+
+    _PUTIMAGE (20, 20), srcText, ref
+    '_SAVEIMAGE "TestTextToGraphics8FlippedRef", ref
+
+    _PUTIMAGE (179, 179)-(20, 20), srcText, dst, (0, 0)-(19, 9)
+    '_SAVEIMAGE "TestTextToGraphics8FlippedDst", dst
+
+    DIM ok AS _BYTE: ok = RegionsEqualIndexed(ref, 20, 20, dst, 179, 179, 160, 160, -1, -1)
+
+    ReportCheck "text->graphics 8bpp flipped", ok
+
+    _FREEIMAGE dst
+    _FREEIMAGE ref
+END SUB
+
+SUB TestTextToGraphics4Basic
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 12)
+    PrepareGraphicsDestinationIndexed dst
+
+    _PUTIMAGE (24, 24), srcText, dst
+    '_SAVEIMAGE "TestTextToGraphics4Basic", dst
+
+    DIM ok AS _BYTE: ok = (CountNonZeroIndexed(dst, 24, 24, 24 + 20 * 8 - 1, 24 + 10 * 16 - 1) > 0)
+    ReportCheck "text->graphics 4bpp basic", ok
+
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToGraphics4Mirrored
+    DIM ref AS LONG: ref = _NEWIMAGE(320, 200, 12)
+    PrepareGraphicsDestinationIndexed ref
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 12)
+    PrepareGraphicsDestinationIndexed dst
+
+    _PUTIMAGE (20, 20), srcText, ref
+    '_SAVEIMAGE "TestTextToGraphics4MirroredRef", ref
+
+    _PUTIMAGE (179, 20)-(20, 179), srcText, dst, (0, 0)-(19, 9)
+    '_SAVEIMAGE "TestTextToGraphics4MirroredDst", dst
+
+    DIM ok AS _BYTE: ok = RegionsEqualIndexed(ref, 20, 20, dst, 179, 20, 160, 160, -1, 1)
+
+    ReportCheck "text->graphics 4bpp mirrored", ok
+
+    _FREEIMAGE dst
+    _FREEIMAGE ref
+END SUB
+
+SUB TestTextToGraphics4Flipped
+    DIM ref AS LONG: ref = _NEWIMAGE(320, 200, 12)
+    PrepareGraphicsDestinationIndexed ref
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 12)
+    PrepareGraphicsDestinationIndexed dst
+
+    _PUTIMAGE (20, 20), srcText, ref
+    '_SAVEIMAGE "TestTextToGraphics4FlippedRef", ref
+
+    _PUTIMAGE (179, 179)-(20, 20), srcText, dst, (0, 0)-(19, 9)
+    '_SAVEIMAGE "TestTextToGraphics4FlippedDst", dst
+
+    DIM ok AS _BYTE: ok = RegionsEqualIndexed(ref, 20, 20, dst, 179, 179, 160, 160, -1, -1)
+
+    ReportCheck "text->graphics 4bpp flipped", ok
+
+    _FREEIMAGE dst
+    _FREEIMAGE ref
+END SUB
+
+SUB TestTextToTextViewPrint
+    DIM dst AS LONG: dst = _NEWIMAGE(30, 16, 0)
+    PrepareTextDestination dst
+    DIM ref AS LONG: ref = _NEWIMAGE(30, 16, 0)
+    PrepareTextDestination ref
+
+    _DEST dst
+    VIEW PRINT 6 TO 10
+    _PUTIMAGE (0, 0), srcText
+    VIEW PRINT
+    '_SAVEIMAGE "TestTextToTextViewPrint", dst
+
+    DIM ok AS _BYTE: ok = _TRUE
+    IF TextCell(dst, 1, 2) <> TextCell(ref, 1, 2) THEN ok = _FALSE
+    IF TextCell(dst, 1, 6) <> TextCell(srcText, 1, 6) THEN ok = _FALSE
+    IF TextCell(dst, 20, 10) <> TextCell(srcText, 20, 10) THEN ok = _FALSE
+    IF TextCell(dst, 1, 11) <> TextCell(ref, 1, 11) THEN ok = _FALSE
+
+    ReportCheck "text->text VIEW PRINT", ok
+
+    _FREEIMAGE ref
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToTextScaleIllegal
+    DIM dst AS LONG: dst = _NEWIMAGE(30, 16, 0)
+    PrepareTextDestination dst
+
+    errCaught = _FALSE
+    ON ERROR GOTO err_text_to_text_scale
+    _PUTIMAGE (0, 0)-(29, 15), srcText, dst
+    ON ERROR GOTO 0
+
+    ReportCheck "text->text scale illegal", errCaught
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToGraphicsScaleIllegal
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 32)
+    PrepareGraphicsDestination32 dst
+
+    errCaught = _FALSE
+    ON ERROR GOTO err_text_to_gfx_scale
+    _PUTIMAGE (0, 0)-(79, 79), srcText, dst
+    ON ERROR GOTO 0
+
+    ReportCheck "text->graphics scale illegal", errCaught
+    _FREEIMAGE dst
+END SUB
+
+SUB TestTextToGraphics2Illegal
+    DIM dst AS LONG: dst = _NEWIMAGE(320, 200, 1)
+    PrepareGraphicsDestinationIndexed dst
+
+    errCaught = _FALSE
+    ON ERROR GOTO err_text_to_gfx2
+    _PUTIMAGE (0, 0), srcText, dst
+    ON ERROR GOTO 0
+
+    ReportCheck "text->graphics 2bpp illegal", errCaught
+    _FREEIMAGE dst
+END SUB
+
+SUB TestGraphicsToTextIllegal
+    DIM src AS LONG: src = _NEWIMAGE(64, 64, 32)
+    DIM dst AS LONG: dst = _NEWIMAGE(30, 16, 0)
+
+    PrepareTextDestination dst
+    _DEST src
+    CLS , _RGB32(0, 0, 0)
+    LINE (0, 0)-(63, 63), _RGB32(255, 0, 0), BF
+
+    errCaught = _FALSE
+    ON ERROR GOTO err_gfx_to_text
+    _PUTIMAGE (1, 1), src, dst
+    ON ERROR GOTO 0
+
+    ReportCheck "graphics->text illegal", errCaught
+
+    _FREEIMAGE dst
+    _FREEIMAGE src
+END SUB

--- a/tests/compile_tests/putimage/putimage_test.output
+++ b/tests/compile_tests/putimage/putimage_test.output
@@ -21,4 +21,5 @@ PASS: text->text scale illegal
 PASS: text->graphics scale illegal
 PASS: text->graphics 2bpp illegal
 PASS: graphics->text illegal
-ALL TESTS PASSED 23 
+PASS: text->graphics 32bpp TTF font
+ALL TESTS PASSED 24 

--- a/tests/compile_tests/putimage/putimage_test.output
+++ b/tests/compile_tests/putimage/putimage_test.output
@@ -1,0 +1,24 @@
+PASS: text->text basic
+PASS: text->text reversed rect
+PASS: text->text mirrored
+PASS: text->text flipped
+PASS: text->text clipping
+PASS: text->graphics 32bpp basic
+PASS: text->graphics 32bpp VIEW clip
+PASS: text->graphics 32bpp WINDOW
+PASS: text->graphics 32bpp reversed rect
+PASS: text->graphics 32bpp mirrored
+PASS: text->graphics 32bpp flipped
+PASS: text->graphics 32bpp clipping
+PASS: text->graphics 8bpp basic
+PASS: text->graphics 8bpp mirrored
+PASS: text->graphics 8bpp flipped
+PASS: text->graphics 4bpp basic
+PASS: text->graphics 4bpp mirrored
+PASS: text->graphics 4bpp flipped
+PASS: text->text VIEW PRINT
+PASS: text->text scale illegal
+PASS: text->graphics scale illegal
+PASS: text->graphics 2bpp illegal
+PASS: graphics->text illegal
+ALL TESTS PASSED 23 


### PR DESCRIPTION
I've had this code sitting with me for quite some time, and I think it's a good moment to contribute it directly to the QB64‑PE RTL while we are gearing up for v4.5.

This change fills a long‑standing gap in `_PUTIMAGE`, which currently cannot handle text surfaces. We allow users to create a `SCREEN 0`–style surface such as `_NEWIMAGE(80, 43, 0)`, but we don't provide any meaningful way to use it. This PR addresses that limitation.

With this update, `_PUTIMAGE` will support text‑to‑text and text‑to‑graphics blits. The implementation is fairly self‑contained within `sub__putimage()`. For now, I've kept `sub__putimage` in `libqb.cpp`, with the intention of moving it to `graphics.cpp` as part of a larger refactor in a future PR.