### PR TITLE
fix for bug 659 (qb64pe.bas) and 739 (ide_methods.bas). 

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -8792,7 +8792,7 @@ FUNCTION idevariablewatchbox$ (currentScope$, filter$, selectVar, returnAction)
     TYPE varDlgList
         AS LONG index, bgColorFlag, colorFlag, colorFlag2, indicator, indicator2
         AS _BYTE selected
-        AS STRING varType
+        AS STRING varType, arrayIndex
     END TYPE
 
     REDIM varDlgList(1 TO totalVariablesCreated) AS varDlgList
@@ -9125,8 +9125,12 @@ FUNCTION idevariablewatchbox$ (currentScope$, filter$, selectVar, returnAction)
 
                             '-------
                             v$ = lineformat$(UCASE$(v$))
+                            watchHasArray = INSTR(v$, "(") <> 0
+                            watchChecking = CheckingOn
+                            IF watchHasArray THEN CheckingOn = 0
                             Error_Happened = 0
                             result$ = udtreference$("", v$, typ)
+                            CheckingOn = watchChecking
                             IF Error_Happened THEN
                                 'shouldn't ever happen
                                 Error_Happened = 0
@@ -9179,7 +9183,13 @@ FUNCTION idevariablewatchbox$ (currentScope$, filter$, selectVar, returnAction)
                                             GOTO dlgLoop
                                         END IF
                                 END SELECT
-                                tempElementOffset$ = MKL$(VAL(MID$(result$, _INSTRREV(result$, sp3) + 1)))
+                                watchOffset& = idewatchoffset&(result$, watchOffsetOK)
+                                IF watchOffsetOK = 0 THEN
+                                    result = idemessagebox("Error", "The debugger can currently watch only TYPE members with a static byte offset.", "#OK")
+                                    _KEYCLEAR
+                                    _CONTINUE
+                                END IF
+                                tempElementOffset$ = MKL$(watchOffset&)
                             END IF
                             '-------
                         ELSE
@@ -9651,8 +9661,12 @@ FUNCTION idevariablewatchbox$ (currentScope$, filter$, selectVar, returnAction)
                                 END IF
                                 usedVariableList(varDlgList(y).index).elements = usedVariableList(varDlgList(y).index).elements + v$ + sp
                                 v$ = lineformat$(UCASE$(v$))
+                                watchHasArray = INSTR(v$, "(") <> 0
+                                watchChecking = CheckingOn
+                                IF watchHasArray THEN CheckingOn = 0
                                 Error_Happened = 0
                                 result$ = udtreference$("", v$, typ)
+                                CheckingOn = watchChecking
                                 IF Error_Happened THEN
                                     'shouldn't ever happen
                                     Error_Happened = 0
@@ -9711,7 +9725,16 @@ FUNCTION idevariablewatchbox$ (currentScope$, filter$, selectVar, returnAction)
                                                 GOTO unWatch
                                             END IF
                                     END SELECT
-                                    usedVariableList(varDlgList(y).index).elementOffset = usedVariableList(varDlgList(y).index).elementOffset + MKL$(VAL(MID$(result$, _INSTRREV(result$, sp3) + 1)))
+                                    watchOffset& = idewatchoffset&(result$, watchOffsetOK)
+                                    IF watchOffsetOK = 0 THEN
+                                        usedVariableList(varDlgList(y).index).watch = 0
+                                        usedVariableList(varDlgList(y).index).elements = ""
+                                        usedVariableList(varDlgList(y).index).elementTypes = ""
+                                        usedVariableList(varDlgList(y).index).elementOffset = ""
+                                        result = idemessagebox("Error", "The debugger can currently watch only TYPE members with a static byte offset.", "#OK")
+                                        GOTO unWatch
+                                    END IF
+                                    usedVariableList(varDlgList(y).index).elementOffset = usedVariableList(varDlgList(y).index).elementOffset + MKL$(watchOffset&)
                                 END IF
                                 '-------
                             LOOP
@@ -10007,6 +10030,11 @@ FUNCTION ideelementwatchbox$ (currentPath$, elementIndexes$, level, singleElemen
     DIM p AS idedbptype
     DIM o(1 TO 100) AS idedbotype
     DIM sep AS STRING * 1
+    DIM thisElement AS LONG
+    DIM watchDims AS LONG, watchDim AS LONG, watchComma AS LONG
+    DIM watchPartStart AS LONG, watchDigitStart AS LONG, watchChar AS LONG
+    DIM watchDescAt AS LONG, watchLower AS LONG, watchCount AS LONG
+    DIM watchUpper AS _INTEGER64, watchValue AS _INTEGER64
     sep = CHR$(0)
     '-------- end of generic dialog box header --------
 
@@ -10146,7 +10174,7 @@ FUNCTION ideelementwatchbox$ (currentPath$, elementIndexes$, level, singleElemen
                     varType$ = varDlgList(y).varType
                     IF INSTR(varType$, "STRING *") THEN varType$ = "STRING"
                     IF INSTR(varType$, "_BIT *") THEN varType$ = "_BIT"
-                    IF INSTR(nativeDataTypes$, varType$) > 0 THEN
+                    IF INSTR(nativeDataTypes$, varType$) > 0 AND udtearrayelements(varDlgList(y).index) = 0 THEN
                         varDlgList(y).selected = -1
                         ASC(idetxt(o(varListBox).txt), varDlgList(y).colorFlag) = variableNameColor
                         ASC(idetxt(o(varListBox).txt), varDlgList(y).colorFlag2) = typeColumnColor
@@ -10191,6 +10219,10 @@ FUNCTION ideelementwatchbox$ (currentPath$, elementIndexes$, level, singleElemen
                         IF INSTR(nativeDataTypes$, varType$) > 0 THEN
                             'non-native data types will have already been added to the return list
                             thisName$ = RTRIM$(udtecname(varDlgList(y).index))
+                            IF udtearrayelements(varDlgList(y).index) THEN
+                                IF LEN(varDlgList(y).arrayIndex) = 0 THEN _CONTINUE
+                                thisName$ = thisName$ + varDlgList(y).arrayIndex
+                            END IF
                             IF LEN(returnList$) THEN returnList$ = returnList$ + sp
                             returnList$ = returnList$ + currentPath$ + thisName$
                         END IF
@@ -10244,6 +10276,21 @@ FUNCTION ideelementwatchbox$ (currentPath$, elementIndexes$, level, singleElemen
                     varDlgList(y).selected = NOT varDlgList(y).selected
                 END IF
                 IF varDlgList(y).selected THEN
+                    IF udtearrayelements(varDlgList(y).index) THEN
+                        thisElement = varDlgList(y).index
+                        GOSUB getStaticArrayIndex
+                        IF arrayIndexOK = 0 THEN
+                            varDlgList(y).selected = 0
+                            ASC(idetxt(o(varListBox).txt), varDlgList(y).colorFlag) = 16
+                            ASC(idetxt(o(varListBox).txt), varDlgList(y).colorFlag2) = 2
+                            ASC(idetxt(o(varListBox).txt), varDlgList(y).bgColorFlag) = 17
+                            ASC(idetxt(o(varListBox).txt), varDlgList(y).indicator) = 32 'space
+                            IF toggleAndReturn THEN RETURN
+                            _CONTINUE
+                        END IF
+                        varDlgList(y).arrayIndex = arrayIndexSuffix$
+                    END IF
+
                     IF singleElementSelection THEN
                         FOR i = 1 TO totalElements
                             IF i = y THEN _CONTINUE
@@ -10274,7 +10321,7 @@ FUNCTION ideelementwatchbox$ (currentPath$, elementIndexes$, level, singleElemen
                             elementIndexes2$ = elementIndexes2$ + MKL$(E)
                             i = i + 1
                         LOOP
-                        v$ = ideelementwatchbox$(currentPath$ + RTRIM$(udtecname(varDlgList(y).index)) + ".", elementIndexes2$, level + 1, singleElementSelection, ok2)
+                        v$ = ideelementwatchbox$(currentPath$ + RTRIM$(udtecname(varDlgList(y).index)) + varDlgList(y).arrayIndex + ".", elementIndexes2$, level + 1, singleElementSelection, ok2)
                         ok = ok2
                         IF ok2 = -2 THEN
                             'single selection
@@ -10285,6 +10332,7 @@ FUNCTION ideelementwatchbox$ (currentPath$, elementIndexes$, level, singleElemen
                         ELSEIF ok2 = -4 THEN
                             i = y
                             varDlgList(i).selected = 0
+                            varDlgList(i).arrayIndex = ""
                             ASC(idetxt(o(varListBox).txt), varDlgList(i).colorFlag) = 16
                             ASC(idetxt(o(varListBox).txt), varDlgList(i).colorFlag2) = 2
                             ASC(idetxt(o(varListBox).txt), varDlgList(i).bgColorFlag) = 17
@@ -10298,6 +10346,7 @@ FUNCTION ideelementwatchbox$ (currentPath$, elementIndexes$, level, singleElemen
                     ASC(idetxt(o(varListBox).txt), varDlgList(y).bgColorFlag) = selectedBG
                     ASC(idetxt(o(varListBox).txt), varDlgList(y).indicator) = 43 '+
                 ELSE
+                    varDlgList(y).arrayIndex = ""
                     ASC(idetxt(o(varListBox).txt), varDlgList(y).colorFlag) = 16
                     ASC(idetxt(o(varListBox).txt), varDlgList(y).colorFlag2) = 2
                     ASC(idetxt(o(varListBox).txt), varDlgList(y).bgColorFlag) = 17
@@ -10319,9 +10368,12 @@ FUNCTION ideelementwatchbox$ (currentPath$, elementIndexes$, level, singleElemen
     maxTypeLen = 0
     FOR x = 1 TO totalElements
         thisType = CVL(MID$(elementIndexes$, x * 4 - 3, 4))
-        IF LEN(RTRIM$(udtecname(thisType))) > longestName THEN longestName = LEN(RTRIM$(udtecname(thisType)))
+        thisName$ = RTRIM$(udtecname(thisType))
+        IF udtearrayelements(thisType) THEN thisName$ = thisName$ + "()"
+        IF LEN(thisName$) > longestName THEN longestName = LEN(thisName$)
         varDlgList(x).index = thisType
         varDlgList(x).selected = 0
+        varDlgList(x).arrayIndex = ""
         id.t = udtetype(thisType)
         id.tsize = udtesize(thisType)
 
@@ -10347,6 +10399,7 @@ FUNCTION ideelementwatchbox$ (currentPath$, elementIndexes$, level, singleElemen
         l$ = l$ + CHR$(16) + " "
 
         thisName$ = RTRIM$(udtecname(thisElement))
+        IF udtearrayelements(thisElement) THEN thisName$ = thisName$ + "()"
         text$ = thisName$ + CHR$(16)
         varDlgList(x).colorFlag2 = LEN(l$) + LEN(text$) + 1
         text$ = text$ + CHR$(2) + " "
@@ -10357,6 +10410,125 @@ FUNCTION ideelementwatchbox$ (currentPath$, elementIndexes$, level, singleElemen
         IF x < totalElements THEN l$ = l$ + sep
     NEXT
     RETURN
+
+    getStaticArrayIndex:
+    arrayIndexOK = 0
+    arrayIndexSuffix$ = ""
+    watchInput$ = ""
+    watchDims = udtearraydims(thisElement)
+    IF watchDims < 1 THEN RETURN
+
+    watchPrompt$ = "#Index"
+    IF watchDims > 1 THEN watchPrompt$ = "#Indexes (" + _TOSTR$(watchDims) + " dimensions)"
+
+    DO
+        watchInput$ = ideinputbox$("Choose Array Element", watchPrompt$, watchInput$, "-0123456789,", 45, 0, watchInputOK)
+        _KEYCLEAR
+        IF watchInputOK = 0 THEN RETURN
+
+        watchInput$ = _TRIM$(watchInput$)
+        DO WHILE LEN(watchInput$) AND RIGHT$(watchInput$, 1) = ","
+            watchInput$ = LEFT$(watchInput$, LEN(watchInput$) - 1)
+        LOOP
+
+        watchValid = -1
+        watchError$ = ""
+        watchNormalized$ = ""
+        watchPartStart = 1
+        watchDescAt = 1
+
+        FOR watchDim = 1 TO watchDims
+            watchComma = INSTR(watchPartStart, watchInput$, ",")
+            IF watchDim < watchDims THEN
+                IF watchComma = 0 THEN
+                    watchValid = 0
+                    watchError$ = "Array has" + STR$(watchDims) + " dimension(s)."
+                    EXIT FOR
+                END IF
+                watchPart$ = MID$(watchInput$, watchPartStart, watchComma - watchPartStart)
+                watchPartStart = watchComma + 1
+            ELSE
+                IF watchComma THEN
+                    watchValid = 0
+                    watchError$ = "Array has" + STR$(watchDims) + " dimension(s)."
+                    EXIT FOR
+                END IF
+                watchPart$ = MID$(watchInput$, watchPartStart)
+            END IF
+
+            watchPart$ = _TRIM$(watchPart$)
+            watchDigitStart = 1
+            IF LEFT$(watchPart$, 1) = "-" THEN watchDigitStart = 2
+            IF LEN(watchPart$) < watchDigitStart THEN
+                watchValid = 0
+                watchError$ = "Enter a valid integer index."
+                EXIT FOR
+            END IF
+
+            FOR watchChar = watchDigitStart TO LEN(watchPart$)
+                watchChar$ = MID$(watchPart$, watchChar, 1)
+                IF watchChar$ < "0" OR watchChar$ > "9" THEN
+                    watchValid = 0
+                    watchError$ = "Enter a valid integer index."
+                    EXIT FOR
+                END IF
+            NEXT
+            IF watchValid = 0 THEN EXIT FOR
+
+            IF ParseNextUDTArrayDescriptorDim(udtearraydesc(thisElement), watchDescAt, watchLower, watchCount) = 0 THEN
+                watchValid = 0
+                watchError$ = "Invalid static TYPE member array metadata."
+                EXIT FOR
+            END IF
+
+            watchValue = VAL(watchPart$)
+            watchUpper = watchLower
+            watchUpper = watchUpper + watchCount - 1
+            IF watchValue < watchLower OR watchValue > watchUpper THEN
+                watchValid = 0
+                watchError$ = "Index" + STR$(watchValue) + " is outside" + STR$(watchLower) + " TO" + STR$(watchUpper) + "."
+                EXIT FOR
+            END IF
+
+            IF LEN(watchNormalized$) THEN watchNormalized$ = watchNormalized$ + ","
+            watchNormalized$ = watchNormalized$ + watchPart$
+        NEXT
+
+        IF watchValid THEN
+            arrayIndexSuffix$ = "(" + watchNormalized$ + ")"
+            arrayIndexOK = -1
+            RETURN
+        END IF
+
+        result = idemessagebox("Error", watchError$, "#OK")
+        _KEYCLEAR
+    LOOP
+
+END FUNCTION
+
+FUNCTION idewatchoffset& (referenceText$, ok)
+    DIM offsetText AS STRING
+    DIM evalText AS STRING
+    DIM parsedNumber AS ParseNum
+    DIM offsetValue AS _INTEGER64
+
+    ok = 0
+    offsetText = MID$(referenceText$, _INSTRREV(referenceText$, sp3) + LEN(sp3))
+    IF LEN(offsetText) = 0 THEN EXIT FUNCTION
+
+    Error_Happened = 0
+    evalText = Evaluate_Expression$(lineformat$(offsetText), parsedNumber)
+    IF Error_Happened THEN
+        Error_Happened = 0
+        EXIT FUNCTION
+    END IF
+    IF INSTR(UCASE$(evalText), "ERROR") THEN EXIT FUNCTION
+
+    offsetValue = parsedNumber.i
+    IF offsetValue < 0 OR offsetValue > 2147483647 THEN EXIT FUNCTION
+
+    idewatchoffset& = offsetValue
+    ok = -1
 END FUNCTION
 
 FUNCTION formatRange$ (__text$)

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -10663,6 +10663,9 @@ DO
         DO WHILE try
             IF id.subfunc = 2 THEN
 
+                'Keep the SUB origin before any helper can change the current id record.
+                subIsInternal = ids(currentid).internal_subfunc
+
                 'check symbol
                 s$ = removesymbol$(firstelement$ + "")
                 IF Error_Happened THEN GOTO errmes
@@ -10678,21 +10681,26 @@ DO
                     END IF
                 END IF
                 'check for array assignment
-                IF n > 2 THEN
-                    IF firstelement$ <> "PRINT" AND firstelement$ <> "LPRINT" THEN
-                        IF getelement$(a$, 2) = "(" THEN
-                            B = 1
-                            FOR i = 3 TO n
-                                e$ = getelement$(a$, i)
-                                IF e$ = "(" THEN B = B + 1
-                                IF e$ = ")" THEN
-                                    B = B - 1
-                                    IF B = 0 THEN
-                                        IF i = n THEN EXIT FOR
-                                        IF getelement$(a$, i + 1) = "=" THEN GOTO notsubcall
+                'Only internal SUBs can legally share a name with a variable/array
+                '(for example WIDTH). A user-defined SUB name cannot, so do not
+                'reinterpret its parenthesized first argument as an array assignment.
+                IF subIsInternal THEN
+                    IF n > 2 THEN
+                        IF firstelement$ <> "PRINT" AND firstelement$ <> "LPRINT" THEN
+                            IF getelement$(a$, 2) = "(" THEN
+                                B = 1
+                                FOR i = 3 TO n
+                                    e$ = getelement$(a$, i)
+                                    IF e$ = "(" THEN B = B + 1
+                                    IF e$ = ")" THEN
+                                        B = B - 1
+                                        IF B = 0 THEN
+                                            IF i = n THEN EXIT FOR
+                                            IF getelement$(a$, i + 1) = "=" THEN GOTO notsubcall
+                                        END IF
                                     END IF
-                                END IF
-                            NEXT
+                                NEXT
+                            END IF
                         END IF
                     END IF
                 END IF

--- a/tests/compile_tests/arrays/t659_array_assignment_control.bas
+++ b/tests/compile_tests/arrays/t659_array_assignment_control.bas
@@ -1,0 +1,26 @@
+OPTION _EXPLICIT
+$CONSOLE:ONLY
+
+DIM values(0 TO 3) AS LONG
+
+values(0) = 10
+values(1) = 20
+values(2) = values(0) + values(1)
+values(3) = 99
+
+expect_bool values(0) = 10, -1, "values(0) assignment"
+expect_bool values(1) = 20, -1, "values(1) assignment"
+expect_bool values(2) = 30, -1, "values(2) assignment"
+expect_bool values(3) = 99, -1, "values(3) assignment"
+expect_bool (values(0) + values(1)) = 30, -1, "array expression comparison"
+
+SYSTEM
+
+
+SUB expect_bool (actual&, expected&, msg$)
+    IF actual& = expected& THEN
+        PRINT "passed: "; msg$
+    ELSE
+        PRINT "failed: "; msg$
+    END IF
+END SUB

--- a/tests/compile_tests/arrays/t659_array_assignment_control.output
+++ b/tests/compile_tests/arrays/t659_array_assignment_control.output
@@ -1,0 +1,5 @@
+passed: values(0) assignment
+passed: values(1) assignment
+passed: values(2) assignment
+passed: values(3) assignment
+passed: array expression comparison

--- a/tests/compile_tests/arrays/t659_explicit_call_control.bas
+++ b/tests/compile_tests/arrays/t659_explicit_call_control.bas
@@ -1,0 +1,17 @@
+OPTION _EXPLICIT
+$CONSOLE:ONLY
+
+CALL expect_bool((5 / 2) = 2, 0, "CALL with false comparison")
+CALL expect_bool((5 \ 2) = 2, -1, "CALL with true comparison")
+CALL expect_bool(((2 + 3) * 4) = 20, -1, "CALL with nested expression")
+CALL expect_bool(("QB" + "64") = "QB64", -1, "CALL with string comparison")
+
+SYSTEM
+
+SUB expect_bool (actual&, expected&, msg$)
+    IF actual& = expected& THEN
+        PRINT "passed: "; msg$
+    ELSE
+        PRINT "failed: "; msg$
+    END IF
+END SUB

--- a/tests/compile_tests/arrays/t659_explicit_call_control.output
+++ b/tests/compile_tests/arrays/t659_explicit_call_control.output
@@ -1,0 +1,4 @@
+passed: CALL with false comparison
+passed: CALL with true comparison
+passed: CALL with nested expression
+passed: CALL with string comparison

--- a/tests/compile_tests/arrays/t659_sub_call_comparisons.bas
+++ b/tests/compile_tests/arrays/t659_sub_call_comparisons.bas
@@ -1,0 +1,20 @@
+OPTION _EXPLICIT
+$CONSOLE:ONLY
+
+expect_bool (5 / 2) = 2, 0, "(5 / 2) = 2"
+expect_bool (5 \ 2) = 2, -1, "(5 \ 2) = 2"
+expect_bool (7 MOD 4) = 3, -1, "(7 MOD 4) = 3"
+expect_bool (2 ^ 3) = 8, -1, "(2 ^ 3) = 8"
+expect_bool (3 + 4 * 2) = 11, -1, "(3 + 4 * 2) = 11"
+expect_bool ((3 + 4) * 2) = 14, -1, "((3 + 4) * 2) = 14"
+expect_bool ("AB" + "CD") = "ABCD", -1, "string expression comparison"
+
+SYSTEM
+
+SUB expect_bool (actual&, expected&, msg$)
+    IF actual& = expected& THEN
+        PRINT "passed: "; msg$
+    ELSE
+        PRINT "failed: "; msg$
+    END IF
+END SUB

--- a/tests/compile_tests/arrays/t659_sub_call_comparisons.output
+++ b/tests/compile_tests/arrays/t659_sub_call_comparisons.output
@@ -1,0 +1,7 @@
+passed: (5 / 2) = 2
+passed: (5 \ 2) = 2
+passed: (7 MOD 4) = 3
+passed: (2 ^ 3) = 8
+passed: (3 + 4 * 2) = 11
+passed: ((3 + 4) * 2) = 14
+passed: string expression comparison

--- a/tests/compile_tests/arrays/t659_variable_boolean_expr.bas
+++ b/tests/compile_tests/arrays/t659_variable_boolean_expr.bas
@@ -1,0 +1,23 @@
+OPTION _EXPLICIT
+$CONSOLE:ONLY
+
+DIM AS LONG valueA, valueB
+
+valueA = 5
+valueB = 2
+
+expect_bool (valueA / valueB) = 2, 0, "variable real division comparison"
+expect_bool (valueA \ valueB) = 2, -1, "variable integer division comparison"
+expect_bool ((valueA \ valueB) + 3) = 5, -1, "nested variable expression"
+expect_bool ((valueA = 5) AND (valueB = 2)) = -1, -1, "combined boolean expression"
+expect_bool ((valueA = 0) OR (valueB = 2)) = -1, -1, "boolean OR expression"
+
+SYSTEM
+
+SUB expect_bool (actual&, expected&, msg$)
+    IF actual& = expected& THEN
+        PRINT "passed: "; msg$
+    ELSE
+        PRINT "failed: "; msg$
+    END IF
+END SUB

--- a/tests/compile_tests/arrays/t659_variable_boolean_expr.output
+++ b/tests/compile_tests/arrays/t659_variable_boolean_expr.output
@@ -1,0 +1,5 @@
+passed: variable real division comparison
+passed: variable integer division comparison
+passed: nested variable expression
+passed: combined boolean expression
+passed: boolean OR expression


### PR DESCRIPTION
## Summary

This PR fixes two separate issues:

* Fixes #659
* Fixes #739

## 1. User-defined SUB calls incorrectly parsed as array assignments

Statements such as:

```basic
test_check (5 / 2) = 2, "(5 / 2) = 2"
```

could be incorrectly identified as array assignments instead of calls to a user-defined `SUB`.

The ambiguity occurs because the beginning of the statement resembles an indexed array expression followed by an assignment.

The parser now preserves whether the resolved identifier belongs to an internal SUB and applies the array-assignment heuristic only to internal SUBs where that special handling is required.

This allows user-defined SUB calls containing comparison expressions to compile correctly while preserving:

* normal array assignments,
* explicit `CALL SubName(...)` syntax,
* existing internal SUB exceptions such as `WIDTH`.

Regression tests and matching `.output` files are included for:

* user-defined SUB calls with arithmetic and comparison expressions,
* variable and combined boolean expressions,
* explicit `CALL` syntax,
* real array assignments.

## 2. `$DEBUG` support for nested static arrays in TYPEs

The debugger previously failed when inspecting an array contained inside a user-defined type.

For example, attempting to inspect an element such as:

sample.nums(1)


could produce:


Expected array index


This PR corrects debugger inspection for nested static arrays.

### Scope

This fix applies only to nested static arrays.

Dynamic nested arrays are not currently an official QB64PE feature. Debugger support for dynamic nested arrays is therefore not included in this PR and will require a separate implementation when that feature becomes official.

## Testing

Automated regression tests are included for the SUB-call parsing fix.

No automated test was added to the `tests` directory for the `$DEBUG` change because the failure occurs through the interactive IDE debugger and I was not sure how to reproduce that interaction in the automated test framework.

The `$DEBUG` fix can be verified manually as follows.

### Manual `$DEBUG` test

Create this program:

```basic
$DEBUG

TYPE DebugType
    nums(0 TO 2) AS LONG
    scalarValue AS LONG
END TYPE

DIM sample AS DebugType

sample.nums(0) = 11
sample.nums(1) = 22
sample.nums(2) = 33
sample.scalarValue = 99

PRINT "Debugger breakpoint"
```

Then:

1. Open the program in the QB64PE IDE.

2. Place the cursor on:

   PRINT "Debugger breakpoint"
  
3. Press `F9` to set a breakpoint on that line.

4. Press `F5` to run the program.

5. Wait for execution to stop at the breakpoint.

6. Press `F4` to open the variable inspection window.

7. Select the variable:

      sample


8. Select its nested array member:

   nums
   
9. Enter array index:

   1
  
10. Verify that the debugger displays the value:

    22
   
The debugger should no longer report:

Expected array index

The scalar member can also be inspected and should contain:

sample.scalarValue = 99



