### PR TITLE
Automatic CF-BFM switching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,33 @@ on:
       - 'main'
 
 jobs:
+  # 1. Prepare-Job: Cloudflare settings
+  cf-bfm-off:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Disable Cloudflare Bot Fight Mode
+        run: |
+          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": false}'
+
+  # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
+    needs: cf-bfm-off
     uses: ./.github/workflows/build-process.yml
     secrets: inherit
+
+  # 3. Cleanup-Job: Wait for Job 2, then reset Cloudflare
+  # Runs ALWAYS – doesn't matter if the Build succeeds, fails or got canceled.
+  cf-bfm-on:
+    needs: build
+    if: always() || cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-enable Cloudflare Bot Fight Mode
+        run: |
+          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": true}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Disable Cloudflare Bot Fight Mode
-        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
+        run: |
+          curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": false}'
 
   # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
@@ -27,4 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
-        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'
+        run: |
+          curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": true}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Disable Cloudflare Bot Fight Mode
-        run: |
-          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
-               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-               -H "Content-Type: application/json" \
-               --data '{"fight_mode": false}'
+        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
 
   # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
@@ -31,8 +27,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
-        run: |
-          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
-               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-               -H "Content-Type: application/json" \
-               --data '{"fight_mode": true}'
+        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Disable Cloudflare Bot Fight Mode
         run: |
-          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": false}'
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
         run: |
-          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": true}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Disable Cloudflare Bot Fight Mode
-        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
+        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
 
   # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
@@ -27,4 +27,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
-        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'
+        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Disable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": false}'
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": true}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Disable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": false}'
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": true}'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,33 @@ on:
       - 'main'
 
 jobs:
+  # 1. Prepare-Job: Cloudflare settings
+  cf-bfm-off:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Disable Cloudflare Bot Fight Mode
+        run: |
+          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": false}'
+
+  # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
+    needs: cf-bfm-off
     uses: ./.github/workflows/build-process.yml
     secrets: inherit
+
+  # 3. Cleanup-Job: Wait for Job 2, then reset Cloudflare
+  # Runs ALWAYS – doesn't matter if the Build succeeds, fails or got canceled.
+  cf-bfm-on:
+    needs: build
+    if: always() || cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-enable Cloudflare Bot Fight Mode
+        run: |
+          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": true}'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Disable Cloudflare Bot Fight Mode
-        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
+        run: |
+          curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": false}'
 
   # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
@@ -27,4 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
-        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'
+        run: |
+          curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": true}'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,11 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Disable Cloudflare Bot Fight Mode
-        run: |
-          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
-               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-               -H "Content-Type: application/json" \
-               --data '{"fight_mode": false}'
+        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
 
   # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
@@ -31,8 +27,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
-        run: |
-          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
-               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-               -H "Content-Type: application/json" \
-               --data '{"fight_mode": true}'
+        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Disable Cloudflare Bot Fight Mode
         run: |
-          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": false}'
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
         run: |
-          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": true}'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Disable Cloudflare Bot Fight Mode
-        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
+        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
 
   # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
@@ -27,4 +27,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
-        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'
+        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Disable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": false}'
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": true}'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Disable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": false}'
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": true}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,33 @@ on:
       - 'v*'
 
 jobs:
+  # 1. Prepare-Job: Cloudflare settings
+  cf-bfm-off:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Disable Cloudflare Bot Fight Mode
+        run: |
+          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": false}'
+
+  # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
+    needs: cf-bfm-off
     uses: ./.github/workflows/build-process.yml
     secrets: inherit
+
+  # 3. Cleanup-Job: Wait for Job 2, then reset Cloudflare
+  # Runs ALWAYS – doesn't matter if the Build succeeds, fails or got canceled.
+  cf-bfm-on:
+    needs: build
+    if: always() || cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-enable Cloudflare Bot Fight Mode
+        run: |
+          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": true}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Disable Cloudflare Bot Fight Mode
-        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
+        run: |
+          curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": false}'
 
   # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
@@ -27,4 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
-        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'
+        run: |
+          curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" \
+               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+               -H "Content-Type: application/json" \
+               --data '{"fight_mode": true}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Disable Cloudflare Bot Fight Mode
-        run: |
-          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
-               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-               -H "Content-Type: application/json" \
-               --data '{"fight_mode": false}'
+        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
 
   # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
@@ -31,8 +27,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
-        run: |
-          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
-               -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
-               -H "Content-Type: application/json" \
-               --data '{"fight_mode": true}'
+        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Disable Cloudflare Bot Fight Mode
         run: |
-          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": false}'
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
         run: |
-          curl -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": true}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Disable Cloudflare Bot Fight Mode
-        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
+        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": false}'
 
   # 2. Main-Job: Wait for Job 1, then call the Matrix-Build
   build:
@@ -27,4 +27,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
-        run: curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'
+        run: curl -g -X PUT "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/bot_management" -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" -H "Content-Type: application/json" --data '{"fight_mode": true}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Disable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": false}'
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": true}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Disable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": false}'
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Re-enable Cloudflare Bot Fight Mode
         run: |
-          curl -g -X PATCH "https://cloudflare.com/{{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
+          curl -g -X PATCH "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/botmanagement" \
                -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
                -H "Content-Type: application/json" \
                --data '{"fight_mode": true}'


### PR DESCRIPTION
So after all trouble with the bot attacks in the past months and now finally putting our qb64phoenix.com behind Cloudflare, I also managed now to allow the GitHub runners to access our Wiki again to fetch the help pages during builds/releases.

The only tear in the eye is, that in the free Cloudflare plan only allows this by temporarily disabling the "Bot Fight Mode" (BFM), which means that during builds the bot hits will raise for time it runs. Well, on the other side we can easily see when a build is running by watching the usercount in the forum ;-)
