### PR TITLE
Fix PRINT USING layout duplication in IDE

### DIFF
--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -24460,7 +24460,13 @@ SUB xfileprint (a$, ca$, n)
                     e$ = fixoperationorder$(e$)
                     IF Error_Happened THEN EXIT SUB
                     IF pnrtnum = 0 THEN
-                        IF last THEN l$ = l$ + sp + tlayout$ ELSE l$ = l$ + sp + tlayout$ + sp2 + a2$
+                        IF last THEN
+                            l$ = l$ + sp + tlayout$
+                        ELSEIF gotofpu THEN
+                            l$ = l$ + sp + tlayout$
+                        ELSE
+                            l$ = l$ + sp + tlayout$ + sp2 + a2$
+                        END IF
                     END IF
                     e$ = evaluate(e$, typ)
                     IF Error_Happened THEN EXIT SUB
@@ -24893,7 +24899,13 @@ SUB xprint (a$, ca$, n)
                     e$ = fixoperationorder$(e$)
                     IF Error_Happened THEN EXIT SUB
                     IF pnrtnum = 0 THEN
-                        IF last THEN l$ = l$ + sp + tlayout$ ELSE l$ = l$ + sp + tlayout$ + sp2 + a2$
+                        IF last THEN
+                            l$ = l$ + sp + tlayout$
+                        ELSEIF gotopu THEN
+                            l$ = l$ + sp + tlayout$
+                        ELSE
+                            l$ = l$ + sp + tlayout$ + sp2 + a2$
+                        END IF
                     END IF
                     e$ = evaluate(e$, typ)
                     IF Error_Happened THEN EXIT SUB


### PR DESCRIPTION
This fixes an old IDE parser/layout issue where editing a `PRINT USING` line can repeatedly insert `Using` into the source line.

Reproduction:

1. Type:

   `Print Using "#"; 0`

2. Move to the next line and type any character.
3. Return to the `PRINT` line and insert `abc ` before `Using`, producing:

   `Print abc Using "#"; 0`

4. Move back to the next line and press keys repeatedly.

Before this fix, the line above keeps growing, for example:

`Print abcUsingUsingUsing Using "#"; 0`

Cause:

When `USING` is encountered after a preceding expression, the general `PRINT` layout path appends the token once through `a2$`, and the later `PRINT USING` path appends `Using` again in `pujump` / `fpujump`.

Fix:

When `gotopu` / `gotofpu` is active, the general layout path now appends only the previous expression layout and leaves `Using` to be appended exactly once by `pujump` / `fpujump`.

This affects both normal `PRINT` and `PRINT #file` parsing/layout paths.