### PR TITLE
Runtime errors leads to the program locking up if `SUB _GL` is used.

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -48,6 +48,7 @@
 
 // These are here because they are used in func__loadfont()
 #include <algorithm>
+#include <atomic>
 #include <string>
 #include <vector>
 
@@ -171,7 +172,7 @@ extern "C" int QB64_Resizable() {
     return ScreenResize;
 }
 
-int32 sub_gl_called = 0;
+thread_local int32 sub_gl_called = 0;
 
 static int32 image_qbicon16_handle;
 static int32 image_qbicon32_handle;
@@ -732,6 +733,49 @@ void hardware_img_requires_depthbuffer(hardware_img_struct *hardware_img) {
 int64 display_lock_request = 0;
 int64 display_lock_confirmed = 0;
 int64 display_lock_released = 0;
+
+extern uint8 close_program;
+extern uint8 suspend_program;
+extern uint8 stop_program;
+
+#ifdef DEPENDENCY_GL
+static std::atomic<int32> display_lock_modal_count{0};
+#endif
+
+void gui_modal_lock_begin() {
+#ifdef DEPENDENCY_GL
+    if (sub_gl_called)
+        return;
+
+    display_lock_modal_count.fetch_add(1, std::memory_order_acq_rel);
+
+    // If the render thread is already waiting for the QB thread to acknowledge
+    // a display lock, acknowledge it before entering a modal OS dialog. The
+    // dialog blocks the QB thread and would otherwise prevent evnt() from doing
+    // this acknowledgement.
+    if (display_lock_request > display_lock_confirmed)
+        display_lock_confirmed = display_lock_request;
+#endif
+}
+
+void gui_modal_lock_end() {
+#ifdef DEPENDENCY_GL
+    if (sub_gl_called)
+        return;
+
+    if (display_lock_modal_count.load(std::memory_order_acquire) > 0)
+        display_lock_modal_count.fetch_sub(1, std::memory_order_acq_rel);
+
+    // Close any last race where the render thread requested the display lock
+    // just as the modal dialog returned. Do not resume QB code until that
+    // in-flight SUB _GL call has released the cooperative display lock.
+    if (display_lock_request > display_lock_confirmed)
+        display_lock_confirmed = display_lock_request;
+
+    while ((display_lock_released < display_lock_confirmed) && (!close_program) && (!suspend_program) && (!stop_program))
+        Sleep(1);
+#endif
+}
 
 // note: only to be used by user functions, not internal functions
 hardware_img_struct *get_hardware_img(int32 handle) {
@@ -27827,6 +27871,10 @@ void GLUT_DISPLAY_REQUEST() {
                 while (display_lock_confirmed < display_lock_request) {
                     if (close_program || dont_call_sub_gl || suspend_program || stop_program)
                         goto abort_gl;
+                    if (display_lock_modal_count.load(std::memory_order_acquire) > 0) {
+                        display_lock_confirmed = display_lock_request;
+                        break;
+                    }
                     qbevent = 1;
                     Sleep(0);
                 }

--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -744,10 +744,7 @@ static std::atomic<int32> display_lock_modal_count{0};
 
 void gui_modal_lock_begin() {
 #ifdef DEPENDENCY_GL
-    if (sub_gl_called)
-        return;
-
-    display_lock_modal_count.fetch_add(1, std::memory_order_acq_rel);
+       display_lock_modal_count.fetch_add(1, std::memory_order_acq_rel);
 
     // If the render thread is already waiting for the QB thread to acknowledge
     // a display lock, acknowledge it before entering a modal OS dialog. The
@@ -760,9 +757,6 @@ void gui_modal_lock_begin() {
 
 void gui_modal_lock_end() {
 #ifdef DEPENDENCY_GL
-    if (sub_gl_called)
-        return;
-
     if (display_lock_modal_count.load(std::memory_order_acquire) > 0)
         display_lock_modal_count.fetch_sub(1, std::memory_order_acq_rel);
 

--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -172,7 +172,7 @@ extern "C" int QB64_Resizable() {
     return ScreenResize;
 }
 
-thread_local int32 sub_gl_called = 0;
+int32 sub_gl_called = 0;
 
 static int32 image_qbicon16_handle;
 static int32 image_qbicon32_handle;

--- a/internal/c/libqb/include/gui.h
+++ b/internal/c/libqb/include/gui.h
@@ -27,5 +27,8 @@ qbs *func__guiOpenFileDialog(qbs *qbsTitle, qbs *qbsDefaultPathAndFile, qbs *qbs
                              int32_t passed);
 qbs *func__guiSaveFileDialog(qbs *qbsTitle, qbs *qbsDefaultPathAndFile, qbs *qbsFilterPatterns, qbs *qbsSingleFilterDescription, int32_t passed);
 
+void gui_modal_lock_begin();
+void gui_modal_lock_end();
+
 int gui_alert(const char *message, const char *title, const char *type);
 bool gui_alert(const char *fmt, ...);

--- a/internal/c/parts/gui/gui.cpp
+++ b/internal/c/parts/gui/gui.cpp
@@ -64,6 +64,15 @@ static void gui_free_tokens(char **tokens) {
     free(tokens);
 }
 
+class gui_modal_guard {
+  public:
+    gui_modal_guard() { gui_modal_lock_begin(); }
+    ~gui_modal_guard() { gui_modal_lock_end(); }
+
+    gui_modal_guard(const gui_modal_guard &) = delete;
+    gui_modal_guard &operator=(const gui_modal_guard &) = delete;
+};
+
 /// @brief Shows a system notification (on Windows this will be an action center notification)
 /// @param qbsTitle [OPTIONAL] Title of the notification
 /// @param qbsMessage [OPTIONAL] The message that will be displayed
@@ -113,6 +122,7 @@ void sub__guiMessageBox(qbs *qbsTitle, qbs *qbsMessage, qbs *qbsIconType, int32_
         aIconType.assign("info");
     }
 
+    gui_modal_guard modalGuard;
     tinyfd_messageBox(aTitle.c_str(), aMessage.c_str(), "ok", aIconType.c_str(), 1);
 }
 
@@ -153,6 +163,7 @@ int32_t func__guiMessageBox(qbs *qbsTitle, qbs *qbsMessage, qbs *qbsDialogType, 
     if (!(passed & 16))
         nDefaultButton = 1;
 
+    gui_modal_guard modalGuard;
     return tinyfd_messageBox(aTitle.c_str(), aMessage.c_str(), aDialogType.c_str(), aIconType.c_str(), nDefaultButton);
 }
 
@@ -181,7 +192,11 @@ qbs *func__guiInputBox(qbs *qbsTitle, qbs *qbsMessage, qbs *qbsDefaultInput, int
         sDefaultInput = aDefaultInput.c_str();
     }
 
-    auto sInput = tinyfd_inputBox(aTitle.c_str(), aMessage.c_str(), sDefaultInput);
+    const char *sInput;
+    {
+        gui_modal_guard modalGuard;
+        sInput = tinyfd_inputBox(aTitle.c_str(), aMessage.c_str(), sDefaultInput);
+    }
 
     // Create a new qbs and then copy the string to it
     auto qbsInput = qbs_new(sInput ? strlen(sInput) : 0, 1);
@@ -206,7 +221,11 @@ qbs *func__guiSelectFolderDialog(qbs *qbsTitle, qbs *qbsDefaultPath, int32_t pas
     if (passed & 2)
         aDefaultPath.assign((const char *)qbsDefaultPath->chr, qbsDefaultPath->len);
 
-    auto sFolder = tinyfd_selectFolderDialog(aTitle.c_str(), aDefaultPath.c_str());
+    const char *sFolder;
+    {
+        gui_modal_guard modalGuard;
+        sFolder = tinyfd_selectFolderDialog(aTitle.c_str(), aDefaultPath.c_str());
+    }
 
     // Create a new qbs and then copy the string to it
     auto qbsFolder = qbs_new(sFolder ? strlen(sFolder) : 0, 1);
@@ -233,8 +252,14 @@ uint32_t func__guiColorChooserDialog(qbs *qbsTitle, uint32_t nDefaultRGB, int32_
     // Break the color into RGB components
     uint8_t lRGB[3] = {image_get_bgra_red(nDefaultRGB), image_get_bgra_green(nDefaultRGB), image_get_bgra_blue(nDefaultRGB)};
 
+    char *lChosen;
+    {
+        gui_modal_guard modalGuard;
+        lChosen = tinyfd_colorChooser(aTitle.c_str(), nullptr, lRGB, lRGB);
+    }
+
     // On cancel, return 0 (i.e. no color, no alpha, nothing). Else, return color with alpha set to 255
-    return !tinyfd_colorChooser(aTitle.c_str(), nullptr, lRGB, lRGB) ? 0 : image_make_bgra(lRGB[0], lRGB[1], lRGB[2], 0xFF);
+    return !lChosen ? 0 : image_make_bgra(lRGB[0], lRGB[1], lRGB[2], 0xFF);
 }
 
 /// @brief Shows the system file open dialog box
@@ -278,8 +303,12 @@ qbs *func__guiOpenFileDialog(qbs *qbsTitle, qbs *qbsDefaultPathAndFile, qbs *qbs
     int32_t aNumOfFilterPatterns;
     auto psaFilterPatterns = gui_tokenize(aFilterPatterns.c_str(), &aNumOfFilterPatterns); // get the number of file filters & count
 
-    auto sFileName = tinyfd_openFileDialog(aTitle.c_str(), aDefaultPathAndFile.c_str(), aNumOfFilterPatterns, psaFilterPatterns, sSingleFilterDescription,
-                                           nAllowMultipleSelects);
+    const char *sFileName;
+    {
+        gui_modal_guard modalGuard;
+        sFileName = tinyfd_openFileDialog(aTitle.c_str(), aDefaultPathAndFile.c_str(), aNumOfFilterPatterns, psaFilterPatterns, sSingleFilterDescription,
+                                          nAllowMultipleSelects);
+    }
 
     gui_free_tokens(psaFilterPatterns); // free memory used by tokenizer
 
@@ -323,7 +352,11 @@ qbs *func__guiSaveFileDialog(qbs *qbsTitle, qbs *qbsDefaultPathAndFile, qbs *qbs
     int32_t aNumOfFilterPatterns;
     auto psaFilterPatterns = gui_tokenize(aFilterPatterns.c_str(), &aNumOfFilterPatterns); // get the number of file filters & count
 
-    auto sFileName = tinyfd_saveFileDialog(aTitle.c_str(), aDefaultPathAndFile.c_str(), aNumOfFilterPatterns, psaFilterPatterns, sSingleFilterDescription);
+    const char *sFileName;
+    {
+        gui_modal_guard modalGuard;
+        sFileName = tinyfd_saveFileDialog(aTitle.c_str(), aDefaultPathAndFile.c_str(), aNumOfFilterPatterns, psaFilterPatterns, sSingleFilterDescription);
+    }
 
     gui_free_tokens(psaFilterPatterns); // free memory used by tokenizer
 
@@ -351,6 +384,7 @@ int gui_alert(const char *message, const char *title, const char *type) {
     // TODO: Probably we should adapt this to a timed terminal message box or prompt when running in $CONSOLE:ONLY mode.
     fprintf(stderr, "\nRuntime error: %s\n", message);
     fflush(stderr);
+    gui_modal_guard modalGuard;
     return tinyfd_messageBox(title, message, type, "error", 1);
 }
 

--- a/internal/c/qbx.cpp
+++ b/internal/c/qbx.cpp
@@ -51,7 +51,7 @@ extern int32 vWatchHandle();
 int _CRT_glob = -1; // enable globbing on llvm-mingw by default
 #endif
 
-extern thread_local int32 sub_gl_called;
+extern int32 sub_gl_called;
 
 #ifdef QB64_GUI
 #    ifdef DEPENDENCY_GL

--- a/internal/c/qbx.cpp
+++ b/internal/c/qbx.cpp
@@ -51,7 +51,7 @@ extern int32 vWatchHandle();
 int _CRT_glob = -1; // enable globbing on llvm-mingw by default
 #endif
 
-extern int32 sub_gl_called;
+extern thread_local int32 sub_gl_called;
 
 #ifdef QB64_GUI
 #    ifdef DEPENDENCY_GL

--- a/setup_win.cmd
+++ b/setup_win.cmd
@@ -24,11 +24,15 @@ cd /d %~dp0
 rem Check if the C++ compiler is there and skip MINGW setup if it exists
 if exist "internal\c\c_compiler\bin\c++.exe" goto build_qb64pe
 
-rem Check the processor type and then set the BITS variable
-powershell -c "(Get-WmiObject Win32_OperatingSystem).OsArchitecture" | find /i "64-bit" > nul && set BITS=64 || set BITS=32
+rem Check the OS bitness and then set the BITS variable
+rem Do not parse the localized OsArchitecture text. On non-English Windows,
+rem it may not contain the literal string "64-bit", which would incorrectly
+rem fall back to 32-bit MinGW.
+powershell -NoProfile -Command "if ([Environment]::Is64BitOperatingSystem) { exit 0 } else { exit 1 }" > nul 2> nul && set "BITS=64" || set "BITS=32"
+echo Detected %BITS%-bit Windows.
 
 rem If the OS is 32-bit then proceed to download right away
-if %BITS% == 32 goto setup_mingw
+if "%BITS%" == "32" goto setup_mingw
 
 rem Check if the user wants to use 32-bit MINGW on a 64-bit system. Default to 64-bit after 60 seconds
 choice /t 60 /c 12 /d 1 /m "Do you prefer to download MinGW [1] 64-bit (default) or [2] 32-bit"


### PR DESCRIPTION
This fix reapir  this bug:

SCREEN 0
_PRINTSTRING (0, 0), "error"

END

SUB _GL
END SUB

This bug is in Discord thread.
Now program continue as expected and crash not  

The current version on non-US Windows only downloads the 32-bit compiler. This version fixes this and gives you the choice on a 64-bit system whether you want the 32-bit or 64-bit version of the compiler. 