### PR TITLE
Use workflow queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # 1. Prepare-Job: Cloudflare settings
   cf-bfm-off:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # 1. Prepare-Job: Cloudflare settings
   cf-bfm-off:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # 1. Prepare-Job: Cloudflare settings
   cf-bfm-off:


### PR DESCRIPTION
Another adaption to our workflows in regards for safe Cloudflare switching.

Formerly when an `Automatc internal/source update` was pushed, it triggered a new workflow instance immediately which was then running parallel to the workflow it was triggered from. Now that we have the Cloudflare Bot Fight Mode switch in place this would mean that whichever of the two workflows finishes first would re-enable Cloudflare again and so compromising the second still running workflow.

With this PR all workflows get a concurrency ID, which makes sure that the source update workflow is deferred until the workflow from which it was triggered is completed, either success, failed or canceled.