### PR TITLE
Compress undo content

### DIFF
--- a/source/ide/config/cfg_global.bas
+++ b/source/ide/config/cfg_global.bas
@@ -48,10 +48,19 @@ BookmarksFile$ = ConfigFolder$ + pathsep$ + "bookmarks.bin" 'set bokmarks (globa
 RecentFile$ = ConfigFolder$ + pathsep$ + "recent.bin" 'recent file list (globally shared)
 SearchedFile$ = ConfigFolder$ + pathsep$ + "searched.bin" 'search history (globally shared)
 AutosaveFile$ = ConfigFolder$ + pathsep$ + "autosave" + tempfolderindexstr$ + ".bin" 'autosave flag (per instance)
-UndoFile$ = ConfigFolder$ + pathsep$ + "undo" + tempfolderindexstr$ + ".bin" 'undo storage (per instance)
+UndoFile$ = ConfigFolder$ + pathsep$ + "undo3" + tempfolderindexstr$ + ".bin" 'undo storage (per instance) (3rd file generation = compressed)
 '---
 askToCopyOther = _FALSE 'shall we ask the user to copy settings from another QB64-PE installation
-IF NOT _DIREXISTS(ConfigFolder$) THEN MKDIR ConfigFolder$: askToCopyOther = _TRUE
+IF NOT _DIREXISTS(ConfigFolder$) THEN
+    'create folder and set ask flag
+    MKDIR ConfigFolder$
+    askToCopyOther = _TRUE
+ELSE
+    'delete old (1st/2nd gen. = uncompressed) undo file of this instance (if any)
+    IF _FILEEXISTS(ConfigFolder$ + pathsep$ + "undo" + tempfolderindexstr$ + ".bin") THEN
+        KILL ConfigFolder$ + pathsep$ + "undo" + tempfolderindexstr$ + ".bin"
+    END IF
+END IF
 
 '===== Define sections and standard behavior ==================================
 '--- config.ini

--- a/source/ide/ide_global.bas
+++ b/source/ide/ide_global.bas
@@ -141,7 +141,7 @@ CONST idesystem2.w = 20 '"Find" field width (Status bar)
 DIM SHARED idesubwindow, idehelp, statusarealink AS INTEGER
 DIM SHARED ideexit
 DIM SHARED idet AS STRING, idel, ideli, iden
-DIM SHARED ideundopos, ideundobase, ideundoflag
+DIM SHARED ideundotxt AS STRING, ideundopos, ideundobase, ideundoflag
 DIM SHARED idelaunched, idecompiling
 DIM SHARED idecompiledline 'stores the number of the last line sent to the compiler, used only to know which line to send next
 DIM SHARED idecompiledline$ 'stores the last line sent to the compiler

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -563,7 +563,8 @@ FUNCTION ide2 (ignore)
                     'bookmark info [v2]
                     GET #150, , IdeBmkN: REDIM IdeBmk(IdeBmkN + 1) AS IdeBmkType
                     FOR bi = 1 TO IdeBmkN: GET #150, , IdeBmk(bi).y: GET #150, , IdeBmk(bi).x: NEXT
-                    GET #150, , x&: idet$ = SPACE$(x&): GET #150, , idet$
+                    GET #150, , x&: GET #150, , ox&: ideundotxt$ = SPACE$(x&): GET #150, , ideundotxt$
+                    idet$ = _INFLATE$(ideundotxt$, ox&)
                 END IF
                 CLOSE #150
             END IF
@@ -1263,9 +1264,9 @@ FUNCTION ide2 (ignore)
                 'bookmark info [v2]
                 a$ = a$ + MKL$(IdeBmkN)
                 FOR bi = 1 TO IdeBmkN: a$ = a$ + MKL$(IdeBmk(bi).y) + MKL$(IdeBmk(bi).x): NEXT
-                l& = LEN(idet$)
-                a$ = a$ + MKL$(l&) 'data size
-                a$ = MKL$(l& + LEN(a$)) + a$ + idet$ + MKL$(l& + LEN(a$)) 'header, data & encapsulation (reverse navigatable list)
+                ideundotxt$ = _DEFLATE$(idet$): l& = LEN(ideundotxt$) 'compress edited text
+                a$ = a$ + MKL$(l&) + MKL$(LEN(idet$)) 'compressed data size + original text size
+                a$ = MKL$(l& + LEN(a$)) + a$ + ideundotxt$ + MKL$(l& + LEN(a$)) 'header, data & encapsulation (reverse navigatable list)
 
                 'add undo event
 
@@ -3621,7 +3622,8 @@ FUNCTION ide2 (ignore)
                     'bookmark info [v2]
                     GET #150, , IdeBmkN: REDIM IdeBmk(IdeBmkN + 1) AS IdeBmkType
                     FOR bi = 1 TO IdeBmkN: GET #150, , IdeBmk(bi).y: GET #150, , IdeBmk(bi).x: NEXT
-                    GET #150, , x&: idet$ = SPACE$(x&): GET #150, , idet$
+                    GET #150, , x&: GET #150, , ox&: ideundotxt$ = SPACE$(x&): GET #150, , ideundotxt$
+                    idet$ = _INFLATE$(ideundotxt$, ox&)
 
                     idechangemade = 1: idenoundo = 1: startPausedPending = 0
 
@@ -3682,7 +3684,8 @@ FUNCTION ide2 (ignore)
                     'bookmark info [v2]
                     GET #150, , IdeBmkN: REDIM IdeBmk(IdeBmkN + 1) AS IdeBmkType
                     FOR bi = 1 TO IdeBmkN: GET #150, , IdeBmk(bi).y: GET #150, , IdeBmk(bi).x: NEXT
-                    GET #150, , x&: idet$ = SPACE$(x&): GET #150, , idet$
+                    GET #150, , x&: GET #150, , ox&: ideundotxt$ = SPACE$(x&): GET #150, , ideundotxt$
+                    idet$ = _INFLATE$(ideundotxt$, ox&)
 
                     idechangemade = 1: idenoundo = 1: startPausedPending = 0
 

--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -563,6 +563,7 @@ FUNCTION ide2 (ignore)
                     'bookmark info [v2]
                     GET #150, , IdeBmkN: REDIM IdeBmk(IdeBmkN + 1) AS IdeBmkType
                     FOR bi = 1 TO IdeBmkN: GET #150, , IdeBmk(bi).y: GET #150, , IdeBmk(bi).x: NEXT
+                    'text info compressed instead plain [v3]
                     GET #150, , x&: GET #150, , ox&: ideundotxt$ = SPACE$(x&): GET #150, , ideundotxt$
                     idet$ = _INFLATE$(ideundotxt$, ox&)
                 END IF
@@ -1264,6 +1265,7 @@ FUNCTION ide2 (ignore)
                 'bookmark info [v2]
                 a$ = a$ + MKL$(IdeBmkN)
                 FOR bi = 1 TO IdeBmkN: a$ = a$ + MKL$(IdeBmk(bi).y) + MKL$(IdeBmk(bi).x): NEXT
+                'text info compressed instead plain [v3]
                 ideundotxt$ = _DEFLATE$(idet$): l& = LEN(ideundotxt$) 'compress edited text
                 a$ = a$ + MKL$(l&) + MKL$(LEN(idet$)) 'compressed data size + original text size
                 a$ = MKL$(l& + LEN(a$)) + a$ + ideundotxt$ + MKL$(l& + LEN(a$)) 'header, data & encapsulation (reverse navigatable list)
@@ -3622,6 +3624,7 @@ FUNCTION ide2 (ignore)
                     'bookmark info [v2]
                     GET #150, , IdeBmkN: REDIM IdeBmk(IdeBmkN + 1) AS IdeBmkType
                     FOR bi = 1 TO IdeBmkN: GET #150, , IdeBmk(bi).y: GET #150, , IdeBmk(bi).x: NEXT
+                    'text info compressed instead plain [v3]
                     GET #150, , x&: GET #150, , ox&: ideundotxt$ = SPACE$(x&): GET #150, , ideundotxt$
                     idet$ = _INFLATE$(ideundotxt$, ox&)
 
@@ -3684,6 +3687,7 @@ FUNCTION ide2 (ignore)
                     'bookmark info [v2]
                     GET #150, , IdeBmkN: REDIM IdeBmk(IdeBmkN + 1) AS IdeBmkType
                     FOR bi = 1 TO IdeBmkN: GET #150, , IdeBmk(bi).y: GET #150, , IdeBmk(bi).x: NEXT
+                    'text info compressed instead plain [v3]
                     GET #150, , x&: GET #150, , ox&: ideundotxt$ = SPACE$(x&): GET #150, , ideundotxt$
                     idet$ = _INFLATE$(ideundotxt$, ox&)
 


### PR DESCRIPTION
- resulting in smaller undo files or more undo events fitting in same file size
- meta data such as cursor, selection and bookmarks remain uncompressed for read-back simplicity (less than 100 bytes per event)
- old undo files will be deleted automatically, just in case you build from the repo
- new releases come clean anyways and start right off with the new format