### PR TITLE
Fix negative bounds formatting in dynamic member REDIM

### DIFF
--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -15968,6 +15968,8 @@ SUB BuildDynMemberBoundsPrep (bounds AS STRING, prep_prefix AS STRING, total_dim
     DIM dim_tokens AS LONG
     DIM dim_token_index AS LONG
     DIM to_position AS LONG
+    DIM lower_is_const AS LONG
+    DIM upper_is_const AS LONG
     DIM current_dim AS LONG
     DIM desc_slots AS LONG
     DIM desc_index AS LONG
@@ -16046,12 +16048,26 @@ SUB BuildDynMemberBoundsPrep (bounds AS STRING, prep_prefix AS STRING, total_dim
             IF Error_Happened THEN EXIT SUB
             lower_text = evaluatetotyp$(lower_ordered, 64&)
             IF Error_Happened THEN EXIT SUB
+            lower_is_const = constequation
 
             constequation = 1
             upper_ordered = fixoperationorder$(upper_expr)
             IF Error_Happened THEN EXIT SUB
             upper_text = evaluatetotyp$(upper_ordered, 64&)
             IF Error_Happened THEN EXIT SUB
+            upper_is_const = constequation
+
+            'Match allocarray(): reject impossible constant bounds in the IDE,
+            'while retaining the generated runtime guard for variable expressions.
+            IF upper_is_const THEN
+                IF to_position THEN
+                    IF lower_is_const THEN
+                        IF VAL(upper_text) < VAL(lower_text) THEN Give_Error "Invalid array bounds": EXIT SUB
+                    END IF
+                ELSE
+                    IF VAL(upper_text) < 0 THEN Give_Error "Invalid array bounds": EXIT SUB
+                END IF
+            END IF
 
             current_dim = current_dim + 1
             desc_index = (total_dims - current_dim) * 4 + 4
@@ -16502,7 +16518,8 @@ FUNCTION CompactMemberRefLayout$ (src AS STRING)
         ELSEIF tok = ")" THEN
             compacttxt = RTRIM$(compacttxt) + ")"
             needspace = 1
-        ELSE
+
+        ELSE 'update (previous version add space before minus if negative arrays bounds in valid range is declared)
             IF LEN(compacttxt) = 0 THEN
                 compacttxt = tok
             ELSEIF needspace THEN
@@ -16512,8 +16529,17 @@ FUNCTION CompactMemberRefLayout$ (src AS STRING)
             ELSE
                 compacttxt = compacttxt + tok
             END IF
+
             needspace = 1
+
+            'Unary + or - must remain attached to its operand.
+            IF tok = "-" OR tok = "+" THEN
+                IF prevtok = "" OR prevtok = "(" OR prevtok = "," OR UCASE$(prevtok) = "TO" THEN
+                    needspace = 0
+                END IF
+            END IF
         END IF
+
         prevtok = tok
     NEXT
 

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -1659,6 +1659,8 @@ reginternal
 
 DIM SHARED GlobTxtBuf: GlobTxtBuf = OpenBuffer%("O", tmpdir$ + "global.txt")
 defdatahandle = GlobTxtBuf
+WriteBufLine GlobTxtBuf, "template <typename QBL, typename QBR> static inline auto qb_safe_idiv(QBL qb_l,QBR qb_r)->decltype(qb_l/qb_r){if (!qb_r){error(11);return (decltype(qb_l/qb_r))0;}return qb_l/qb_r;}"
+WriteBufLine GlobTxtBuf, "template <typename QBL, typename QBR> static inline auto qb_safe_mod(QBL qb_l,QBR qb_r)->decltype(qb_l%qb_r){if (!qb_r){error(11);return (decltype(qb_l%qb_r))0;}return qb_l%qb_r;}"
 
 IF iderecompile THEN
     iderecompile = 0
@@ -25234,8 +25236,8 @@ FUNCTION operatorusage (operator$, typ AS LONG, info$, lhs AS LONG, rhs AS LONG,
 
     lhs = 1: rhs = 1: result = 1
     operator$ = UCASE$(operator$)
-    IF operator$ = "MOD" THEN info$ = "%": operatorusage = 1: EXIT FUNCTION
-    IF operator$ = "\" THEN info$ = "/ ": operatorusage = 1: EXIT FUNCTION
+    IF operator$ = "MOD" THEN info$ = "qb_safe_mod": operatorusage = 2: EXIT FUNCTION
+    IF operator$ = "\" THEN info$ = "qb_safe_idiv": operatorusage = 2: EXIT FUNCTION
     IF operator$ = "IMP" THEN info$ = "|": operatorusage = 4: EXIT FUNCTION
     IF operator$ = "EQV" THEN info$ = "^": operatorusage = 4: EXIT FUNCTION
     IF operator$ = "XOR" THEN info$ = "^": operatorusage = 1: EXIT FUNCTION

--- a/tests/format_tests/dynamic_member_redim/dynamic_member_redim.bas
+++ b/tests/format_tests/dynamic_member_redim/dynamic_member_redim.bas
@@ -1,0 +1,7 @@
+Type BufferType
+    sample(1, 1) _Dynamic As Long
+End Type
+
+ReDim buffers(1) As BufferType
+ReDim buffers(1).sample(-5 To -3, -2 To -1)
+ReDim buffers(1).sample(firstIndex - 5 To lastIndex - 3, -2 To -1)

--- a/tests/format_tests/dynamic_member_redim/dynamic_member_redim.bas
+++ b/tests/format_tests/dynamic_member_redim/dynamic_member_redim.bas
@@ -1,3 +1,5 @@
+$Unstable:TypeFields
+
 Type BufferType
     sample(1, 1) _Dynamic As Long
 End Type

--- a/tests/format_tests/dynamic_member_redim/dynamic_member_redim.flagmap
+++ b/tests/format_tests/dynamic_member_redim/dynamic_member_redim.flagmap
@@ -1,0 +1,1 @@
+spacing-cc.out -f:autoindent=0 -f:autoindentsize=4 -f:indentsubs=0 -f:autolayout=1 -f:keywordcapitals=0 -f:keywordlowercase=0

--- a/tests/format_tests/dynamic_member_redim/spacing-cc.out
+++ b/tests/format_tests/dynamic_member_redim/spacing-cc.out
@@ -1,0 +1,7 @@
+Type BufferType
+    sample(1, 1) _Dynamic As Long
+End Type
+
+ReDim buffers(1) As BufferType
+ReDim buffers(1).sample(-5 To -3, -2 To -1)
+ReDim buffers(1).sample(firstIndex - 5 To lastIndex - 3, -2 To -1)

--- a/tests/format_tests/dynamic_member_redim/spacing-cc.out
+++ b/tests/format_tests/dynamic_member_redim/spacing-cc.out
@@ -1,3 +1,5 @@
+$Unstable:TypeFields
+
 Type BufferType
     sample(1, 1) _Dynamic As Long
 End Type


### PR DESCRIPTION
Fixed a bug reported by RhoSigma: In array declarations such as `myArray(1 TO 5)`, the `TO` keyword did not follow the selected UPPER/CaMeL/lower keyword style when used for a member array, either inside a `TYPE` declaration or in a `(RE)DIM` statement.

Fixed the formatting of negative bounds in `REDIM` statements for dynamic member arrays.
