### PR TITLE
Fix qbs large string arena and $ErrorLocation handling

### DIFF
--- a/internal/c/libqb.cpp
+++ b/internal/c/libqb.cpp
@@ -761,13 +761,16 @@ void gui_modal_lock_end() {
         display_lock_modal_count.fetch_sub(1, std::memory_order_acq_rel);
 
     // Close any last race where the render thread requested the display lock
-    // just as the modal dialog returned. Do not resume QB code until that
-    // in-flight SUB _GL call has released the cooperative display lock.
+    // just as the modal dialog returned. A dialog opened from SUB _GL already
+    // runs on the GLUT thread, so it must not wait for the lock that the same
+    // thread can release only after SUB _GL returns.
     if (display_lock_request > display_lock_confirmed)
         display_lock_confirmed = display_lock_request;
 
-    while ((display_lock_released < display_lock_confirmed) && (!close_program) && (!suspend_program) && (!stop_program))
-        Sleep(1);
+    if (!libqb_is_glut_thread()) {
+        while ((display_lock_released < display_lock_confirmed) && (!close_program) && (!suspend_program) && (!stop_program))
+            Sleep(1);
+    }
 #endif
 }
 

--- a/internal/c/libqb/include/glut-thread.h
+++ b/internal/c/libqb/include/glut-thread.h
@@ -15,6 +15,9 @@ void libqb_start_glut_thread();
 // do any GLUT-related stuff
 bool libqb_is_glut_up();
 
+// Returns true only on the native thread that owns the GLUT event loop.
+bool libqb_is_glut_thread();
+
 // Called at consistent intervals from a GLUT callback
 void libqb_process_glut_queue();
 

--- a/internal/c/libqb/src/console-only-main-thread.cpp
+++ b/internal/c/libqb/src/console-only-main-thread.cpp
@@ -33,6 +33,10 @@ bool libqb_is_glut_up() {
     return false;
 }
 
+bool libqb_is_glut_thread() {
+    return false;
+}
+
 void libqb_process_glut_queue() {}
 
 void libqb_glut_set_cursor(int style) {

--- a/internal/c/libqb/src/error_handle.cpp
+++ b/internal/c/libqb/src/error_handle.cpp
@@ -6,13 +6,18 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <string>
+#ifdef QB64_WINDOWS
+#include <windows.h>
+#elif defined(QB64_LINUX) || defined(QB64_MACOSX)
+#include <pthread.h>
+#endif
 
 #include "command.h"
 #include "error_handle.h"
 #include "logging.h"
 #include "event.h"
 #include "gui.h"
+#include "glut-thread.h"
 
 uint32_t new_error;
 uint32_t error_occurred;
@@ -28,15 +33,119 @@ static uint32_t inclercl;
 
 static const char *includedfilename;
 
-// Tracks the BASIC source line before each generated statement executes.
-// This is intentionally separate from ercl/inclercl, because fatal errors
-// such as SIGFPE division by zero can occur before the normal qbevent/evnt()
-// path has a chance to update the standard runtime error line fields.
+// Tracks the BASIC source line before each generated statement executes when
+// the whole-program $ErrorLocation:ON diagnostic mode is enabled. This is
+// intentionally separate from ercl/inclercl, because fatal errors can occur
+// before the normal qbevent/evnt() path updates the standard error-line fields.
 static uint32_t current_ercl;
 static uint32_t current_inclercl;
 static const char *current_includedfilename;
 
-static const char *human_error(int32_t errorcode) {
+// False only for executables produced by an older bootstrap compiler that
+// emits no explicit error_track_line(...) calls. A newly generated program
+// clears the tracker once at startup, and $ErrorLocation:ON then updates it
+// before statements. The legacy event path must not repopulate it afterwards.
+static bool explicit_line_tracking_seen;
+
+// Returns the BASIC source position most recently emitted by
+// $ErrorLocation:ON. Included-file coordinates take precedence so the
+// location matches the existing _INCLERRORLINE/_INCLERRORFILE behavior.
+static bool get_current_error_location(uint32_t &srcLine, const char *&srcFile) {
+    if (current_inclercl) {
+        srcLine = current_inclercl;
+        srcFile = current_includedfilename ? current_includedfilename : "included file";
+        return true;
+    }
+
+    if (current_ercl) {
+        srcLine = current_ercl;
+        srcFile = "main module";
+        return true;
+    }
+
+    srcLine = 0;
+    srcFile = NULL;
+    return false;
+}
+
+// Formats fatal runtime errors without dynamic allocation. Static storage
+// keeps the out-of-stack path from allocating another object while reporting
+// the original failure.
+static const char *critical_error_message(const char *message) {
+    static char errmess[1024];
+    uint32_t srcLine;
+    const char *srcFile;
+
+    if (get_current_error_location(srcLine, srcFile))
+        snprintf(errmess, sizeof(errmess), "Line: %u (in %s)\n%s", srcLine, srcFile, message);
+    else
+        snprintf(errmess, sizeof(errmess), "%s\nEnable $ErrorLocation:ON for source location details.", message);
+
+    return errmess;
+}
+
+// Returns true after reporting error 256 when the current native thread is
+// close enough to its stack limit that another recursive BASIC call would be
+// unsafe. Stack-bound discovery is platform-specific, but the policy and
+// reporting path are shared by Windows, Linux and macOS.
+bool error_check_stack() {
+    // Keep enough stack available for error formatting, the native dialog and
+    // the platform-specific shutdown path. The check is emitted for every user
+    // SUB/FUNCTION; $ErrorLocation affects only source-position reporting.
+    static constexpr uintptr_t STACK_REPORT_RESERVE = 256u * 1024u;
+    static thread_local bool stack_bounds_checked;
+    static thread_local bool stack_bounds_available;
+    static thread_local uintptr_t stack_lower_bound;
+    static thread_local bool stack_error_reported;
+
+    uint8_t stack_marker;
+
+    if (!stack_bounds_checked) {
+#ifdef QB64_WINDOWS
+        MEMORY_BASIC_INFORMATION stack_info;
+        if (VirtualQuery(&stack_marker, &stack_info, sizeof(stack_info)) == sizeof(stack_info)) {
+            // AllocationBase is the low address of the thread's reserved stack
+            // region. Supported Windows targets use downward-growing stacks.
+            stack_lower_bound = reinterpret_cast<uintptr_t>(stack_info.AllocationBase);
+            stack_bounds_available = stack_lower_bound != 0;
+        }
+#elif defined(QB64_LINUX)
+        pthread_attr_t stack_attributes;
+        if (pthread_getattr_np(pthread_self(), &stack_attributes) == 0) {
+            void *stack_address = NULL;
+            size_t stack_size = 0;
+
+            if (pthread_attr_getstack(&stack_attributes, &stack_address, &stack_size) == 0 && stack_address && stack_size) {
+                stack_lower_bound = reinterpret_cast<uintptr_t>(stack_address);
+                stack_bounds_available = true;
+            }
+
+            pthread_attr_destroy(&stack_attributes);
+        }
+#elif defined(QB64_MACOSX)
+        const uintptr_t stack_upper_bound = reinterpret_cast<uintptr_t>(pthread_get_stackaddr_np(pthread_self()));
+        const size_t stack_size = pthread_get_stacksize_np(pthread_self());
+
+        if (stack_upper_bound && stack_size) {
+            stack_lower_bound = stack_upper_bound - stack_size;
+            stack_bounds_available = true;
+        }
+#endif
+        stack_bounds_checked = true;
+    }
+
+    const uintptr_t current_stack = reinterpret_cast<uintptr_t>(&stack_marker);
+    if (!stack_error_reported && stack_bounds_available && current_stack > stack_lower_bound &&
+        current_stack - stack_lower_bound < STACK_REPORT_RESERVE) {
+        stack_error_reported = true;
+        error(256);
+        return true;
+    }
+
+    return stack_error_reported;
+}
+
+static const char *error_code_to_text(int32_t errorcode) {
     // clang-format off
     switch (errorcode) {
         case 0: return "No error";
@@ -150,17 +259,19 @@ void error_set_line(uint32_t errorline, uint32_t incerrorline, const char *incfi
     inclercl = incerrorline;
     includedfilename = incfilename;
 
-    // Keep the division-by-zero tracker warm even in a bootstrap build that
-    // was generated by an older compiler and therefore has no explicit
-    // error_track_line(...) calls inside the QB64PE executable itself.
-    // In fully rebuilt code, error_track_line(...) still wins because it is
-    // emitted immediately before each executable BASIC statement.
-    current_ercl = errorline;
-    current_inclercl = incerrorline;
-    current_includedfilename = incfilename;
+    // Bootstrap compatibility: an executable generated by an older compiler
+    // has no explicit error_track_line(...) calls, so keep its critical-error
+    // position warm through the legacy event path. A new compiler clears the
+    // tracker at startup; after that, $ErrorLocation controls this tracker.
+    if (!explicit_line_tracking_seen) {
+        current_ercl = errorline;
+        current_inclercl = incerrorline;
+        current_includedfilename = incfilename;
+    }
 }
 
 void error_track_line(uint32_t errorline, uint32_t incerrorline, const char *incfilename) {
+    explicit_line_tracking_seen = true;
     current_ercl = errorline;
     current_inclercl = incerrorline;
     current_includedfilename = incfilename;
@@ -169,12 +280,21 @@ void error_track_line(uint32_t errorline, uint32_t incerrorline, const char *inc
 qbs *func__errormessage(int32_t errorcode, int32_t passed) {
     if (!passed)
         errorcode = get_error_err();
-    return qbs_new_txt(human_error(errorcode));
+    return qbs_new_txt(error_code_to_text(errorcode));
 }
 
 extern uint8_t close_program;
 extern double last_line;
 void end();
+
+// Fatal errors may be raised from the BASIC thread or from SUB _GL. Route the
+// final shutdown through libqb_exit(), which transfers exit handling to the
+// GLUT thread when a graphics window is active and exits directly otherwise.
+// This is the same cross-platform path on Windows, Linux and macOS.
+static void exit_after_fatal_error() {
+    close_program = 1;
+    libqb_exit(0);
+}
 
 extern void QBMAIN(void *);
 
@@ -198,7 +318,7 @@ void fix_error() {
             }
         }
 
-        cp = human_error(new_error);
+        cp = error_code_to_text(new_error);
 #define FIXERRMSG_TITLE "%s%u - %s"
 #define FIXERRMSG_BODY "Line: %u (in %s)\n%s%s"
 #define FIXERRMSG_MAINFILE "main module"
@@ -209,20 +329,25 @@ void fix_error() {
         len = snprintf(errmess, 0, FIXERRMSG_BODY, (inclercl ? inclercl : ercl), (inclercl ? includedfilename : FIXERRMSG_MAINFILE), cp,
                        (!prevent_handling ? FIXERRMSG_CONT : ""));
         errmess = (char *)malloc(len + 1);
-        if (!errmess)
-            exit(0); // At this point we just give up
+        if (!errmess) {
+            exit_after_fatal_error(); // At this point we just give up
+            return;
+        }
         snprintf(errmess, len + 1, FIXERRMSG_BODY, (inclercl ? inclercl : ercl), (inclercl ? includedfilename : FIXERRMSG_MAINFILE), cp,
                  (!prevent_handling ? FIXERRMSG_CONT : ""));
 
         len = snprintf(errtitle, 0, FIXERRMSG_TITLE, (!prevent_handling ? FIXERRMSG_UNHAND : FIXERRMSG_CRIT), new_error, binary_name->chr);
         errtitle = (char *)malloc(len + 1);
-        if (!errtitle)
-            exit(0); // At this point we just give up
+        if (!errtitle) {
+            exit_after_fatal_error(); // At this point we just give up
+            return;
+        }
         snprintf(errtitle, len + 1, FIXERRMSG_TITLE, (!prevent_handling ? FIXERRMSG_UNHAND : FIXERRMSG_CRIT), new_error, binary_name->chr);
 
         if (prevent_handling) {
             v = gui_alert(errmess, errtitle, "ok");
-            exit(0);
+            exit_after_fatal_error();
+            return;
         } else {
             v = gui_alert(errmess, errtitle, "yesno");
         }
@@ -245,138 +370,67 @@ void fix_error() {
 }
 
 void error(int32_t error_number) {
-    libqb_log_error("QB64 Error %d reported: %s", error_number, human_error(error_number));
+    libqb_log_error("QB64 Error %d reported: %s", error_number, error_code_to_text(error_number));
 
     // critical errors:
 
-    // out of memory errors
-    if (error_number == 257) {
-        gui_alert("Out of memory", "Critical Error #1", "ok");
-        exit(0);
-    } // generic "Out of memory" error
-    // tracable "Out of memory" errors
-    if (error_number == 502) {
-        gui_alert("Out of memory", "Critical Error #2", "ok");
-        exit(0);
-    }
-    if (error_number == 503) {
-        gui_alert("Out of memory", "Critical Error #3", "ok");
-        exit(0);
-    }
-    if (error_number == 504) {
-        gui_alert("Out of memory", "Critical Error #4", "ok");
-        exit(0);
-    }
-    if (error_number == 505) {
-        gui_alert("Out of memory", "Critical Error #5", "ok");
-        exit(0);
-    }
-    if (error_number == 506) {
-        gui_alert("Out of memory", "Critical Error #6", "ok");
-        exit(0);
-    }
-    if (error_number == 507) {
-        gui_alert("Out of memory", "Critical Error #7", "ok");
-        exit(0);
-    }
-    if (error_number == 508) {
-        gui_alert("Out of memory", "Critical Error #8", "ok");
-        exit(0);
-    }
-    if (error_number == 509) {
-        gui_alert("Out of memory", "Critical Error #9", "ok");
-        exit(0);
-    }
-    if (error_number == 510) {
-        gui_alert("Out of memory", "Critical Error #10", "ok");
-        exit(0);
-    }
-    if (error_number == 511) {
-        gui_alert("Out of memory", "Critical Error #11", "ok");
-        exit(0);
-    }
-    if (error_number == 512) {
-        gui_alert("Out of memory", "Critical Error #12", "ok");
-        exit(0);
-    }
-    if (error_number == 513) {
-        gui_alert("Out of memory", "Critical Error #13", "ok");
-        exit(0);
-    }
-    if (error_number == 514) {
-        gui_alert("Out of memory", "Critical Error #14", "ok");
-        exit(0);
-    }
-    if (error_number == 515) {
-        gui_alert("Out of memory", "Critical Error #15", "ok");
-        exit(0);
-    }
-    if (error_number == 516) {
-        gui_alert("Out of memory", "Critical Error #16", "ok");
-        exit(0);
-    }
-    if (error_number == 517) {
-        gui_alert("Out of memory", "Critical Error #17", "ok");
-        exit(0);
-    }
-    if (error_number == 518) {
-        gui_alert("Out of memory", "Critical Error #18", "ok");
-        exit(0);
+    // Out-of-memory errors include the BASIC source module and line that were executing.
+    // Use fixed-size stack buffers here: allocating memory while reporting an
+    // allocation failure could itself fail.
+    int32_t critical_number = 0;
+    if (error_number == 257)
+        critical_number = 1;
+    else if (error_number >= 502 && error_number <= 518)
+        critical_number = error_number - 500;
+
+    if (critical_number) {
+        char errmess[512];
+        char errtitle[32];
+        uint32_t srcLine;
+        const char *srcFile;
+
+        if (get_current_error_location(srcLine, srcFile))
+            snprintf(errmess, sizeof(errmess), "Out of memory (in %s) on line %u", srcFile, srcLine);
+        else
+            snprintf(errmess, sizeof(errmess), "Out of memory\nEnable $ErrorLocation:ON for source location details.");
+
+        snprintf(errtitle, sizeof(errtitle), "Critical Error #%d", critical_number);
+        gui_alert(errmess, errtitle, "ok");
+        exit_after_fatal_error();
+        return;
     }
 
-    // other critical errors
-    if (error_number == QB_ERROR_DIVISION_BY_ZERO) {
-        std::string errmess;
-        uint32_t srcLine = 0;
-        const char *srcFile = NULL;
-
-        if (current_inclercl) {
-            srcLine = current_inclercl;
-            srcFile = current_includedfilename ? current_includedfilename : "included file";
-        } else if (current_ercl) {
-            srcLine = current_ercl;
-            srcFile = "main module";
-        } else if (inclercl) {
-            srcLine = inclercl;
-            srcFile = includedfilename ? includedfilename : "included file";
-        } else if (ercl) {
-            srcLine = ercl;
-            srcFile = "main module";
-        }
-
-        if (srcLine) {
-            errmess = "Line: " + std::to_string(srcLine) + " (in " + srcFile + ")\nDivision by zero";
-        } else {
-            errmess = "Line: unknown\nDivision by zero";
-        }
-
-        gui_alert(errmess.c_str(), "Critical Error", "ok");
-        exit(0);
-    }
-    if (error_number == 256) {
-        gui_alert("Out of stack space", "Critical Error", "ok");
-        exit(0);
-    }
-    if (error_number == 259) {
-        gui_alert("Cannot find dynamic library file", "Critical Error", "ok");
-        exit(0);
-    }
-    if (error_number == 260) {
-        gui_alert("Sub/Function does not exist in dynamic library", "Critical Error", "ok");
-        exit(0);
-    }
-    if (error_number == 261) {
-        gui_alert("Sub/Function does not exist in dynamic library", "Critical Error", "ok");
-        exit(0);
+    // Other fatal runtime errors used to bypass the standard error-event
+    // path and therefore discarded the source position captured by
+    // $ErrorLocation:ON. Keep their existing messages and titles, but route
+    // all of them through the same allocation-free location formatter.
+    const char *critical_message = NULL;
+    switch (error_number) {
+        case QB_ERROR_DIVISION_BY_ZERO:
+            critical_message = "Division by zero";
+            break;
+        case 256:
+            critical_message = "Out of stack space";
+            break;
+        case 259:
+            critical_message = "Cannot find dynamic library file";
+            break;
+        case 260:
+        case 261:
+            critical_message = "Sub/Function does not exist in dynamic library";
+            break;
+        case 270:
+            critical_message = "_GL command called outside of SUB _GL's scope";
+            break;
+        case 271:
+            critical_message = "END/SYSTEM called within SUB _GL's scope";
+            break;
     }
 
-    if (error_number == 270) {
-        gui_alert("_GL command called outside of SUB _GL's scope", "Critical Error", "ok");
-        exit(0);
-    }
-    if (error_number == 271) {
-        gui_alert("END/SYSTEM called within SUB _GL's scope", "Critical Error", "ok");
-        exit(0);
+    if (critical_message) {
+        gui_alert(critical_error_message(critical_message), "Critical Error", "ok");
+        exit_after_fatal_error();
+        return;
     }
 
     if (!new_error) {

--- a/internal/c/libqb/src/glut-main-thread.cpp
+++ b/internal/c/libqb/src/glut-main-thread.cpp
@@ -113,6 +113,9 @@ static void initialize_glut(int argc, char **argv) {
 }
 
 static bool glut_is_started;
+// True only on the initial thread that owns GLUT. thread_local avoids any
+// platform-specific thread-ID API and works on Windows, Linux and macOS.
+static thread_local bool current_thread_owns_glut;
 static struct completion glut_thread_starter;
 static struct completion *glut_thread_initialized;
 
@@ -136,7 +139,13 @@ bool libqb_is_glut_up() {
     return glut_is_started;
 }
 
+bool libqb_is_glut_thread() {
+    return current_thread_owns_glut;
+}
+
 void libqb_glut_presetup(int argc, char **argv) {
+    current_thread_owns_glut = true;
+
     if (!screen_hide) {
         initialize_glut(argc, argv); // Initialize GLUT if the screen isn't hidden
         glut_is_started = true;
@@ -168,16 +177,13 @@ void libqb_start_main_thread(int argc, char **argv) {
     glutMainLoop();
 }
 
-// Due to GLUT making use of cleanup via atexit, we have to call exit() from
-// the same thread handling the GLUT logic so that the atexit handler also runs
-// from that thread (not doing that can result in a segfault due to using GLUT
-// from two threads at the same time).
-//
-// This is accomplished by simply queuing a GLUT message that calls exit() for us.
+// Due to GLUT making use of cleanup via atexit, exit() must run on the thread
+// that owns GLUT. Calls from another thread are transferred through the GLUT
+// queue. Calls already executing on the GLUT thread exit directly; queueing
+// and waiting there would deadlock the thread against its own message queue.
 void libqb_exit(int exitcode) {
     libqb_log_info("Program exiting with code: %d\n", exitcode);
-    // If GLUT isn't running then we're free to do the exit() call from here
-    if (!libqb_is_glut_up())
+    if (!libqb_is_glut_up() || libqb_is_glut_thread())
         exit(exitcode);
 
     libqb_glut_exit_program(exitcode);

--- a/internal/c/libqb/src/qbs.cpp
+++ b/internal/c/libqb/src/qbs.cpp
@@ -2,6 +2,7 @@
 #include "libqb-common.h"
 
 #include <algorithm>
+#include <limits>
 #include <stdlib.h>
 #include <string.h>
 
@@ -76,8 +77,33 @@ uint32_t qbs_tmp_list_nexti;
 // entended string memory
 
 static uint8_t *qbs_data = (uint8_t *)malloc(1048576);
-static uint32_t qbs_data_size = 1048576;
-static uint32_t qbs_sp = 0;
+static size_t qbs_data_size = 1048576;
+static size_t qbs_sp = 0;
+
+#ifdef QB64_QBS_TEST
+static void *(*qbs_data_realloc)(void *, size_t) = realloc;
+#else
+static void *qbs_data_realloc(void *memory, size_t size) {
+    return realloc(memory, size);
+}
+#endif
+
+static bool qbs_size_add_overflow(size_t left, size_t right, size_t *result) {
+    if (left > std::numeric_limits<size_t>::max() - right)
+        return true;
+
+    *result = left + right;
+    return false;
+}
+
+static size_t qbs_data_offset(const uint8_t *position) {
+    return (size_t)((uintptr_t)position - (uintptr_t)qbs_data);
+}
+
+static bool qbs_data_has_space(const uint8_t *position, size_t bytes) {
+    size_t offset = qbs_data_offset(position);
+    return offset <= qbs_data_size && bytes <= qbs_data_size - offset;
+}
 
 void qbs_free(qbs *str) {
 
@@ -105,9 +131,15 @@ void qbs_free(qbs *str) {
                 goto retry;
         }
         if (qbs_list_nexti) {
-            qbs_sp = ((qbs *)qbs_list[qbs_list_nexti - 1])->chr - qbs_data + ((qbs *)qbs_list[qbs_list_nexti - 1])->len + 32;
-            if (qbs_sp > qbs_data_size)
-                qbs_sp = qbs_data_size; // adding 32 could overflow buffer!
+            qbs *laststr = (qbs *)qbs_list[qbs_list_nexti - 1];
+            size_t offset = qbs_data_offset(laststr->chr);
+            size_t length = laststr->len;
+            size_t used;
+
+            if (offset > qbs_data_size || qbs_size_add_overflow(offset, length, &used) || used > qbs_data_size ||
+                qbs_size_add_overflow(used, 32, &qbs_sp) || qbs_sp > qbs_data_size) {
+                qbs_sp = qbs_data_size;
+            }
         } else {
             qbs_sp = 0;
         }
@@ -149,7 +181,26 @@ static void qbs_tmp_concat_list() {
     }
 }
 
-static void qbs_concat(uint32_t bytesrequired) {
+static bool qbs_resize_data(size_t new_size) {
+    uintptr_t oldbase = (uintptr_t)qbs_data;
+    uint8_t *newbase = (uint8_t *)qbs_data_realloc(qbs_data, new_size);
+    if (newbase == NULL)
+        return false;
+
+    qbs_data = newbase;
+    qbs_data_size = new_size;
+
+    for (uint32_t i = 0; i < qbs_list_nexti; i++) {
+        if (qbs_list[i] != -1) {
+            qbs *tqbs = (qbs *)qbs_list[i];
+            tqbs->chr = qbs_data + (size_t)((uintptr_t)tqbs->chr - oldbase);
+        }
+    }
+
+    return true;
+}
+
+static void qbs_concat(size_t bytesrequired) {
     // this does not change indexing, only ->chr pointers and the location of their data
     static uint32_t i;
     static uint8_t *dest;
@@ -160,30 +211,66 @@ static void qbs_concat(uint32_t bytesrequired) {
         for (i = 0; i < qbs_list_nexti; i++) {
             if (qbs_list[i] != -1) {
                 tqbs = (qbs *)qbs_list[i];
-                if ((tqbs->chr - dest) > 32) {
+                if ((size_t)((uintptr_t)tqbs->chr - (uintptr_t)dest) > 32) {
                     if (tqbs->len) {
                         memmove(dest, tqbs->chr, tqbs->len);
                     }
                     tqbs->chr = dest;
                 }
                 dest = tqbs->chr + tqbs->len;
-                qbs_sp = dest - qbs_data;
+                qbs_sp = qbs_data_offset(dest);
             }
         }
     }
 
-    if (((qbs_sp * 2) + (bytesrequired + 32)) >= qbs_data_size) {
-        static uint8_t *oldbase;
-        oldbase = qbs_data;
-        qbs_data_size = qbs_data_size * 2 + bytesrequired;
-        qbs_data = (uint8_t *)realloc(qbs_data, qbs_data_size);
-        if (qbs_data == NULL)
-            error(512); // realloc failed!
-        for (i = 0; i < qbs_list_nexti; i++) {
-            if (qbs_list[i] != -1) {
-                tqbs = (qbs *)qbs_list[i];
-                tqbs->chr = tqbs->chr - oldbase + qbs_data;
+    size_t required_size;
+    if (qbs_size_add_overflow(qbs_sp, bytesrequired, &required_size)) {
+        error(512);
+        return;
+    }
+
+    // Keep the existing growth policy without performing an overflowing 2 * qbs_sp calculation.
+    size_t reserve;
+    bool grow = required_size > qbs_data_size;
+    if (!grow) {
+        if (qbs_size_add_overflow(bytesrequired, 32, &reserve) || reserve >= qbs_data_size) {
+            grow = true;
+        } else {
+            size_t threshold = qbs_data_size - reserve;
+            grow = qbs_sp >= (threshold / 2 + threshold % 2);
+        }
+    }
+
+    if (grow) {
+        size_t new_size;
+        const size_t max_size = std::numeric_limits<size_t>::max();
+
+        if (qbs_data_size <= (max_size - bytesrequired) / 2) {
+            new_size = qbs_data_size * 2 + bytesrequired;
+        } else {
+            // Geometric growth no longer fits in size_t. Grow only by the amount actually required
+            // so 32-bit targets can still use the remaining address space instead of wrapping.
+            new_size = required_size;
+        }
+
+        if (new_size > qbs_data_size) {
+            if (!qbs_resize_data(new_size)) {
+                // The geometric reserve is optional. On constrained address spaces (especially
+                // 32-bit targets), allocating both the old arena and a doubled replacement can
+                // fail even though the bytes required by the current request would still fit.
+                if (required_size <= qbs_data_size)
+                    return;
+
+                // realloc leaves the old allocation untouched on failure, so retry with only
+                // the minimum size needed by this request before reporting an actual OOM.
+                if (new_size == required_size || !qbs_resize_data(required_size)) {
+                    error(512);
+                    return;
+                }
             }
+        } else if (required_size > qbs_data_size) {
+            error(512);
+            return;
         }
     }
 }
@@ -244,12 +331,29 @@ qbs *qbs_new_fixed(uint8_t *offset, uint32_t size, uint8_t tmp) {
 
 qbs *qbs_new(int32_t size, uint8_t tmp) {
     static qbs *newstr;
-    if ((qbs_sp + size + 32) > qbs_data_size)
-        qbs_concat(size + 32);
+    if (size < 0) {
+        error(512);
+        return NULL;
+    }
+
+    size_t bytesrequired;
+    size_t new_sp;
+    if (qbs_size_add_overflow((size_t)size, 32, &bytesrequired) || qbs_size_add_overflow(qbs_sp, bytesrequired, &new_sp)) {
+        error(512);
+        return NULL;
+    }
+    if (new_sp > qbs_data_size) {
+        qbs_concat(bytesrequired);
+        if (qbs_size_add_overflow(qbs_sp, bytesrequired, &new_sp) || new_sp > qbs_data_size) {
+            error(512);
+            return NULL;
+        }
+    }
+
     newstr = qbs_new_descriptor();
     newstr->len = size;
     newstr->chr = qbs_data + qbs_sp;
-    qbs_sp += size + 32;
+    qbs_sp = new_sp;
     if (qbs_list_nexti > qbs_list_lasti)
         qbs_concat_list();
     newstr->listi = qbs_list_nexti;
@@ -338,10 +442,10 @@ qbs *qbs_set(qbs *deststr, qbs *srcstr) {
 
     // not in cmem
     if (deststr->listi == (qbs_list_nexti - 1)) {                                                       // last index
-        if (((intptr_t)deststr->chr + srcstr->len) <= ((intptr_t)qbs_data + (intptr_t)qbs_data_size)) { // space available
+        if (qbs_data_has_space(deststr->chr, (size_t)srcstr->len)) { // space available
             memcpy(deststr->chr, srcstr->chr, srcstr->len);
             deststr->len = srcstr->len;
-            qbs_sp = ((intptr_t)deststr->chr) + (intptr_t)deststr->len - (intptr_t)qbs_data;
+            qbs_sp = qbs_data_offset(deststr->chr) + (size_t)deststr->len;
             goto qbs_set_return;
         }
         goto qbs_set_concat_required;
@@ -355,7 +459,7 @@ qbs_set_nextindex2:
             if (srcstr->tmp == 1)
                 goto skippedtmpsrcindex2;
         }
-        if ((deststr->chr + srcstr->len) > tqbs->chr)
+        if ((size_t)srcstr->len > (size_t)((uintptr_t)tqbs->chr - (uintptr_t)deststr->chr))
             goto qbs_set_concat_required;
         memcpy(deststr->chr, srcstr->chr, srcstr->len);
         deststr->len = srcstr->len;
@@ -368,19 +472,28 @@ skippedtmpsrcindex2:
     // all next indexes invalid!
 
     qbs_list_nexti = deststr->listi + 1;                                                            // adjust nexti
-    if (((intptr_t)deststr->chr + srcstr->len) <= ((intptr_t)qbs_data + (intptr_t)qbs_data_size)) { // space available
+    if (qbs_data_has_space(deststr->chr, (size_t)srcstr->len)) { // space available
         memmove(deststr->chr, srcstr->chr, srcstr->len); // overlap possible due to sometimes acquiring srcstr's space
         deststr->len = srcstr->len;
-        qbs_sp = ((intptr_t)deststr->chr) + (intptr_t)deststr->len - (intptr_t)qbs_data;
+        qbs_sp = qbs_data_offset(deststr->chr) + (size_t)deststr->len;
         goto qbs_set_return;
     }
 
 qbs_set_concat_required:
     // srcstr could not fit in deststr
     //"realloc" deststr
-    qbs_list[deststr->listi] = -1;                // unlist
-    if ((qbs_sp + srcstr->len) > qbs_data_size) { // must concat!
-        qbs_concat(srcstr->len);
+    qbs_list[deststr->listi] = -1; // unlist
+    size_t new_sp;
+    if (qbs_size_add_overflow(qbs_sp, (size_t)srcstr->len, &new_sp)) {
+        error(512);
+        return deststr;
+    }
+    if (new_sp > qbs_data_size) { // must concat!
+        qbs_concat((size_t)srcstr->len);
+        if (qbs_size_add_overflow(qbs_sp, (size_t)srcstr->len, &new_sp) || new_sp > qbs_data_size) {
+            error(512);
+            return deststr;
+        }
     }
     if (qbs_list_nexti > qbs_list_lasti)
         qbs_concat_list();
@@ -390,7 +503,7 @@ qbs_set_concat_required:
 
     deststr->chr = qbs_data + qbs_sp;
     deststr->len = srcstr->len;
-    qbs_sp += deststr->len;
+    qbs_sp = new_sp;
     memcpy(deststr->chr, srcstr->chr, srcstr->len);
 
 //(fall through to qbs_set_return)
@@ -408,13 +521,21 @@ qbs *qbs_add(qbs *str1, qbs *str2) {
         return str1; // pass on
     if (!str1->len)
         return str2; // pass on
+
+    size_t combined_length;
+    if (str1->len < 0 || str2->len < 0 ||
+        qbs_size_add_overflow((size_t)str1->len, (size_t)str2->len, &combined_length) ||
+        combined_length > (size_t)std::numeric_limits<int32_t>::max()) {
+        error(512);
+        return NULL;
+    }
     // may be possible to acquire str1 or str2's space but...
     // 1. check if dest has enough space (because its data is already in the correct place)
     // 2. check if source has enough space
     // 3. give up
     // nb. they would also have to be a tmp, var. len str in ext memory!
     // brute force method...
-    tqbs = qbs_new(str1->len + str2->len, 1);
+    tqbs = qbs_new((int32_t)combined_length, 1);
     memcpy(tqbs->chr, str1->chr, str1->len);
     memcpy(tqbs->chr + str1->len, str2->chr, str2->len);
 

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -166,6 +166,7 @@ DIM SHARED AssertsOn AS RCStateVar
 DIM SHARED ConsoleOn AS RCStateVar
 DIM SHARED vWatchOn AS RCStateVar
 DIM SHARED SockDepOn AS RCStateVar
+DIM SHARED ErrorLocationMode AS RCStateVar
 DIM SHARED CheckingOn
 DIM SHARED ScreenHideOn
 DIM SHARED ResizeOn, ResizeScale
@@ -1178,6 +1179,7 @@ ClearRCStateVar AssertsOn
 ClearRCStateVar ConsoleOn
 ClearRCStateVar vWatchOn
 ClearRCStateVar SockDepOn
+ClearRCStateVar ErrorLocationMode
 
 '--------------------
 recompile:
@@ -1191,6 +1193,7 @@ ExecuteRCStateVar ConsoleOn
 ExecuteRCStateVar vWatchOn
 vWatchVariable "", -1 'reset internal variables list
 ExecuteRCStateVar SockDepOn
+ExecuteRCStateVar ErrorLocationMode
 
 lastLineReturn = 0
 lastLine = 0
@@ -1685,6 +1688,11 @@ SetPreLET "_DEBUG_", _TOSTR$(GetRCStateVar(vWatchOn))
 'auto-includes beforefirstline.bi and afterlastline.bm to include/exclude
 'network specific code
 SetPreLET "_SOCKETS_", _TOSTR$(GetRCStateVar(SockDepOn))
+IF GetRCStateVar(ErrorLocationMode) = 2 THEN
+    SetPreLET "_ERRORLOCATION_", "1"
+ELSE
+    SetPreLET "_ERRORLOCATION_", "0"
+END IF
 RETURN
 
 autoIncludeManager:
@@ -1969,6 +1977,18 @@ DO
         IF temp$ = "$DEBUG" THEN
             SetRCStateVar vWatchOn, 1
             SetPreLET "_DEBUG_", "1"
+            GOTO finishedlinepp
+        END IF
+
+        IF temp$ = "$ERRORLOCATION:ON" THEN
+            SetRCStateVar ErrorLocationMode, 2
+            SetPreLET "_ERRORLOCATION_", "1"
+            GOTO finishedlinepp
+        END IF
+
+        IF temp$ = "$ERRORLOCATION:OFF" THEN
+            SetRCStateVar ErrorLocationMode, 1
+            SetPreLET "_ERRORLOCATION_", "0"
             GOTO finishedlinepp
         END IF
 
@@ -3225,6 +3245,9 @@ FOR i = 1 TO 27: defineaz(i) = "SINGLE": defineextaz(i) = "!": NEXT
 DIM SHARED DataBinBuf: DataBinBuf = OpenBuffer%("O", tmpdir$ + "data.bin")
 
 DIM SHARED MainTxtBuf: MainTxtBuf = OpenBuffer%("O", tmpdir$ + "main0.txt")
+'Mark source-location tracking as explicitly controlled by this generated program.
+'This one-time clear keeps $ErrorLocation:OFF independent of the legacy evnt() path.
+WriteBufLine MainTxtBuf, "error_track_line(0,0,NULL);"
 DIM SHARED DataTxtBuf: DataTxtBuf = OpenBuffer%("O", tmpdir$ + "maindata.txt")
 DIM SHARED VWatchMainDispatchBuf: VWatchMainDispatchBuf = OpenBuffer%("O", tmpdir$ + "vw_main_dispatch.txt")
 DIM SHARED VWatchMainSkipBuf: VWatchMainSkipBuf = OpenBuffer%("O", tmpdir$ + "vw_main_skip.txt")
@@ -3524,6 +3547,21 @@ DO
         IF a3u$ = "$CHECKING:ON" THEN
             layout$ = SCase$("$Checking:On")
             CheckingOn = 1
+            GOTO finishednonexec
+        END IF
+
+        IF a3u$ = "$ERRORLOCATION:ON" THEN
+            layout$ = SCase$("$ErrorLocation:On")
+            IF GetRCStateVar(ErrorLocationMode) <> 2 THEN
+                a$ = "$ErrorLocation is a whole-program option and cannot be changed within the program": GOTO errmes
+            END IF
+            GOTO finishednonexec
+        END IF
+        IF a3u$ = "$ERRORLOCATION:OFF" THEN
+            layout$ = SCase$("$ErrorLocation:Off")
+            IF GetRCStateVar(ErrorLocationMode) = 2 THEN
+                a$ = "$ErrorLocation is a whole-program option and cannot be changed within the program": GOTO errmes
+            END IF
             GOTO finishednonexec
         END IF
 
@@ -5192,11 +5230,26 @@ DO
 
                                 IF sfdeclare THEN
 
+                                    'Dynamic libraries are loaded during generated initialization code,
+                                    'before normal BASIC statement tracking can identify the declaration.
+                                    'Record the DECLARE line only on loader failure, avoiding stale locations
+                                    'after a successful load.
+                                    errortrackcall$ = ""
+                                    IF GetRCStateVar(ErrorLocationMode) = 2 THEN
+                                        IF inclinenumber(inclevel) THEN
+                                            thisincname$ = getfilepath$(incname$(inclevel))
+                                            thisincname$ = MID$(incname$(inclevel), LEN(thisincname$) + 1)
+                                            errortrackcall$ = "error_track_line(" + _TOSTR$(linenumber) + "," + _TOSTR$(inclinenumber(inclevel)) + "," + CHR$(34) + thisincname$ + CHR$(34) + ");"
+                                        ELSE
+                                            errortrackcall$ = "error_track_line(" + _TOSTR$(linenumber) + ",0,NULL);"
+                                        END IF
+                                    END IF
+
                                     IF os$ = "WIN" THEN
                                         WriteBufLine RegTxtBuf, "HINSTANCE DLL_" + x2$ + "=NULL;"
                                         WriteBufLine f, "if (!DLL_" + x2$ + "){"
                                         WriteBufLine f, "DLL_" + x2$ + "=LoadLibrary(" + CHR$(34) + inlinelibname$ + CHR$(34) + ");"
-                                        WriteBufLine f, "if (!DLL_" + x2$ + ") error(259);"
+                                        WriteBufLine f, "if (!DLL_" + x2$ + "){" + errortrackcall$ + "error(259);}"
                                         WriteBufLine f, "}"
                                     END IF
 
@@ -5204,7 +5257,7 @@ DO
                                         WriteBufLine RegTxtBuf, "void *DLL_" + x2$ + "=NULL;"
                                         WriteBufLine f, "if (!DLL_" + x2$ + "){"
                                         WriteBufLine f, "DLL_" + x2$ + "=dlopen(" + CHR$(34) + inlinelibname$ + CHR$(34) + ",RTLD_LAZY);"
-                                        WriteBufLine f, "if (!DLL_" + x2$ + ") error(259);"
+                                        WriteBufLine f, "if (!DLL_" + x2$ + "){" + errortrackcall$ + "error(259);}"
                                         WriteBufLine f, "}"
                                     END IF
 
@@ -5718,6 +5771,15 @@ DO
             WriteBufLine MainTxtBuf, "sf_mem_lock=mem_lock_tmp;"
             WriteBufLine MainTxtBuf, "sf_mem_lock->type=3;"
 
+            ' Native recursion can exhaust the C++ thread stack before error(256)
+            ' is reached. Check every user SUB/FUNCTION entry while enough stack
+            ' remains to report the error. $ErrorLocation controls only whether
+            ' the report includes a BASIC source position; stack exhaustion must
+            ' still be caught when source tracking is disabled. The runtime helper
+            ' uses platform-specific stack bounds behind one common interface.
+            WriteBufLine MainTxtBuf, "extern bool error_check_stack();"
+            WriteBufLine MainTxtBuf, "if (error_check_stack()) goto exit_subfunc;"
+
             IF GetRCStateVar(vWatchOn) THEN
                 WriteBufLine MainTxtBuf, "*__LONG_VWATCH_SUBLEVEL=*__LONG_VWATCH_SUBLEVEL+ 1 ;"
                 IF subfunc <> "SUB_VWATCH" THEN
@@ -5788,14 +5850,27 @@ DO
                             f = DataTxtBuf
                         END IF
 
+                        'Dynamic symbol resolution also runs outside the normal statement path.
+                        'Capture the individual SUB/FUNCTION declaration line only if lookup fails.
+                        errortrackcall$ = ""
+                        IF GetRCStateVar(ErrorLocationMode) = 2 THEN
+                            IF inclinenumber(inclevel) THEN
+                                thisincname$ = getfilepath$(incname$(inclevel))
+                                thisincname$ = MID$(incname$(inclevel), LEN(thisincname$) + 1)
+                                errortrackcall$ = "error_track_line(" + _TOSTR$(linenumber) + "," + _TOSTR$(inclinenumber(inclevel)) + "," + CHR$(34) + thisincname$ + CHR$(34) + ");"
+                            ELSE
+                                errortrackcall$ = "error_track_line(" + _TOSTR$(linenumber) + ",0,NULL);"
+                            END IF
+                        END IF
+
                         WriteBufLine f, "if (!" + removecast$(RTRIM$(id2.callname)) + "){"
                         IF os$ = "WIN" THEN
                             WriteBufLine f, removecast$(RTRIM$(id2.callname)) + "=(DLLCALL_" + removecast$(RTRIM$(id2.callname)) + ")GetProcAddress(DLL_" + DLLname$ + "," + CHR$(34) + aliasname$ + CHR$(34) + ");"
-                            WriteBufLine f, "if (!" + removecast$(RTRIM$(id2.callname)) + ") error(260);"
+                            WriteBufLine f, "if (!" + removecast$(RTRIM$(id2.callname)) + "){" + errortrackcall$ + "error(260);}"
                         END IF
                         IF os$ = "LNX" THEN
                             WriteBufLine f, removecast$(RTRIM$(id2.callname)) + "=(DLLCALL_" + removecast$(RTRIM$(id2.callname)) + ")dlsym(DLL_" + DLLname$ + "," + CHR$(34) + aliasname$ + CHR$(34) + ");"
-                            WriteBufLine f, "if (dlerror()) error(260);"
+                            WriteBufLine f, "if (dlerror()){" + errortrackcall$ + "error(260);}"
                         END IF
                         WriteBufLine f, "}"
 
@@ -6101,12 +6176,15 @@ DO
     'Track the current BASIC source line before executing generated code.
     'Fatal runtime errors such as division by zero may occur before the
     'normal post-statement evnt() path is reached, so keep this separately.
-    IF inclinenumber(inclevel) THEN
-        thisincname$ = getfilepath$(incname$(inclevel))
-        thisincname$ = MID$(incname$(inclevel), LEN(thisincname$) + 1)
-        WriteBufLine MainTxtBuf, "error_track_line(" + _TOSTR$(linenumber) + "," + _TOSTR$(inclinenumber(inclevel)) + "," + CHR$(34) + thisincname$ + CHR$(34) + ");"
-    ELSE
-        WriteBufLine MainTxtBuf, "error_track_line(" + _TOSTR$(linenumber) + ",0,NULL);"
+    '$ErrorLocation is a whole-program opt-in diagnostic mode; it is OFF by default.
+    IF GetRCStateVar(ErrorLocationMode) = 2 THEN
+        IF inclinenumber(inclevel) THEN
+            thisincname$ = getfilepath$(incname$(inclevel))
+            thisincname$ = MID$(incname$(inclevel), LEN(thisincname$) + 1)
+            WriteBufLine MainTxtBuf, "error_track_line(" + _TOSTR$(linenumber) + "," + _TOSTR$(inclinenumber(inclevel)) + "," + CHR$(34) + thisincname$ + CHR$(34) + ");"
+        ELSE
+            WriteBufLine MainTxtBuf, "error_track_line(" + _TOSTR$(linenumber) + ",0,NULL);"
+        END IF
     END IF
 
     IF n >= 1 THEN
@@ -8885,7 +8963,12 @@ DO
                                 IF Error_Happened THEN GOTO errmes
                                 AppendDynMemberRedim redimDynPrefix$, redimDynDims, redimSlot$, redimElementBytes, redimElemUDT, DynMemVarStr%(redimE), redimoption, redimAcc$, id.dynudtmode
                                 IF Error_Happened THEN GOTO errmes
+                                'Keep REDIM runtime-bound temporaries in a local C++ scope even
+                                'under $CHECKING:OFF. Otherwise the SUB prologue's early
+                                'goto exit_subfunc can jump over initialized dyn_mem_rt_* locals.
+                                WriteBufLine MainTxtBuf, "{"
                                 WriteBufLine MainTxtBuf, redimAcc$
+                                WriteBufLine MainTxtBuf, "}"
                             ELSE
                                 ' The requested bounds must describe the exact same inline storage layout.
                                 ' A static TYPE member array has fixed bounds at compile time, so REDIM may only
@@ -14393,10 +14476,10 @@ FUNCTION ParseCMDLineArgs$ ()
                 CMDLineSwitch = _TRUE
 
             CASE "-u" 'Invoke "Update all pages" to populate internal/help files (hidden CI build option)
-                Help_Recaching = 2: Help_IgnoreCache = 0
+                Help_Recaching = 2: Help_IgnoreCache = 1
                 IF ideupdatehelpbox THEN
                     _DEST _CONSOLE
-                    PRINT "Help update incomplete, missing pages will be fetched on demand when a user requests it."
+                    PRINT "Help update failed: Can't make connection to Wiki."
                     SYSTEM 1
                 END IF
                 SYSTEM
@@ -17487,11 +17570,23 @@ FUNCTION dim2 (varname$, typ2$, method, elements$)
                         IF Error_Happened THEN EXIT FUNCTION
                         WriteBufLine DataTxtBuf, acc$
                         acc$ = ""
-                        AppendDynUDTDescInitAt n$, i, 0, _TOSTR$(bytes), "0", acc$, dyn_udt_prefix$, scalar_dyn_mode
+                        IF udtxvariable(i) THEN
+                            ' A descriptor-layout scalar UDT may also own variable STRING slots.
+                            ' Use the ownership-aware walker so qbs* members are initialized at
+                            ' dynamic-layout offsets; the legacy inline walker could overwrite
+                            ' descriptor slots when a _Dynamic member appears before a STRING.
+                            AppendDynUDTOwnInitAt n$, i, 0, _TOSTR$(bytes), "0", acc$, dyn_udt_prefix$, scalar_dyn_mode
+                        ELSE
+                            AppendDynUDTDescInitAt n$, i, 0, _TOSTR$(bytes), "0", acc$, dyn_udt_prefix$, scalar_dyn_mode
+                        END IF
                         IF Error_Happened THEN EXIT FUNCTION
                         WriteBufLine DataTxtBuf, acc$
                         acc$ = ""
-                        AppendDynUDTDescFreeAt n$, i, 0, _TOSTR$(bytes), "0", acc$, scalar_dyn_mode
+                        IF udtxvariable(i) THEN
+                            AppendDynUDTOwnFreeAt n$, i, 0, _TOSTR$(bytes), "0", acc$, scalar_dyn_mode
+                        ELSE
+                            AppendDynUDTDescFreeAt n$, i, 0, _TOSTR$(bytes), "0", acc$, scalar_dyn_mode
+                        END IF
                         IF Error_Happened THEN EXIT FUNCTION
                         IF acc$ <> "" THEN WriteBufLine FreeTxtBuf, acc$
                     END IF
@@ -17509,11 +17604,23 @@ FUNCTION dim2 (varname$, typ2$, method, elements$)
                         IF Error_Happened THEN EXIT FUNCTION
                         WriteBufLine DataTxtBuf, acc$
                         acc$ = ""
-                        AppendDynUDTDescInitAt n$, i, 0, _TOSTR$(bytes), "0", acc$, dyn_udt_prefix$, scalar_dyn_mode
+                        IF udtxvariable(i) THEN
+                            ' A descriptor-layout scalar UDT may also own variable STRING slots.
+                            ' Use the ownership-aware walker so qbs* members are initialized at
+                            ' dynamic-layout offsets; the legacy inline walker could overwrite
+                            ' descriptor slots when a _Dynamic member appears before a STRING.
+                            AppendDynUDTOwnInitAt n$, i, 0, _TOSTR$(bytes), "0", acc$, dyn_udt_prefix$, scalar_dyn_mode
+                        ELSE
+                            AppendDynUDTDescInitAt n$, i, 0, _TOSTR$(bytes), "0", acc$, dyn_udt_prefix$, scalar_dyn_mode
+                        END IF
                         IF Error_Happened THEN EXIT FUNCTION
                         WriteBufLine DataTxtBuf, acc$
                         acc$ = ""
-                        AppendDynUDTDescFreeAt n$, i, 0, _TOSTR$(bytes), "0", acc$, scalar_dyn_mode
+                        IF udtxvariable(i) THEN
+                            AppendDynUDTOwnFreeAt n$, i, 0, _TOSTR$(bytes), "0", acc$, scalar_dyn_mode
+                        ELSE
+                            AppendDynUDTDescFreeAt n$, i, 0, _TOSTR$(bytes), "0", acc$, scalar_dyn_mode
+                        END IF
                         IF Error_Happened THEN EXIT FUNCTION
                         IF acc$ <> "" THEN WriteBufLine FreeTxtBuf, acc$
                     END IF

--- a/tests/c/qbs_issue278_tests.cpp
+++ b/tests/c/qbs_issue278_tests.cpp
@@ -1,0 +1,511 @@
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+struct ReallocControl {
+    void *target = nullptr;
+    std::size_t old_size = 0;
+    std::size_t calls = 0;
+    std::size_t last_size = 0;
+    std::vector<std::size_t> requested_sizes;
+    std::size_t fail_above = std::numeric_limits<std::size_t>::max();
+    bool fail = false;
+    bool force_move = false;
+    bool fake_success = false;
+};
+
+static ReallocControl realloc_control;
+
+static void *qbs_test_realloc(void *ptr, std::size_t bytes) {
+    if (ptr == realloc_control.target) {
+        ++realloc_control.calls;
+        realloc_control.last_size = bytes;
+        realloc_control.requested_sizes.push_back(bytes);
+
+        if (realloc_control.fail || bytes > realloc_control.fail_above)
+            return nullptr;
+
+        if (realloc_control.fake_success)
+            return ptr;
+
+        if (realloc_control.force_move) {
+            void *replacement = std::malloc(bytes);
+            if (!replacement)
+                return nullptr;
+
+            std::memcpy(replacement, ptr, std::min(realloc_control.old_size, bytes));
+            std::free(ptr);
+            return replacement;
+        }
+    }
+
+    return std::realloc(ptr, bytes);
+}
+
+// Include the implementation directly so the test can exercise the file-local
+// arena state and overflow helpers without exporting production internals.
+#define QB64_QBS_TEST 1
+#include "../../../internal/c/libqb/src/qbs.cpp"
+#undef QB64_QBS_TEST
+
+struct QbsError {
+    int32_t code;
+};
+
+void error(int32_t code) { throw QbsError{code}; }
+void field_free(qbs *) {}
+void qbs_remove_cmem(qbs *) {}
+bool qbs_new_fixed_cmem(uint8_t *, uint32_t, uint8_t, qbs *) { return false; }
+void qbs_move_cmem(qbs *, qbs *) {}
+void qbs_copy_cmem(qbs *, qbs *) {}
+void qbs_create_cmem(int32_t, uint8_t, qbs *) { std::abort(); }
+
+struct TestFailure : std::exception {
+    std::string message;
+    explicit TestFailure(std::string text) : message(std::move(text)) {}
+    const char *what() const noexcept override { return message.c_str(); }
+};
+
+#define REQUIRE(condition)                                                                                               \
+    do {                                                                                                                 \
+        if (!(condition))                                                                                                \
+            throw TestFailure(std::string(__FILE__) + ":" + std::to_string(__LINE__) + ": " #condition);             \
+    } while (false)
+
+static void reset_realloc_control() {
+    realloc_control = {};
+    qbs_data_realloc = qbs_test_realloc;
+}
+
+static void reset_runtime() {
+    reset_realloc_control();
+
+    std::free(qbs_data);
+    qbs_data = static_cast<uint8_t *>(std::malloc(1048576));
+    REQUIRE(qbs_data != nullptr);
+    qbs_data_size = 1048576;
+    qbs_sp = 0;
+
+    std::free(qbs_list);
+    qbs_list = static_cast<intptr_t *>(std::malloc(65536 * sizeof(intptr_t)));
+    REQUIRE(qbs_list != nullptr);
+    qbs_list_lasti = 65535;
+    qbs_list_nexti = 0;
+
+    std::free(qbs_tmp_list);
+    qbs_tmp_list = static_cast<intptr_t *>(std::calloc(65536, sizeof(intptr_t)));
+    REQUIRE(qbs_tmp_list != nullptr);
+    qbs_tmp_list_lasti = 65535;
+    qbs_tmp_list_nexti = 0;
+
+    std::memset(qbs_malloc, 0, sizeof(qbs) * 65536);
+    qbs_malloc_next = 0;
+    qbs_malloc_freed_num = 0;
+}
+
+template <typename Function> static void require_error_512(Function &&function) {
+    bool caught = false;
+    try {
+        function();
+    } catch (const QbsError &raised) {
+        REQUIRE(raised.code == 512);
+        caught = true;
+    }
+    REQUIRE(caught);
+}
+
+static void fill_pattern(qbs *text, uint32_t seed) {
+    for (int32_t index = 0; index < text->len; ++index)
+        text->chr[index] = static_cast<uint8_t>((uint32_t(index) * 131u + seed) & 0xffu);
+}
+
+static void verify_pattern(const qbs *text, uint32_t seed) {
+    for (int32_t index = 0; index < text->len; ++index)
+        REQUIRE(text->chr[index] == static_cast<uint8_t>((uint32_t(index) * 131u + seed) & 0xffu));
+}
+
+static void test_platform_sized_arena_types() {
+    static_assert(std::is_same_v<decltype(qbs_data_size), std::size_t>);
+    static_assert(std::is_same_v<decltype(qbs_sp), std::size_t>);
+    REQUIRE(sizeof(qbs_data_size) == sizeof(std::size_t));
+    REQUIRE(sizeof(qbs_sp) == sizeof(std::size_t));
+}
+
+static void test_checked_size_addition_boundaries() {
+    std::size_t result = 0;
+    const std::size_t maximum = std::numeric_limits<std::size_t>::max();
+
+    REQUIRE(!qbs_size_add_overflow(0, 0, &result));
+    REQUIRE(result == 0);
+    REQUIRE(!qbs_size_add_overflow(maximum - 1, 1, &result));
+    REQUIRE(result == maximum);
+
+    result = 0x1234;
+    REQUIRE(qbs_size_add_overflow(maximum, 1, &result));
+    REQUIRE(result == 0x1234);
+    REQUIRE(qbs_size_add_overflow(maximum - 7, 8, &result));
+}
+
+static void test_data_space_boundaries() {
+    reset_runtime();
+    REQUIRE(qbs_data_has_space(qbs_data, qbs_data_size));
+    REQUIRE(qbs_data_has_space(qbs_data + qbs_data_size, 0));
+    REQUIRE(!qbs_data_has_space(qbs_data + qbs_data_size, 1));
+
+    const uintptr_t beyond = reinterpret_cast<uintptr_t>(qbs_data) + qbs_data_size + 1;
+    REQUIRE(!qbs_data_has_space(reinterpret_cast<uint8_t *>(beyond), 0));
+}
+
+static void test_negative_allocation_reports_oom() {
+    reset_runtime();
+    const std::size_t old_sp = qbs_sp;
+    const uint32_t old_count = qbs_list_nexti;
+    require_error_512([] { (void)qbs_new(-1, 0); });
+    REQUIRE(qbs_sp == old_sp);
+    REQUIRE(qbs_list_nexti == old_count);
+}
+
+static void test_fixed_and_variable_copy_paths() {
+    reset_runtime();
+
+    uint8_t fixed_buffer[8] = {};
+    qbs *fixed_text = qbs_new_fixed(fixed_buffer, sizeof(fixed_buffer), 0);
+    qbs_set(fixed_text, qbs_new_txt_len("abc", 3));
+    REQUIRE(std::memcmp(fixed_buffer, "abc     ", 8) == 0);
+
+    qbs *long_destination = qbs_new(32, 0);
+    std::memset(long_destination->chr, 'x', long_destination->len);
+    qbs *short_source = qbs_new(7, 0);
+    std::memcpy(short_source->chr, "shorter", 7);
+    uint8_t *long_destination_address = long_destination->chr;
+    qbs_set(long_destination, short_source);
+    REQUIRE(long_destination->chr == long_destination_address);
+    REQUIRE(long_destination->len == 7);
+    REQUIRE(std::memcmp(long_destination->chr, "shorter", 7) == 0);
+
+    qbs *relocated_destination = qbs_new(8, 0);
+    qbs *blocker = qbs_new(4096, 0);
+    qbs *long_source = qbs_new(65536, 0);
+    fill_pattern(blocker, 17);
+    fill_pattern(long_source, 91);
+    uint8_t *old_destination_address = relocated_destination->chr;
+    qbs_set(relocated_destination, long_source);
+    REQUIRE(relocated_destination->chr != old_destination_address);
+    REQUIRE(relocated_destination->len == long_source->len);
+    verify_pattern(relocated_destination, 91);
+    verify_pattern(blocker, 17);
+
+    qbs *acquiring_destination = qbs_new(4, 0);
+    qbs *temporary_source = qbs_new(32768, 1);
+    fill_pattern(temporary_source, 203);
+    uint8_t *temporary_data = temporary_source->chr;
+    const uint32_t temporary_list_index = temporary_source->listi;
+    const uint32_t temporary_tracking_index = temporary_source->tmplisti;
+    qbs_set(acquiring_destination, temporary_source);
+    REQUIRE(acquiring_destination->chr == temporary_data);
+    REQUIRE(acquiring_destination->listi == temporary_list_index);
+    REQUIRE(qbs_tmp_list[temporary_tracking_index] == -1);
+    verify_pattern(acquiring_destination, 203);
+}
+
+static void test_concatenation_and_binary_copy() {
+    reset_runtime();
+
+    const char left_bytes[] = {'A', '\0', 'B', 'C'};
+    const char right_bytes[] = {'D', 'E', '\0', 'F', 'G'};
+    qbs *joined = qbs_add(qbs_new_txt_len(left_bytes, sizeof(left_bytes)), qbs_new_txt_len(right_bytes, sizeof(right_bytes)));
+
+    const char expected[] = {'A', '\0', 'B', 'C', 'D', 'E', '\0', 'F', 'G'};
+    REQUIRE(joined != nullptr);
+    REQUIRE(joined->len == static_cast<int32_t>(sizeof(expected)));
+    REQUIRE(std::memcmp(joined->chr, expected, sizeof(expected)) == 0);
+    REQUIRE(joined->tmp == 1);
+}
+
+static void test_concatenation_length_overflow_reports_oom() {
+    reset_runtime();
+
+    uint8_t dummy = 0;
+    qbs left{};
+    qbs right{};
+    left.chr = &dummy;
+    right.chr = &dummy;
+    left.len = std::numeric_limits<int32_t>::max();
+    right.len = 1;
+
+    const std::size_t old_sp = qbs_sp;
+    const uint32_t old_count = qbs_list_nexti;
+    require_error_512([&] { (void)qbs_add(&left, &right); });
+    REQUIRE(qbs_sp == old_sp);
+    REQUIRE(qbs_list_nexti == old_count);
+}
+
+static void test_forced_realloc_move_rebases_every_live_string() {
+    reset_runtime();
+
+    std::vector<qbs *> strings;
+    std::vector<std::size_t> offsets;
+    for (int index = 0; index < 12; ++index) {
+        qbs *text = qbs_new(40000 + index * 97, 0);
+        fill_pattern(text, 1000u + uint32_t(index));
+        strings.push_back(text);
+        offsets.push_back(qbs_data_offset(text->chr));
+    }
+
+    uint8_t *old_base = qbs_data;
+    realloc_control.target = qbs_data;
+    realloc_control.old_size = qbs_data_size;
+    realloc_control.force_move = true;
+
+    qbs *large_text = qbs_new(2 * 1024 * 1024, 0);
+    REQUIRE(large_text != nullptr);
+    REQUIRE(realloc_control.calls == 1);
+    REQUIRE(qbs_data != old_base);
+
+    for (std::size_t index = 0; index < strings.size(); ++index) {
+        REQUIRE(qbs_data_offset(strings[index]->chr) == offsets[index]);
+        verify_pattern(strings[index], 1000u + uint32_t(index));
+    }
+}
+
+static void test_fragmentation_compaction_preserves_data() {
+    reset_runtime();
+
+    qbs *first = qbs_new(180000, 0);
+    qbs *discarded = qbs_new(210000, 0);
+    qbs *third = qbs_new(190000, 0);
+    fill_pattern(first, 41);
+    fill_pattern(discarded, 42);
+    fill_pattern(third, 43);
+
+    const std::size_t third_offset_before = qbs_data_offset(third->chr);
+    qbs_free(discarded);
+
+    qbs *large_text = qbs_new(800000, 0);
+    REQUIRE(large_text != nullptr);
+    REQUIRE(qbs_data_offset(third->chr) < third_offset_before);
+    verify_pattern(first, 41);
+    verify_pattern(third, 43);
+}
+
+static void test_realloc_failure_reports_oom_and_preserves_live_data() {
+    reset_runtime();
+
+    qbs *survivor = qbs_new(240000, 0);
+    fill_pattern(survivor, 77);
+    uint8_t *old_base = qbs_data;
+    const std::size_t old_size = qbs_data_size;
+    const uint32_t old_count = qbs_list_nexti;
+
+    realloc_control.target = qbs_data;
+    realloc_control.old_size = qbs_data_size;
+    realloc_control.fail = true;
+
+    require_error_512([] { (void)qbs_new(2 * 1024 * 1024, 0); });
+    REQUIRE(realloc_control.calls == 2);
+    REQUIRE(realloc_control.requested_sizes[1] < realloc_control.requested_sizes[0]);
+    REQUIRE(qbs_data == old_base);
+    REQUIRE(qbs_data_size == old_size);
+    REQUIRE(qbs_list_nexti == old_count);
+    verify_pattern(survivor, 77);
+}
+
+static void test_failed_optional_growth_uses_existing_capacity() {
+    reset_runtime();
+
+    const std::size_t old_size = qbs_data_size;
+    uint8_t *old_base = qbs_data;
+    qbs_list_nexti = 0;
+    qbs_sp = 600000;
+
+    const std::size_t bytesrequired = 100000;
+    REQUIRE(qbs_sp + bytesrequired <= qbs_data_size);
+
+    realloc_control.target = qbs_data;
+    realloc_control.fail = true;
+
+    qbs_concat(bytesrequired);
+
+    REQUIRE(realloc_control.calls == 1);
+    REQUIRE(qbs_data == old_base);
+    REQUIRE(qbs_data_size == old_size);
+    REQUIRE(qbs_sp + bytesrequired <= qbs_data_size);
+}
+
+static void test_failed_geometric_growth_retries_exact_requirement() {
+    reset_runtime();
+
+    qbs_list_nexti = 0;
+    qbs_sp = qbs_data_size - 100000;
+    const std::size_t bytesrequired = 200000;
+    const std::size_t required_size = qbs_sp + bytesrequired;
+    const std::size_t preferred_size = qbs_data_size * 2 + bytesrequired;
+
+    realloc_control.target = qbs_data;
+    realloc_control.fail_above = required_size;
+    realloc_control.fake_success = true;
+
+    qbs_concat(bytesrequired);
+
+    REQUIRE(realloc_control.calls == 2);
+    REQUIRE(realloc_control.requested_sizes.size() == 2);
+    REQUIRE(realloc_control.requested_sizes[0] == preferred_size);
+    REQUIRE(realloc_control.requested_sizes[1] == required_size);
+    REQUIRE(qbs_data_size == required_size);
+}
+
+static void test_arena_overflow_and_geometric_growth_boundaries() {
+    reset_runtime();
+    const std::size_t maximum = std::numeric_limits<std::size_t>::max();
+    uint8_t *actual_data = qbs_data;
+    const std::size_t actual_size = qbs_data_size;
+
+    qbs_list_nexti = 0;
+    qbs_data_size = maximum - 1024;
+    qbs_sp = maximum - 64;
+    realloc_control.target = qbs_data;
+    require_error_512([] { qbs_concat(128); });
+    REQUIRE(realloc_control.calls == 0);
+
+    reset_realloc_control();
+    realloc_control.target = qbs_data;
+    realloc_control.fake_success = true;
+    qbs_data_size = maximum / 2 + 4096;
+    qbs_sp = qbs_data_size - 128;
+    qbs_concat(128);
+    REQUIRE(realloc_control.calls == 0);
+
+    reset_realloc_control();
+    realloc_control.target = qbs_data;
+    realloc_control.fake_success = true;
+    qbs_data_size = maximum / 2 + 4096;
+    qbs_sp = qbs_data_size - 64;
+    const std::size_t exact_required = qbs_sp + 128;
+    qbs_concat(128);
+    REQUIRE(realloc_control.calls == 1);
+    REQUIRE(realloc_control.last_size == exact_required);
+    REQUIRE(qbs_data_size == exact_required);
+
+    qbs_data = actual_data;
+    qbs_data_size = actual_size;
+    qbs_sp = 0;
+    reset_realloc_control();
+}
+
+static void test_qbs_set_size_overflow_reports_oom() {
+    reset_runtime();
+
+    qbs *destination = qbs_new(1, 0);
+    (void)qbs_new(1, 0); // Prevent destination from being the last live string.
+
+    uint8_t source_bytes[64] = {};
+    qbs source{};
+    source.chr = source_bytes;
+    source.len = sizeof(source_bytes);
+    source.readonly = 1;
+
+    const std::size_t actual_size = qbs_data_size;
+    qbs_data_size = std::numeric_limits<std::size_t>::max();
+    qbs_sp = std::numeric_limits<std::size_t>::max() - 4;
+    require_error_512([&] { (void)qbs_set(destination, &source); });
+    qbs_data_size = actual_size;
+    qbs_sp = 0;
+}
+
+static void test_configurable_large_arena_stress() {
+    reset_runtime();
+
+    std::size_t stress_mib = 64;
+    if (const char *setting = std::getenv("QBS_ISSUE278_STRESS_MIB")) {
+        char *end = nullptr;
+        const unsigned long long parsed = std::strtoull(setting, &end, 10);
+        if (end != setting && *end == '\0' && parsed > 0)
+            stress_mib = static_cast<std::size_t>(parsed);
+    }
+
+    const std::size_t chunk_size = 4 * 1024 * 1024;
+    const std::size_t chunk_count = std::max<std::size_t>(1, (stress_mib * 1024 * 1024) / chunk_size);
+    std::vector<qbs *> chunks;
+    chunks.reserve(chunk_count);
+
+    for (std::size_t chunk_index = 0; chunk_index < chunk_count; ++chunk_index) {
+        qbs *text = qbs_new(static_cast<int32_t>(chunk_size), 0);
+        REQUIRE(text != nullptr);
+        const uint8_t marker = static_cast<uint8_t>((chunk_index * 29u + 7u) & 0xffu);
+        text->chr[0] = marker;
+        text->chr[chunk_size / 2] = static_cast<uint8_t>(marker ^ 0x5a);
+        text->chr[chunk_size - 1] = static_cast<uint8_t>(marker ^ 0xa5);
+        chunks.push_back(text);
+
+        for (std::size_t verify_index = 0; verify_index < chunks.size(); ++verify_index) {
+            const uint8_t expected = static_cast<uint8_t>((verify_index * 29u + 7u) & 0xffu);
+            REQUIRE(chunks[verify_index]->chr[0] == expected);
+            REQUIRE(chunks[verify_index]->chr[chunk_size / 2] == static_cast<uint8_t>(expected ^ 0x5a));
+            REQUIRE(chunks[verify_index]->chr[chunk_size - 1] == static_cast<uint8_t>(expected ^ 0xa5));
+        }
+    }
+}
+
+using TestFunction = void (*)();
+
+static int run_test(const char *name, TestFunction function) {
+    try {
+        function();
+        std::printf("PASS  %s\n", name);
+        return 0;
+    } catch (const TestFailure &failure) {
+        std::fprintf(stderr, "FAIL  %s\n      %s\n", name, failure.what());
+    } catch (const QbsError &raised) {
+        std::fprintf(stderr, "FAIL  %s\n      unexpected error(%d)\n", name, raised.code);
+    } catch (const std::exception &failure) {
+        std::fprintf(stderr, "FAIL  %s\n      %s\n", name, failure.what());
+    } catch (...) {
+        std::fprintf(stderr, "FAIL  %s\n      unknown exception\n", name);
+    }
+    return 1;
+}
+
+int main() {
+    const std::pair<const char *, TestFunction> tests[] = {
+        {"platform-sized arena counters", test_platform_sized_arena_types},
+        {"checked size addition boundaries", test_checked_size_addition_boundaries},
+        {"arena space boundaries", test_data_space_boundaries},
+        {"negative allocation -> OOM", test_negative_allocation_reports_oom},
+        {"fixed and variable copy paths", test_fixed_and_variable_copy_paths},
+        {"binary-safe concatenation", test_concatenation_and_binary_copy},
+        {"concatenation length overflow -> OOM", test_concatenation_length_overflow_reports_oom},
+        {"realloc move rebases live pointers", test_forced_realloc_move_rebases_every_live_string},
+        {"fragmentation compaction", test_fragmentation_compaction_preserves_data},
+        {"realloc failure -> OOM", test_realloc_failure_reports_oom_and_preserves_live_data},
+        {"optional reserve failure uses current arena", test_failed_optional_growth_uses_existing_capacity},
+        {"geometric failure retries exact size", test_failed_geometric_growth_retries_exact_requirement},
+        {"SIZE_MAX growth boundaries", test_arena_overflow_and_geometric_growth_boundaries},
+        {"qbs_set size overflow -> OOM", test_qbs_set_size_overflow_reports_oom},
+        {"configurable large arena stress", test_configurable_large_arena_stress},
+    };
+
+    int failures = 0;
+    for (const auto &test : tests)
+        failures += run_test(test.first, test.second);
+
+    if (failures) {
+        std::fprintf(stderr, "\n%d qbs issue #278 test(s) failed.\n", failures);
+        return 1;
+    }
+
+    const std::size_t reported_stress = std::getenv("QBS_ISSUE278_STRESS_MIB")
+                                            ? static_cast<std::size_t>(std::strtoull(std::getenv("QBS_ISSUE278_STRESS_MIB"), nullptr, 10))
+                                            : std::size_t{64};
+    std::printf("\nAll qbs issue #278 tests passed. size_t=%zu bits, arena=%zu MiB stress.\n", sizeof(std::size_t) * 8,
+                reported_stress);
+    return 0;
+}


### PR DESCRIPTION
This change fixes large-string memory handling in the qbs runtime and adds explicit runtime source-location tracking through `$ErrorLocation`.

The qbs string data arena now uses platform-sized counters for arena size and stack position, and its growth paths check for overflow before reallocating. This prevents wrapped arena sizes from corrupting memory or crashing programs when creating, concatenating, or assigning very large strings.

The qbs arena growth logic now:

* detects arithmetic overflow before allocation,
* reports Out of memory instead of continuing with wrapped sizes,
* preserves existing live qbs data if realloc fails,
* retries with the exact required size when preferred geometric growth fails,
* correctly rebases live qbs string pointers when realloc moves the arena,
* preserves binary-safe string operations, including strings containing embedded NUL bytes.

This addresses the large-string arena issues tracked by #278 and #559.

A native regression/stress test was added for the qbs issue #278 path. It covers arena counter sizes, overflow boundaries, negative allocation, large qbs_set paths, binary-safe concatenation, realloc relocation, fragmentation compaction, realloc failure, exact-size retry behavior, qbs_set overflow handling, and configurable large-arena stress testing.

This change also adds `$ErrorLocation:On` / `$ErrorLocation:Off`.

`$ErrorLocation` is a whole-program diagnostic option. It is off by default and is independent from `$Checking`. When enabled, the generated program tracks the current BASIC source line before executing statements so fatal runtime errors that bypass the normal error-event path can still report the BASIC source location.

The fatal-error reporting path now uses the tracked BASIC location for:

* critical Out of memory errors,
* Division by zero,
* Out of stack space,
* dynamic library load failures,
* missing dynamic-library SUB/FUNCTION symbols,
* `_GL` calls outside `SUB _GL`,
* `END` / `SYSTEM` called inside `SUB _GL`.

Dynamic library loading and symbol lookup run during generated initialization / registration code, outside the normal statement path. `$ErrorLocation:On` now records the corresponding DECLARE line only when such a load or lookup failure occurs, avoiding stale source locations after successful loads.

Fatal shutdown now routes through `libqb_exit()`. When a GLUT/OpenGL window is active, exit handling is transferred to the GLUT-owning thread; if the current thread already owns GLUT, it exits directly instead of queueing a message to itself. This avoids deadlock during fatal-error shutdown from OpenGL-related paths.

Test 1:

$ErrorLocation:On

OPTION _EXPLICIT

SCREEN _NEWIMAGE(320, 200, 32)

DO
    _LIMIT 60
LOOP

SUB _GL
    SYSTEM
END SUB

Test 2:

$Console:Only
$ErrorLocation:Off

Option _Explicit

Print "Starting recursive stack test with source tracking disabled."
RecurseStack 0
System

Sub RecurseStack (depth As Long)
    RecurseStack depth + 1
End Sub

Test 3:

$Console:Only
$ErrorLocation:On

Option _Explicit

Print "Starting recursive stack test with source tracking enabled."
RecurseStack 0
System

Sub RecurseStack (depth As Long)
    RecurseStack depth + 1
End Sub

and also test from your Github:

c$=space$(1123123123)
c$=space$(1123123123)
c$=space$(1123123123)
c$=space$(1123123123)
c$=space$(1123123123)
c$=space$(1123123123)
c$=space$(1123123123)

program normal continue in 64bit OS, Out of memory occur in 32bit OS.