### PR TITLE
feat: widen the UDT index field from 9 to 12 bits (raises the silent 511-TYPE cap, adds honest error)

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -9102,7 +9102,7 @@ FUNCTION idevariablewatchbox$ (currentScope$, filter$, selectVar, returnAction)
                         IF ok = -2 THEN
                             getid usedVariableList(tempIndex&).id
                             IF id.t = 0 THEN
-                                typ = id.arraytype AND 511
+                                typ = id.arraytype AND UDTMASK
                                 IF id.arraytype AND ISINCONVENTIONALMEMORY THEN
                                     typ = typ - ISINCONVENTIONALMEMORY
                                 END IF
@@ -9634,7 +9634,7 @@ FUNCTION idevariablewatchbox$ (currentScope$, filter$, selectVar, returnAction)
                             usedVariableList(varDlgList(y).index).elementOffset = ""
                             getid usedVariableList(varDlgList(y).index).id
                             IF id.t = 0 THEN
-                                typ = id.arraytype AND 511
+                                typ = id.arraytype AND UDTMASK
                                 IF id.arraytype AND ISINCONVENTIONALMEMORY THEN
                                     typ = typ - ISINCONVENTIONALMEMORY
                                 END IF

--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -2278,12 +2278,12 @@ DO
 
                                 'Calculate element's size
                                 IF typ AND ISUDT THEN
-                                    u = typ AND 511
+                                    u = typ AND UDTMASK
                                     udtesize(i2) = udtxsize(u)
                                     IF udtxvariable(u) THEN udtxvariable(i) = -1
                                 ELSEIF typ AND ISSTRING THEN
                                     IF (typ AND ISFIXEDLENGTH) = 0 THEN
-                                        udtesize(i2) = OFFSETTYPE AND 511
+                                        udtesize(i2) = OFFSETTYPE AND UDTMASK
                                         udtxvariable(i) = -1
                                     ELSE
                                         udtesize(i2) = typsize * 8
@@ -2291,7 +2291,7 @@ DO
                                 ELSEIF typ AND ISOFFSETINBITS THEN
                                     a$ = "Cannot use _BIT inside user defined types": GOTO errmes
                                 ELSE
-                                    udtesize(i2) = typ AND 511
+                                    udtesize(i2) = typ AND UDTMASK
                                 END IF
 
                                 ' For TYPE member arrays, udtesize() stores the declared inline block size.
@@ -2436,6 +2436,7 @@ DO
                         IF n >= 1 THEN
                             IF firstelement$ = "TYPE" THEN
                                 IF n <> 2 THEN a$ = "Expected TYPE typename": GOTO errmes
+                                IF lasttype >= UDTMASK THEN a$ = "Too many user-defined types (maximum" + STR$(UDTMASK) + ")": GOTO errmes
                                 lasttype = lasttype + 1
                                 typeDefinitions$ = typeDefinitions$ + MKL$(-1) + MKL$(lasttype)
                                 definingtype = lasttype
@@ -2560,7 +2561,7 @@ DO
                                     constval&& = constval##
                                     constval~&& = constval&&
                                 ELSE
-                                    IF (t AND ISUNSIGNED) AND (t AND 511) = 64 THEN
+                                    IF (t AND ISUNSIGNED) AND (t AND UDTMASK) = 64 THEN
                                         constval~&& = tempNum.ui
                                         constval&& = constval~&&
                                         constval## = constval&&
@@ -4280,7 +4281,7 @@ DO
             l$ = SCase$("As")
             IF declModeStart THEN layoutMemberStart = declModeStart ELSE layoutMemberStart = declStart
             IF typ AND ISUDT THEN
-                t$ = RTRIM$(udtxcname(typ AND 511))
+                t$ = RTRIM$(udtxcname(typ AND UDTMASK))
                 l$ = l$ + sp + t$
             ELSE
                 l$ = l$ + sp + SCase2$(t$)
@@ -4356,7 +4357,7 @@ DO
             IF Error_Happened THEN GOTO errmes
             IF typ = 0 THEN a$ = "Undefined type": GOTO errmes
             IF typ AND ISUDT THEN
-                t$ = RTRIM$(udtxcname(typ AND 511))
+                t$ = RTRIM$(udtxcname(typ AND UDTMASK))
                 l$ = l$ + sp + t$
             ELSE
                 l$ = l$ + sp + SCase2$(t$)
@@ -5558,7 +5559,7 @@ DO
                             IF Error_Happened THEN GOTO errmes
                             IF typ = 0 THEN a$ = "Undefined type": GOTO errmes
                             IF typ AND ISUDT THEN
-                                t3$ = RTRIM$(udtxcname(typ AND 511))
+                                t3$ = RTRIM$(udtxcname(typ AND UDTMASK))
                                 l$ = l$ + sp + t3$
                             ELSE
                                 FOR t3i = 1 TO LEN(t3$)
@@ -6410,7 +6411,7 @@ DO
             'markup to cater for greater range/accuracy
             ctype$ = ""
             ctyp = typ - ISPOINTER
-            bits = typ AND 511
+            bits = typ AND UDTMASK
             IF (typ AND ISFLOAT) THEN
                 IF bits = 32 THEN ctype$ = "double": ctyp = 64& + ISFLOAT
                 IF bits = 64 THEN ctype$ = "long double": ctyp = 256& + ISFLOAT
@@ -6746,9 +6747,9 @@ DO
 
                 IF (typ AND ISFLOAT) THEN
 
-                    IF (typ AND 511) > 64 THEN t = 3: t$ = "long double"
-                    IF (typ AND 511) = 32 THEN t = 4: t$ = "float"
-                    IF (typ AND 511) = 64 THEN t = 5: t$ = "double"
+                    IF (typ AND UDTMASK) > 64 THEN t = 3: t$ = "long double"
+                    IF (typ AND UDTMASK) = 32 THEN t = 4: t$ = "float"
+                    IF (typ AND UDTMASK) = 64 THEN t = 5: t$ = "double"
                     IF (typ AND ISUDT) = 0 AND (typ AND ISARRAY) = 0 AND (typ AND ISREFERENCE) <> 0 THEN
                         controlvalue(controllevel) = VAL(e$)
                     ELSE
@@ -6765,11 +6766,11 @@ DO
                     'non-float
                     t = 1: t$ = "int64"
                     IF (typ AND ISUNSIGNED) THEN
-                        IF (typ AND 511) <= 32 THEN t = 7: t$ = "uint32"
-                        IF (typ AND 511) > 32 THEN t = 2: t$ = "uint64"
+                        IF (typ AND UDTMASK) <= 32 THEN t = 7: t$ = "uint32"
+                        IF (typ AND UDTMASK) > 32 THEN t = 2: t$ = "uint64"
                     ELSE
-                        IF (typ AND 511) <= 32 THEN t = 6: t$ = "int32"
-                        IF (typ AND 511) > 32 THEN t = 1: t$ = "int64"
+                        IF (typ AND UDTMASK) <= 32 THEN t = 6: t$ = "int32"
+                        IF (typ AND UDTMASK) > 32 THEN t = 1: t$ = "int64"
                     END IF
                     IF (typ AND ISUDT) = 0 AND (typ AND ISARRAY) = 0 AND (typ AND ISREFERENCE) <> 0 THEN
                         controlvalue(controllevel) = VAL(e$)
@@ -6897,7 +6898,7 @@ DO
             '16=SELECT CASE int32
             '17=SELECT CASE uint32
 
-            '    bits = targettyp AND 511
+            '    bits = targettyp AND UDTMASK
             '                                IF bits <= 16 THEN e$ = "qbr_float_to_long(" + e$ + ")"
             '                                IF bits > 16 AND bits < 32 THEN e$ = "qbr_double_to_long(" + e$ + ")"
             '                                IF bits >= 32 THEN e$ = "qbr(" + e$ + ")"
@@ -7019,7 +7020,7 @@ DO
                     '16=SELECT CASE int32
                     '17=SELECT CASE uint32
 
-                    '    bits = targettyp AND 511
+                    '    bits = targettyp AND UDTMASK
                     '                                IF bits <= 16 THEN e$ = "qbr_float_to_long(" + e$ + ")"
                     '                                IF bits > 16 AND bits < 32 THEN e$ = "qbr_double_to_long(" + e$ + ")"
                     '                                IF bits >= 32 THEN e$ = "qbr(" + e$ + ")"
@@ -7146,14 +7147,14 @@ DO
                     IF Error_Happened THEN GOTO errmes
                     z = 1
                     t = id.arraytype
-                    IF (t AND 511) <> 16 AND (t AND 511) <> 32 THEN z = 0
+                    IF (t AND UDTMASK) <> 16 AND (t AND UDTMASK) <> 32 THEN z = 0
                     IF t AND ISFLOAT THEN z = 0
                     IF t AND ISOFFSETINBITS THEN z = 0
                     IF t AND ISSTRING THEN z = 0
                     IF t AND ISUDT THEN z = 0
                     IF t AND ISUNSIGNED THEN z = 0
                     IF z = 0 THEN a$ = "Array must be of type INTEGER or LONG": GOTO errmes
-                    bits = t AND 511
+                    bits = t AND UDTMASK
                     GOTO pu_gotarray
                 END IF
                 IF Error_Happened THEN GOTO errmes
@@ -7583,7 +7584,7 @@ DO
                     IF id.args = 0 THEN a$ = "SUB has no arguments": GOTO errmes
 
                     t = CVL(id.arg)
-                    B = t AND 511
+                    B = t AND UDTMASK
                     IF B = 0 OR (t AND ISARRAY) <> 0 OR (t AND ISFLOAT) <> 0 OR (t AND ISSTRING) <> 0 OR (t AND ISOFFSETINBITS) <> 0 THEN a$ = "Only SUB arguments of integer-type allowed": GOTO errmes
                     IF B = 8 THEN ct$ = "int8"
                     IF B = 16 THEN ct$ = "int16"
@@ -7770,7 +7771,7 @@ DO
                     IF id.args = 0 THEN a$ = "SUB has no arguments": GOTO errmes
 
                     t = CVL(id.arg)
-                    B = t AND 511
+                    B = t AND UDTMASK
                     IF B = 0 OR (t AND ISARRAY) <> 0 OR (t AND ISFLOAT) <> 0 OR (t AND ISSTRING) <> 0 OR (t AND ISOFFSETINBITS) <> 0 THEN a$ = "Only SUB arguments of integer-type allowed": GOTO errmes
                     IF B = 8 THEN ct$ = "int8"
                     IF B = 16 THEN ct$ = "int16"
@@ -7921,7 +7922,7 @@ DO
                     IF id.args = 0 THEN a$ = "SUB has no arguments": GOTO errmes
 
                     t = CVL(id.arg)
-                    B = t AND 511
+                    B = t AND UDTMASK
                     IF B = 0 OR (t AND ISARRAY) <> 0 OR (t AND ISFLOAT) <> 0 OR (t AND ISSTRING) <> 0 OR (t AND ISOFFSETINBITS) <> 0 THEN a$ = "Only SUB arguments of integer-type allowed": GOTO errmes
                     IF B = 8 THEN ct$ = "int8"
                     IF B = 16 THEN ct$ = "int16"
@@ -8016,7 +8017,7 @@ DO
                         ts$ = type2symbol$(t$)
                         l2$ = l2$ + sp + SCase2$(t3$)
                     ELSE
-                        t3$ = RTRIM$(udtxcname(t AND 511))
+                        t3$ = RTRIM$(udtxcname(t AND UDTMASK))
                         l2$ = l2$ + sp + t3$
                     END IF
                     IF Error_Happened THEN GOTO errmes
@@ -8164,7 +8165,7 @@ DO
                     ts$ = type2symbol$(t$)
                     l2$ = l2$ + sp + SCase2$(t3$)
                 ELSE
-                    t3$ = RTRIM$(udtxcname(t AND 511))
+                    t3$ = RTRIM$(udtxcname(t AND UDTMASK))
                     l2$ = l2$ + sp + t3$
                 END IF
                 IF Error_Happened THEN GOTO errmes
@@ -8463,12 +8464,12 @@ DO
                 'erase the array
                 clearerase:
                 n$ = RTRIM$(id.callname)
-                bytesperelement$ = _TOSTR$((id.arraytype AND 511) \ 8)
+                bytesperelement$ = _TOSTR$((id.arraytype AND UDTMASK) \ 8)
                 udt = 0
                 IF id.arraytype AND ISSTRING THEN bytesperelement$ = _TOSTR$(id.tsize)
-                IF id.arraytype AND ISOFFSETINBITS THEN bytesperelement$ = _TOSTR$((id.arraytype AND 511)) + "/8+1"
+                IF id.arraytype AND ISOFFSETINBITS THEN bytesperelement$ = _TOSTR$((id.arraytype AND UDTMASK)) + "/8+1"
                 IF id.arraytype AND ISUDT THEN
-                    udt = id.arraytype AND 511
+                    udt = id.arraytype AND UDTMASK
                     IF id.dynudt THEN
                         bytesperelement$ = _TOSTR$(UDTDynLayoutSize&(udt, id.dynudtmode) \ 8)
                     ELSE
@@ -8647,9 +8648,9 @@ DO
                             ' Match ordinary QB64PE static-array reset semantics for STRING * N.
                             ' Fixed-length string storage is cleared to NUL bytes here, not spaces.
                             WriteBufLine MainTxtBuf, "memset((void*)" + ptr$ + ",0," + _TOSTR$(memberbytes) + ");"
-                        ELSEIF (udtetype(member_element_id) AND ISUDT) <> 0 AND udtxvariable(udtetype(member_element_id) AND 511) THEN
+                        ELSEIF (udtetype(member_element_id) AND ISUDT) <> 0 AND udtxvariable(udtetype(member_element_id) AND UDTMASK) THEN
                             FOR i2 = 0 TO memberelems - 1
-                                clear_udt_with_varstrings ptr$, udtetype(member_element_id) AND 511, MainTxtBuf, i2 * elementbytes
+                                clear_udt_with_varstrings ptr$, udtetype(member_element_id) AND UDTMASK, MainTxtBuf, i2 * elementbytes
                             NEXT
                         ELSE
                             WriteBufLine MainTxtBuf, "memset((void*)" + ptr$ + ",0," + _TOSTR$(memberbytes) + ");"
@@ -8837,8 +8838,8 @@ DO
                                 IF Error_Happened THEN GOTO errmes
                                 IF redimTypeValue = 0 THEN a$ = "Undefined type": GOTO errmes
                                 redimTypeSize = typname2typsize
-                                redimTypeMask = redimTypeValue AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH + ISOFFSETINBITS)
-                                redimMemberMask = udtetype(redimE) AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH + ISOFFSETINBITS)
+                                redimTypeMask = redimTypeValue AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH + ISOFFSETINBITS)
+                                redimMemberMask = udtetype(redimE) AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH + ISOFFSETINBITS)
                                 IF redimTypeMask <> redimMemberMask OR redimTypeSize <> udtetypesize(redimE) THEN
                                     a$ = "TYPE member array REDIM type mismatch": GOTO errmes
                                 END IF
@@ -8875,7 +8876,7 @@ DO
                                 redimMemberElems = udtearrayelements(redimE)
                                 redimElementBytes = udt_dyn_array_elem_bytes(redimE, id.dynudtmode)
                                 redimElemUDT = 0
-                                IF (udtetype(redimE) AND ISUDT) <> 0 THEN redimElemUDT = udtetype(redimE) AND 511
+                                IF (udtetype(redimE) AND ISUDT) <> 0 THEN redimElemUDT = udtetype(redimE) AND UDTMASK
                                 redimSlot$ = "((char*)" + redimBase$ + "+(" + redimOffset$ + "))"
                                 redimAcc$ = ""
                                 redimDynPrefix$ = "dyn_mem_rt_" + _TOSTR$(uniquenumber)
@@ -8914,9 +8915,9 @@ DO
                                         ' Match ordinary QB64PE static-array REDIM semantics for STRING * N.
                                         ' Fixed-length string storage is reinitialized to NUL bytes, not spaces.
                                         WriteBufLine MainTxtBuf, "memset((void*)" + redimPtr$ + ",0," + _TOSTR$(redimMemberBytes) + ");"
-                                    ELSEIF (udtetype(redimE) AND ISUDT) <> 0 AND udtxvariable(udtetype(redimE) AND 511) THEN
+                                    ELSEIF (udtetype(redimE) AND ISUDT) <> 0 AND udtxvariable(udtetype(redimE) AND UDTMASK) THEN
                                         FOR redimI2 = 0 TO redimMemberElems - 1
-                                            clear_udt_with_varstrings redimPtr$, udtetype(redimE) AND 511, MainTxtBuf, redimI2 * redimElementBytes
+                                            clear_udt_with_varstrings redimPtr$, udtetype(redimE) AND UDTMASK, MainTxtBuf, redimI2 * redimElementBytes
                                         NEXT
                                     ELSE
                                         WriteBufLine MainTxtBuf, "memset((void*)" + redimPtr$ + ",0," + _TOSTR$(redimMemberBytes) + ");"
@@ -9057,7 +9058,7 @@ DO
                         IF id.insubfuncn = subfuncn THEN 'global cannot conflict with static
                             IF LEN(RTRIM$(id.musthave)) THEN
                                 'if types match then fail
-                                IF (id.arraytype AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
+                                IF (id.arraytype AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
                                     IF ts = id.tsize THEN
                                         a$ = "Name already in use (" + varname$ + ")": GOTO errmes
                                     END IF
@@ -9067,7 +9068,7 @@ DO
                                     a$ = "Name already in use (" + varname$ + ")": GOTO errmes 'explicit over explicit
                                 ELSE
                                     'if types match then fail
-                                    IF (id.arraytype AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
+                                    IF (id.arraytype AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
                                         IF ts = id.tsize THEN
                                             a$ = "Name already in use (" + varname$ + ")": GOTO errmes
                                         END IF
@@ -9084,7 +9085,7 @@ DO
                             IF id.insubfuncn = subfuncn THEN 'global cannot conflict with static
                                 IF LEN(RTRIM$(id.musthave)) THEN
                                     'if types match then fail
-                                    IF (id.arraytype AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
+                                    IF (id.arraytype AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
                                         IF ts = id.tsize THEN
                                             a$ = "Name already in use (" + varname$ + s2$ + ")": GOTO errmes
                                         END IF
@@ -9094,7 +9095,7 @@ DO
                                         a$ = "Name already in use (" + varname$ + s2$ + ")": GOTO errmes 'explicit over explicit
                                     ELSE
                                         'if types match then fail
-                                        IF (id.arraytype AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
+                                        IF (id.arraytype AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
                                             IF ts = id.tsize THEN
                                                 a$ = "Name already in use (" + varname$ + s2$ + ")": GOTO errmes
                                             END IF
@@ -9140,7 +9141,7 @@ DO
                         IF id.insubfuncn = subfuncn THEN 'global cannot conflict with static
                             IF LEN(RTRIM$(id.musthave)) THEN
                                 'if types match then fail
-                                IF (id.arraytype AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
+                                IF (id.arraytype AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
                                     IF ts = id.tsize THEN
                                         a$ = "Name already in use (" + varname$ + ")": GOTO errmes
                                     END IF
@@ -9150,7 +9151,7 @@ DO
                                     a$ = "Name already in use (" + varname$ + ")": GOTO errmes 'explicit over explicit
                                 ELSE
                                     'if types match then fail
-                                    IF (id.arraytype AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
+                                    IF (id.arraytype AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
                                         IF ts = id.tsize THEN
                                             a$ = "Name already in use (" + varname$ + ")": GOTO errmes
                                         END IF
@@ -9167,7 +9168,7 @@ DO
                             IF id.insubfuncn = subfuncn THEN 'global cannot conflict with static
                                 IF LEN(RTRIM$(id.musthave)) THEN
                                     'if types match then fail
-                                    IF (id.arraytype AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
+                                    IF (id.arraytype AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
                                         IF ts = id.tsize THEN
                                             a$ = "Name already in use (" + varname$ + s2$ + ")": GOTO errmes
                                         END IF
@@ -9177,7 +9178,7 @@ DO
                                         a$ = "Name already in use (" + varname$ + s2$ + ")": GOTO errmes 'explicit over explicit
                                     ELSE
                                         'if types match then fail
-                                        IF (id.arraytype AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + 511 + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
+                                        IF (id.arraytype AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) = (t AND (ISFLOAT + ISUDT + UDTMASK + ISUNSIGNED + ISSTRING + ISFIXEDLENGTH)) THEN
                                             IF ts = id.tsize THEN
                                                 a$ = "Name already in use (" + varname$ + s2$ + ")": GOTO errmes
                                             END IF
@@ -9262,7 +9263,7 @@ DO
                                         IF (t AND ISFIXEDLENGTH) <> (t2 AND ISFIXEDLENGTH) THEN match = 0
                                         IF (t AND ISOFFSETINBITS) <> (t2 AND ISOFFSETINBITS) THEN match = 0
                                         IF (t AND ISUDT) <> (t2 AND ISUDT) THEN match = 0
-                                        IF (t AND 511) <> (t2 AND 511) THEN match = 0
+                                        IF (t AND UDTMASK) <> (t2 AND UDTMASK) THEN match = 0
                                         IF s <> s2 THEN match = 0
                                         'check for implicit/explicit declaration match
                                         oldmethod = 0: IF LEN(RTRIM$(id.musthave)) THEN oldmethod = 1
@@ -9276,7 +9277,7 @@ DO
 
                                         IF dimmethod = 0 THEN
                                             IF t AND ISUDT THEN
-                                                dim2typepassback$ = RTRIM$(udtxcname(t AND 511))
+                                                dim2typepassback$ = RTRIM$(udtxcname(t AND UDTMASK))
                                             ELSE
                                                 dim2typepassback$ = typ$
                                                 DO WHILE INSTR(dim2typepassback$, " ")
@@ -9372,8 +9373,8 @@ DO
                         WriteBufLine MainTxtBuf, "sub_put(FF,NULL,byte_element((uint64)&int32val,4," + NewByteElement$ + "),0);"
 
                         t = id.t
-                        bits = t AND 511
-                        IF t AND ISUDT THEN bits = udtxsize(t AND 511)
+                        bits = t AND UDTMASK
+                        IF t AND ISUDT THEN bits = udtxsize(t AND UDTMASK)
                         IF t AND ISSTRING THEN
                             IF t AND ISFIXEDLENGTH THEN
                                 bits = id.tsize * 8
@@ -10123,7 +10124,7 @@ DO
             l$ = SCase$("_MemGet") + sp + tlayout$
 
             test$ = evaluate(e$, typ): IF Error_Happened THEN GOTO errmes
-            IF (typ AND ISUDT) = 0 OR (typ AND 511) <> 1 THEN a$ = "Expected _MEM type": GOTO errmes
+            IF (typ AND ISUDT) = 0 OR (typ AND UDTMASK) <> 1 THEN a$ = "Expected _MEM type": GOTO errmes
             blkoffs$ = evaluatetotyp(e$, -6)
 
             '            IF typ AND ISREFERENCE THEN e$ = refer(e$, typ, 0)
@@ -10222,7 +10223,7 @@ DO
             l$ = SCase$("_MemPut") + sp + tlayout$
 
             test$ = evaluate(e$, typ): IF Error_Happened THEN GOTO errmes
-            IF (typ AND ISUDT) = 0 OR (typ AND 511) <> 1 THEN a$ = "Expected _MEM type": GOTO errmes
+            IF (typ AND ISUDT) = 0 OR (typ AND UDTMASK) <> 1 THEN a$ = "Expected _MEM type": GOTO errmes
             blkoffs$ = evaluatetotyp(e$, -6)
 
             e$ = fixoperationorder$(offs$): IF Error_Happened THEN GOTO errmes
@@ -10299,7 +10300,7 @@ DO
                 l$ = l$ + sp2 + "," + sp + tlayout$ + sp + SCase$("As") + sp + SCase2$(typ$)
                 e$ = evaluatetotyp(e$, t): IF Error_Happened THEN GOTO errmes
                 st$ = typ2ctyp$(t, "")
-                varsize$ = _TOSTR$((t AND 511) \ 8)
+                varsize$ = _TOSTR$((t AND UDTMASK) \ 8)
                 IF CheckingOn = 0 THEN
                     'fast version:
                     WriteBufLine MainTxtBuf, "*(" + st$ + "*)(" + offs$ + ")=" + e$ + ";"
@@ -10362,7 +10363,7 @@ DO
             l$ = SCase$("_MemFill") + sp + tlayout$
 
             test$ = evaluate(e$, typ): IF Error_Happened THEN GOTO errmes
-            IF (typ AND ISUDT) = 0 OR (typ AND 511) <> 1 THEN a$ = "Expected " + "_MEM type": GOTO errmes
+            IF (typ AND ISUDT) = 0 OR (typ AND UDTMASK) <> 1 THEN a$ = "Expected " + "_MEM type": GOTO errmes
             blkoffs$ = evaluatetotyp(e$, -6)
 
             e$ = fixoperationorder$(offs$): IF Error_Happened THEN GOTO errmes
@@ -10417,11 +10418,11 @@ DO
                     c$ = c$ + "OFFSET"
                 ELSE
                     IF t AND ISFLOAT THEN
-                        IF (t AND 511) = 32 THEN c$ = c$ + "SINGLE"
-                        IF (t AND 511) = 64 THEN c$ = c$ + "DOUBLE"
-                        IF (t AND 511) = 256 THEN c$ = c$ + "FLOAT" 'padded variable
+                        IF (t AND UDTMASK) = 32 THEN c$ = c$ + "SINGLE"
+                        IF (t AND UDTMASK) = 64 THEN c$ = c$ + "DOUBLE"
+                        IF (t AND UDTMASK) = 256 THEN c$ = c$ + "FLOAT" 'padded variable
                     ELSE
-                        c$ = c$ + _TOSTR$((t AND 511) \ 8)
+                        c$ = c$ + _TOSTR$((t AND UDTMASK) \ 8)
                     END IF
                 END IF
                 c$ = c$ + "("
@@ -10564,7 +10565,7 @@ DO
                                 'assume not string
                                 'single, double or integer64?
                                 IF typ AND ISFLOAT THEN
-                                    IF (typ AND 511) = 32 THEN
+                                    IF (typ AND UDTMASK) = 32 THEN
                                         e$ = evaluatetotyp(e$, SINGLETYPE - ISPOINTER)
                                         IF Error_Happened THEN GOTO errmes
                                         v$ = "pass" + _TOSTR$(uniquenumber)
@@ -10931,7 +10932,7 @@ DO
                                         IF lineinput THEN a$ = "Expected string-variable": GOTO errmes
 
                                         'numeric variable
-                                        IF (t AND ISFLOAT) <> 0 OR (t AND 511) <> 64 THEN
+                                        IF (t AND ISFLOAT) <> 0 OR (t AND UDTMASK) <> 64 THEN
                                             IF (t AND ISOFFSETINBITS) THEN
                                                 setrefer e$, t, "((int64)func_file_input_float(tmp_fileno," + _TOSTR$(t) + "))", 1
                                                 IF Error_Happened THEN GOTO errmes
@@ -11344,7 +11345,7 @@ DO
                     IF e1typc <> e2typc THEN a$ = "Type mismatch": GOTO errmes
                     t = e1typ
                     IF t AND ISOFFSETINBITS THEN a$ = "Cannot SWAP bit-length variables": GOTO errmes
-                    B = t AND 511
+                    B = t AND UDTMASK
                     t$ = _TOSTR$(B): IF B > 64 THEN t$ = "longdouble"
                     WriteBufLine MainTxtBuf, "swap_" + t$ + "(&" + refer(e1$, e1typ, 0) + ",&" + refer(e2$, e2typ, 0) + ");"
                     IF Error_Happened THEN GOTO errmes
@@ -11665,7 +11666,7 @@ DO
                             END IF
 
                             ' Only _BYTE array is allowed
-                            IF (sourcetyp AND ISSTRING) OR (sourcetyp AND ISFLOAT) OR (sourcetyp AND ISOFFSET) OR (sourcetyp AND ISUDT) OR (sourcetyp AND ISUNSIGNED) OR (sourcetyp AND 511) <> 8 THEN
+                            IF (sourcetyp AND ISSTRING) OR (sourcetyp AND ISFLOAT) OR (sourcetyp AND ISOFFSET) OR (sourcetyp AND ISUDT) OR (sourcetyp AND ISUNSIGNED) OR (sourcetyp AND UDTMASK) <> 8 THEN
                                 a$ = "Expected _BYTE array name": GOTO errmes
                             END IF
 
@@ -11685,7 +11686,7 @@ DO
                             END IF
 
                             ' Only 32-bit floating-point array is allowed
-                            IF (sourcetyp AND ISFLOAT) = 0 OR (sourcetyp AND 511) <> 32 THEN
+                            IF (sourcetyp AND ISFLOAT) = 0 OR (sourcetyp AND UDTMASK) <> 32 THEN
                                 a$ = "Expected SINGLE array name": GOTO errmes
                             END IF
 
@@ -11739,7 +11740,7 @@ DO
                                 DO WHILE try
                                     IF id.arraytype AND ISUDT THEN
                                         IF id.dynudt THEN
-                                            udt = id.arraytype AND 511
+                                            udt = id.arraytype AND UDTMASK
                                             IF UDTDynHasMemberArrays%(udt, id.dynudtmode) THEN
                                                 IF firstelement$ = "GET" THEN
                                                     e$ = UDTFileArrayBE$(RTRIM$(id.callname), udt, id.dynudtmode, id.arrayelements, -1, dynfilepost$)
@@ -11764,7 +11765,7 @@ DO
                                     getid idnumber
                                     IF Error_Happened THEN GOTO errmes
                                     IF id.dynudt THEN
-                                        udt = id.arraytype AND 511
+                                        udt = id.arraytype AND UDTMASK
                                         IF UDTDynHasMemberArrays%(udt, id.dynudtmode) THEN
                                             IF firstelement$ = "GET" THEN
                                                 e$ = UDTFileArrayBE$(RTRIM$(id.callname), udt, id.dynudtmode, id.arrayelements, -1, dynfilepost$)
@@ -11835,8 +11836,8 @@ DO
 
                                     'check arrays are of same type
                                     targettyp2 = targettyp: sourcetyp2 = sourcetyp
-                                    targettyp2 = targettyp2 AND (511 + ISOFFSETINBITS + ISUDT + ISSTRING + ISFIXEDLENGTH + ISFLOAT)
-                                    sourcetyp2 = sourcetyp2 AND (511 + ISOFFSETINBITS + ISUDT + ISSTRING + ISFIXEDLENGTH + ISFLOAT)
+                                    targettyp2 = targettyp2 AND (UDTMASK + ISOFFSETINBITS + ISUDT + ISSTRING + ISFIXEDLENGTH + ISFLOAT)
+                                    sourcetyp2 = sourcetyp2 AND (UDTMASK + ISOFFSETINBITS + ISUDT + ISSTRING + ISFIXEDLENGTH + ISFLOAT)
                                     IF sourcetyp2 <> targettyp2 THEN a$ = "Incorrect array type passed to sub": GOTO errmes
 
 
@@ -11957,8 +11958,8 @@ DO
                                         passudtelement = 0: IF (targettyp2 AND ISUDT) = 0 AND (sourcetyp2 AND ISUDT) <> 0 THEN passudtelement = 1: sourcetyp2 = sourcetyp2 - ISUDT
 
                                         'remove flags irrelevant for comparison... ISPOINTER,ISREFERENCE,ISINCONVENTIONALMEMORY,ISARRAY
-                                        targettyp2 = targettyp2 AND (511 + ISOFFSETINBITS + ISUDT + ISFLOAT + ISSTRING)
-                                        sourcetyp2 = sourcetyp2 AND (511 + ISOFFSETINBITS + ISUDT + ISFLOAT + ISSTRING)
+                                        targettyp2 = targettyp2 AND (UDTMASK + ISOFFSETINBITS + ISUDT + ISFLOAT + ISSTRING)
+                                        sourcetyp2 = sourcetyp2 AND (UDTMASK + ISOFFSETINBITS + ISUDT + ISFLOAT + ISSTRING)
 
                                         'compare types
                                         IF sourcetyp2 = targettyp2 THEN
@@ -12097,7 +12098,7 @@ DO
                         IF explicitreference = 0 THEN
                             IF targettyp AND ISUDT THEN
                                 nth = i
-                                x$ = "'" + RTRIM$(udtxcname(targettyp AND 511)) + "'"
+                                x$ = "'" + RTRIM$(udtxcname(targettyp AND UDTMASK)) + "'"
                                 IF ids(targetid).args = 1 THEN a$ = "TYPE " + x$ + " required for sub": GOTO errmes
                                 a$ = str_nth$(nth) + " sub argument requires TYPE " + x$: GOTO errmes
                             END IF
@@ -12109,7 +12110,7 @@ DO
                         IF (sourcetyp AND ISFLOAT) THEN
                             IF (targettyp AND ISFLOAT) = 0 THEN
                                 '**32 rounding fix
-                                bits = targettyp AND 511
+                                bits = targettyp AND UDTMASK
                                 IF bits <= 16 THEN e$ = "qbr_float_to_long(" + e$ + ")"
                                 IF bits > 16 AND bits < 32 THEN e$ = "qbr_double_to_long(" + e$ + ")"
                                 IF bits >= 32 THEN e$ = "qbr(" + e$ + ")"
@@ -12123,7 +12124,7 @@ DO
                             v$ = "pass" + _TOSTR$(uniquenumber)
                             'assume numeric type
                             IF MID$(sfcmemargs(targetid), i, 1) = CHR$(1) THEN 'cmem required?
-                                bytesreq = ((targettyp AND 511) + 7) \ 8
+                                bytesreq = ((targettyp AND UDTMASK) + 7) \ 8
                                 WriteBufLine defdatahandle, t$ + " *" + v$ + "=NULL;"
                                 WriteBufLine DataTxtBuf, "if(" + v$ + "==NULL){"
                                 WriteBufLine DataTxtBuf, "cmem_sp-=" + _TOSTR$(bytesreq) + ";"
@@ -12618,7 +12619,7 @@ FOR i = 1 TO idn
             'create a reference
             typ = id.t + ISREFERENCE
             IF typ AND ISUDT THEN
-                e$ = _TOSTR$(i) + sp3 + _TOSTR$(typ AND 511) + sp3 + "0" + sp3 + "0"
+                e$ = _TOSTR$(i) + sp3 + _TOSTR$(typ AND UDTMASK) + sp3 + "0" + sp3 + "0"
             ELSE
                 e$ = _TOSTR$(i)
             END IF
@@ -12636,9 +12637,9 @@ FOR i = 1 TO idn
                 END IF
             END IF
             IF typ AND ISUDT THEN
-                IF udtxvariable(typ AND 511) THEN
+                IF udtxvariable(typ AND UDTMASK) THEN
                     'this next procedure resets values of UDT variables with variable-length strings
-                    clear_udt_with_varstrings e$, typ AND 511, MainTxtBuf, 0
+                    clear_udt_with_varstrings e$, typ AND UDTMASK, MainTxtBuf, 0
                 ELSE
                     WriteBufLine MainTxtBuf, "memset((void*)" + e$ + ",0," + bytes$ + ");"
                 END IF
@@ -13202,8 +13203,8 @@ FOR x = 1 TO commonarraylistn
 
         IF command = 3 THEN
             'size of each element in bits
-            bits = t AND 511
-            IF t AND ISUDT THEN bits = udtxsize(t AND 511)
+            bits = t AND UDTMASK
+            IF t AND ISUDT THEN bits = udtxsize(t AND UDTMASK)
             IF t AND ISSTRING THEN bits = tsize * 8
             WriteBufLine MainTxtBuf, "int64val=" + _TOSTR$(bits) + ";" 'size in bits
             WriteBufLine MainTxtBuf, "sub_put(FF,NULL,byte_element((uint64)&int64val,8," + NewByteElement$ + "),0);"
@@ -14546,7 +14547,7 @@ FUNCTION Type2MemTypeValue (t1)
     t = 0
     IF t1 AND ISARRAY THEN t = t + 65536
     IF t1 AND ISUDT THEN
-        IF (t1 AND 511) = 1 THEN
+        IF (t1 AND UDTMASK) = 1 THEN
             t = t + 4096 '_MEM type
         ELSE
             t = t + 32768
@@ -14562,7 +14563,7 @@ FUNCTION Type2MemTypeValue (t1)
                 IF t1 AND ISUNSIGNED THEN t = t + 1024
                 IF t1 AND ISOFFSET THEN t = t + 8192 'offset type
             END IF
-            t1s = (t1 AND 511) \ 8
+            t1s = (t1 AND UDTMASK) \ 8
             IF t1s = 1 THEN t = t + t1s
             IF t1s = 2 THEN t = t + t1s
             IF t1s = 4 THEN t = t + t1s
@@ -14611,7 +14612,7 @@ FUNCTION UDTRuntimeMemberArrays% (udt AS LONG)
             IF LEFT$(udtearraydesc(elemnum), 1) = "@" THEN UDTRuntimeMemberArrays% = -1: EXIT FUNCTION
         END IF
         IF (udtetype(elemnum) AND ISUDT) <> 0 THEN
-            nestedudt = udtetype(elemnum) AND 511
+            nestedudt = udtetype(elemnum) AND UDTMASK
             IF UDTRuntimeMemberArrays%(nestedudt) THEN UDTRuntimeMemberArrays% = -1: EXIT FUNCTION
         END IF
         elemnum = udtenext(elemnum)
@@ -15719,7 +15720,7 @@ FUNCTION UDTForcedDynMembers% (udt_index AS LONG)
             IF udtearrayfieldmode(member_id) = 2 THEN UDTForcedDynMembers% = -1: EXIT FUNCTION
         END IF
         IF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             IF UDTForcedDynMembers%(nested_udt) THEN UDTForcedDynMembers% = -1: EXIT FUNCTION
         END IF
         member_id = udtenext(member_id)
@@ -16223,12 +16224,12 @@ SUB AppendDynUDTBoundsPrepSeen (udt_index AS LONG, prep_prefix AS STRING, acc AS
                 END IF
             END IF
             IF udtetype(member_id) AND ISUDT THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 AppendDynUDTBoundsPrepSeen nested_udt, prep_prefix, acc, seen_members
                 IF Error_Happened THEN EXIT SUB
             END IF
         ELSEIF udtetype(member_id) AND ISUDT THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             AppendDynUDTBoundsPrepSeen nested_udt, prep_prefix, acc, seen_members
             IF Error_Happened THEN EXIT SUB
         END IF
@@ -16832,7 +16833,7 @@ SUB AppendUDTFileConvCode (dst_expr AS STRING, src_expr AS STRING, udt_index AS 
         stat_bytes = udtesize(elemnum) \ 8
         dyn_bytes = UDTDynMemberSize&(elemnum, layout_mode) \ 8
         nested_udt = 0
-        IF (udtetype(elemnum) AND ISUDT) <> 0 THEN nested_udt = udtetype(elemnum) AND 511
+        IF (udtetype(elemnum) AND ISUDT) <> 0 THEN nested_udt = udtetype(elemnum) AND UDTMASK
 
         IF UDTMemberDynDesc%(elemnum, layout_mode) THEN
             desc_name = "file_dyn_desc_" + _TOSTR$(uniquenumber)
@@ -17044,8 +17045,8 @@ SUB assign (a$, n)
                     IF Error_Happened THEN EXIT SUB
                 LOOP
                 IF lhsok AND rhsok THEN
-                    lhsudt = lhsid.arraytype AND 511
-                    rhsudt = rhsid.arraytype AND 511
+                    lhsudt = lhsid.arraytype AND UDTMASK
+                    rhsudt = rhsid.arraytype AND UDTMASK
                     IF lhsudt = rhsudt AND lhsid.dynudt AND rhsid.dynudt THEN
                         IF lhsid.dynudtmode <> rhsid.dynudtmode THEN Give_Error "Cannot assign between different descriptor-layout user defined type modes": EXIT SUB
                         IF lhsid.arrayelements <> rhsid.arrayelements THEN Give_Error "Cannot assign arrays with different dimensions": EXIT SUB
@@ -18800,10 +18801,10 @@ FUNCTION udtreference$ (o$, a$, typ AS LONG)
 
     incmem = 0
     IF id.t THEN
-        u = id.t AND 511
+        u = id.t AND UDTMASK
         IF id.t AND ISINCONVENTIONALMEMORY THEN incmem = 1
     ELSE
-        u = id.arraytype AND 511
+        u = id.arraytype AND UDTMASK
         IF id.arraytype AND ISINCONVENTIONALMEMORY THEN incmem = 1
     END IF
     udtElem = 0
@@ -18902,7 +18903,7 @@ FUNCTION udtreference$ (o$, a$, typ AS LONG)
             base_ptr = root_base_ptr
             IF id.t = 0 AND CheckingOn THEN
                 guard_desc = scope$ + "ARRAY_UDT_" + RTRIM$(id.n)
-                guard_udt = id.arraytype AND 511
+                guard_udt = id.arraytype AND UDTMASK
                 guard_mode = id.dynudtmode
                 IF guard_mode = 0 THEN guard_mode = id.dynudt
                 base_ptr = "((char*)" + UDTRootDataGuard$(guard_desc, guard_udt, guard_mode) + ")"
@@ -18942,7 +18943,7 @@ FUNCTION udtreference$ (o$, a$, typ AS LONG)
     'Move into another UDT structure?
     IF i <> n THEN
         IF (udtetype(udtElem) AND ISUDT) = 0 THEN Give_Error "Expected user defined type": EXIT FUNCTION
-        u = udtetype(udtElem) AND 511
+        u = udtetype(udtElem) AND UDTMASK
         udtElem = 0
         i = i + 1
         GOTO udtfindelenext
@@ -18950,7 +18951,7 @@ FUNCTION udtreference$ (o$, a$, typ AS LONG)
 
     'Change e reference to u | 0 reference?
     IF udtetype(udtElem) AND ISUDT THEN
-        u = udtetype(udtElem) AND 511
+        u = udtetype(udtElem) AND UDTMASK
         udtElem = 0
     END IF
 
@@ -19083,7 +19084,7 @@ FUNCTION evaluate$ (a2$, typ AS LONG)
                                             IF Error_Happened THEN EXIT FUNCTION
                                             o$ = RIGHT$(c$, LEN(c$) - INSTR(c$, sp3))
                                             'change o$ to a byte offset
-                                            u = typ2 AND 511
+                                            u = typ2 AND UDTMASK
                                             s = udtxsize(u) \ 8
                                             IF id.dynudt THEN s = UDTDynLayoutSize&(u, id.dynudtmode) \ 8
                                             o$ = "(" + o$ + ")*" + _TOSTR$(s)
@@ -19347,7 +19348,7 @@ FUNCTION evaluate$ (a2$, typ AS LONG)
                         blocktype(i) = typname2typ(removesymbol$(num$))
                         IF Error_Happened THEN EXIT FUNCTION
                         IF blocktype(i) AND ISPOINTER THEN blocktype(i) = blocktype(i) - ISPOINTER
-                        IF (blocktype(i) AND 511) > 32 THEN
+                        IF (blocktype(i) AND UDTMASK) > 32 THEN
                             IF blocktype(i) AND ISUNSIGNED THEN num$ = num$ + "ull" ELSE num$ = num$ + "ll"
                         END IF
                     END IF
@@ -19663,7 +19664,7 @@ FUNCTION evaluate$ (a2$, typ AS LONG)
                     '2. Comparison of a double higher/lower than single range may fail
                     'solution: out of range values convert to +/-1.#INF, making comparison still possible
                     IF (oldtyp AND ISFLOAT) <> 0 AND (newtyp AND ISFLOAT) <> 0 THEN 'both floating point
-                        s1 = oldtyp AND 511: s2 = newtyp AND 511
+                        s1 = oldtyp AND UDTMASK: s2 = newtyp AND UDTMASK
                         IF s2 < s1 THEN s1 = s2
                         IF s1 = 32 THEN
                             block(i - 1) = "((float)(" + block(i - 1) + "))": oldtyp = 32& + ISFLOAT
@@ -19686,16 +19687,16 @@ FUNCTION evaluate$ (a2$, typ AS LONG)
                 IF (oldtyp AND ISSTRING) = 0 AND (newtyp AND ISSTRING) = 0 THEN
                     IF (oldtyp AND ISFLOAT) <> 0 OR (newtyp AND ISFLOAT) <> 0 THEN
                         'float
-                        b = 0: IF (oldtyp AND ISFLOAT) THEN b = oldtyp AND 511
+                        b = 0: IF (oldtyp AND ISFLOAT) THEN b = oldtyp AND UDTMASK
                         IF (newtyp AND ISFLOAT) THEN
-                            b2 = newtyp AND 511: IF b2 > b THEN b = b2
+                            b2 = newtyp AND UDTMASK: IF b2 > b THEN b = b2
                         END IF
                         typ = ISFLOAT + b
                     ELSE
                         'integer
                         '***THIS IS THE IDEAL MARKUP FOR A 64-BIT SYSTEM***
                         'In reality 32-bit C++ only marks-up to 32-bit integers
-                        b = oldtyp AND 511: b2 = newtyp AND 511: IF b2 > b THEN b = b2
+                        b = oldtyp AND UDTMASK: b2 = newtyp AND UDTMASK: IF b2 > b THEN b = b2
                         typ = 64&
                         IF b = 64 THEN
                             IF (oldtyp AND ISUNSIGNED) <> 0 AND (newtyp AND ISUNSIGNED) <> 0 THEN typ = 64& + ISUNSIGNED
@@ -19731,7 +19732,7 @@ FUNCTION evaluate$ (a2$, typ AS LONG)
 
                         'QB-like conversion of math functions returning floating point values
                         'reassess oldtype & newtype
-                        b = oldtyp AND 511
+                        b = oldtyp AND UDTMASK
                         IF oldtyp AND ISFLOAT THEN
                             'no change to b
                         ELSE
@@ -19739,7 +19740,7 @@ FUNCTION evaluate$ (a2$, typ AS LONG)
                             IF b > 32 THEN b = 256 'larger than LONG? return _FLOAT
                             IF b <= 16 THEN b = 32
                         END IF
-                        b2 = newtyp AND 511
+                        b2 = newtyp AND UDTMASK
                         IF newtyp AND ISFLOAT THEN
                             IF b2 > b THEN b = b2
                         ELSE
@@ -19818,7 +19819,7 @@ FUNCTION evaluate$ (a2$, typ AS LONG)
         IF (typ AND ISPOINTER) THEN PRINT #9, "[ISPOINTER]";
         IF (typ AND ISFIXEDLENGTH) THEN PRINT #9, "[ISFIXEDLENGTH]";
         IF (typ AND ISINCONVENTIONALMEMORY) THEN PRINT #9, "[ISINCONVENTIONALMEMORY]";
-        PRINT #9, "(size in bits=" + _TOSTR$(typ AND 511) + ")"
+        PRINT #9, "(size in bits=" + _TOSTR$(typ AND UDTMASK) + ")"
     END IF
 
 
@@ -20206,10 +20207,10 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                             memget_ctyp$ = "qbs*"
                         ELSE
                             IF t AND ISUDT THEN
-                                memget_size = udtxsize(t AND 511) \ 8
+                                memget_size = udtxsize(t AND UDTMASK) \ 8
                                 memget_ctyp$ = "void*"
                             ELSE
-                                memget_size = (t AND 511) \ 8
+                                memget_size = (t AND UDTMASK) \ 8
                                 memget_ctyp$ = typ2ctyp$(t, "")
                             END IF
                         END IF
@@ -20230,7 +20231,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                         ELSE
                             IF t AND ISUDT THEN
                                 r$ = "((void*)+" + offs$ + ")"
-                                t = ISUDT + ISPOINTER + (t AND 511)
+                                t = ISUDT + ISPOINTER + (t AND UDTMASK)
                             ELSE
                                 r$ = "*(" + memget_ctyp$ + "*)(" + offs$ + ")"
                                 IF t AND ISPOINTER THEN t = t - ISPOINTER
@@ -20484,7 +20485,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                         END IF
 
                         ' Cannot be one of these
-                        IF (sourcetyp AND ISSTRING) OR (sourcetyp AND ISFLOAT) OR (sourcetyp AND ISOFFSET) OR (sourcetyp AND ISUDT) OR (sourcetyp AND 511) <> 32 THEN
+                        IF (sourcetyp AND ISSTRING) OR (sourcetyp AND ISFLOAT) OR (sourcetyp AND ISOFFSET) OR (sourcetyp AND ISUDT) OR (sourcetyp AND UDTMASK) <> 32 THEN
                             Give_Error "Expected LONG array-name"
                             EXIT FUNCTION
                         END IF
@@ -20552,13 +20553,13 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                 '*special case*
                 IF n$ = "_BIN" THEN
                     IF RTRIM$(id2.musthave) = "$" THEN
-                        bits = sourcetyp AND 511
+                        bits = sourcetyp AND UDTMASK
 
                         IF (sourcetyp AND ISSTRING) THEN Give_Error "Expected numeric value": EXIT FUNCTION
                         wasref = 0
                         IF (sourcetyp AND ISREFERENCE) THEN e$ = refer(e$, sourcetyp, 0): wasref = 1
                         IF Error_Happened THEN EXIT FUNCTION
-                        bits = sourcetyp AND 511
+                        bits = sourcetyp AND UDTMASK
                         IF (sourcetyp AND ISOFFSETINBITS) THEN
                             e$ = "func__bin(" + e$ + "," + _TOSTR$(bits) + ")"
                         ELSE
@@ -20580,13 +20581,13 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                 '*special case*
                 IF n$ = "OCT" THEN
                     IF RTRIM$(id2.musthave) = "$" THEN
-                        bits = sourcetyp AND 511
+                        bits = sourcetyp AND UDTMASK
 
                         IF (sourcetyp AND ISSTRING) THEN Give_Error "Expected numeric value": EXIT FUNCTION
                         wasref = 0
                         IF (sourcetyp AND ISREFERENCE) THEN e$ = refer(e$, sourcetyp, 0): wasref = 1
                         IF Error_Happened THEN EXIT FUNCTION
-                        bits = sourcetyp AND 511
+                        bits = sourcetyp AND UDTMASK
                         IF (sourcetyp AND ISOFFSETINBITS) THEN
                             e$ = "func_oct(" + e$ + "," + _TOSTR$(bits) + ")"
                         ELSE
@@ -20608,12 +20609,12 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                 '*special case*
                 IF n$ = "HEX" THEN
                     IF RTRIM$(id2.musthave) = "$" THEN
-                        bits = sourcetyp AND 511
+                        bits = sourcetyp AND UDTMASK
                         IF (sourcetyp AND ISSTRING) THEN Give_Error "Expected numeric value": EXIT FUNCTION
                         wasref = 0
                         IF (sourcetyp AND ISREFERENCE) THEN e$ = refer(e$, sourcetyp, 0): wasref = 1
                         IF Error_Happened THEN EXIT FUNCTION
-                        bits = sourcetyp AND 511
+                        bits = sourcetyp AND UDTMASK
                         IF (sourcetyp AND ISOFFSETINBITS) THEN
                             chars = (bits + 3) \ 4
                             e$ = "func_hex(" + e$ + "," + _TOSTR$(chars) + ")"
@@ -20639,11 +20640,11 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
 
                 '*special case*
                 IF n$ = "EXP" THEN
-                    bits = sourcetyp AND 511
+                    bits = sourcetyp AND UDTMASK
                     IF (sourcetyp AND ISSTRING) THEN Give_Error "Expected numeric value": EXIT FUNCTION
                     IF (sourcetyp AND ISREFERENCE) THEN e$ = refer(e$, sourcetyp, 0)
                     IF Error_Happened THEN EXIT FUNCTION
-                    bits = sourcetyp AND 511
+                    bits = sourcetyp AND UDTMASK
                     typ& = SINGLETYPE - ISPOINTER
                     IF (sourcetyp AND ISFLOAT) THEN
                         IF bits = 32 THEN e$ = "func_exp_single(" + e$ + ")" ELSE e$ = "func_exp_float(" + e$ + ")": typ& = FLOATTYPE - ISPOINTER
@@ -20676,7 +20677,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                     IF (sourcetyp AND ISREFERENCE) THEN e$ = refer(e$, sourcetyp, 0)
                     IF Error_Happened THEN EXIT FUNCTION
                     'establish which function (if any!) should be used
-                    bits = sourcetyp AND 511
+                    bits = sourcetyp AND UDTMASK
                     IF (sourcetyp AND ISFLOAT) THEN
                         IF bits > 64 THEN e$ = "func_fix_float(" + e$ + ")" ELSE e$ = "func_fix_double(" + e$ + ")"
                     ELSE
@@ -20694,7 +20695,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                     IF Error_Happened THEN EXIT FUNCTION
                     'establish which function (if any!) should be used
                     IF (sourcetyp AND ISFLOAT) THEN
-                        bits = sourcetyp AND 511
+                        bits = sourcetyp AND UDTMASK
                         IF bits > 64 THEN e$ = "func_round_float(" + e$ + ")" ELSE e$ = "func_round_double(" + e$ + ")"
                     ELSE
                         e$ = "(" + e$ + ")"
@@ -20714,7 +20715,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                     IF (sourcetyp AND ISREFERENCE) THEN e$ = refer(e$, sourcetyp, 0)
                     IF Error_Happened THEN EXIT FUNCTION
                     'establish which function (if any!) should be used
-                    bits = sourcetyp AND 511
+                    bits = sourcetyp AND UDTMASK
                     IF (sourcetyp AND ISFLOAT) THEN
                         IF bits > 64 THEN e$ = "func_cdbl_float(" + e$ + ")"
                     ELSE
@@ -20731,7 +20732,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                     IF (sourcetyp AND ISREFERENCE) THEN e$ = refer(e$, sourcetyp, 0)
                     IF Error_Happened THEN EXIT FUNCTION
                     'establish which function (if any!) should be used
-                    bits = sourcetyp AND 511
+                    bits = sourcetyp AND UDTMASK
                     IF (sourcetyp AND ISFLOAT) THEN
                         IF bits = 64 THEN e$ = "func_csng_double(" + e$ + ")"
                         IF bits > 64 THEN e$ = "func_csng_float(" + e$ + ")"
@@ -20750,7 +20751,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                     IF (sourcetyp AND ISREFERENCE) THEN e$ = refer(e$, sourcetyp, 0)
                     IF Error_Happened THEN EXIT FUNCTION
                     'establish which function (if any!) should be used
-                    bits = sourcetyp AND 511
+                    bits = sourcetyp AND UDTMASK
                     IF (sourcetyp AND ISFLOAT) THEN
                         IF bits > 64 THEN e$ = "func_clng_float(" + e$ + ")" ELSE e$ = "func_clng_double(" + e$ + ")"
                     ELSE 'integer
@@ -20772,7 +20773,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                     IF (sourcetyp AND ISREFERENCE) THEN e$ = refer(e$, sourcetyp, 0)
                     IF Error_Happened THEN EXIT FUNCTION
                     'establish which function (if any!) should be used
-                    bits = sourcetyp AND 511
+                    bits = sourcetyp AND UDTMASK
                     IF (sourcetyp AND ISFLOAT) THEN
                         IF bits > 64 THEN e$ = "func_cint_float(" + e$ + ")" ELSE e$ = "func_cint_double(" + e$ + ")"
                     ELSE 'integer
@@ -20947,7 +20948,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                                 t = t + 64
                                 t = t + (sourcetyp AND 63)
                             ELSE
-                                bits = sourcetyp AND 511
+                                bits = sourcetyp AND UDTMASK
                                 IF (sourcetyp AND ISFLOAT) THEN
                                     IF bits = 32 THEN t = t + 4
                                     IF bits = 64 THEN t = t + 8
@@ -21017,7 +21018,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                         END IF
 
                         'non-UDT array
-                        m = (sourcetyp AND 511) \ 8 'calculate size multiplier
+                        m = (sourcetyp AND UDTMASK) \ 8 'calculate size multiplier
                         index$ = RIGHT$(e$, LEN(e$) - INSTR(e$, sp3))
                         typ = 64&
                         r$ = "((" + index$ + ")*" + _TOSTR$(m) + ")"
@@ -21196,8 +21197,8 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
 
                             'check arrays are of same type
                             targettyp2 = targettyp: sourcetyp2 = sourcetyp
-                            targettyp2 = targettyp2 AND (511 + ISOFFSETINBITS + ISUDT + ISSTRING + ISFIXEDLENGTH + ISFLOAT)
-                            sourcetyp2 = sourcetyp2 AND (511 + ISOFFSETINBITS + ISUDT + ISSTRING + ISFIXEDLENGTH + ISFLOAT)
+                            targettyp2 = targettyp2 AND (UDTMASK + ISOFFSETINBITS + ISUDT + ISSTRING + ISFIXEDLENGTH + ISFLOAT)
+                            sourcetyp2 = sourcetyp2 AND (UDTMASK + ISOFFSETINBITS + ISUDT + ISSTRING + ISFIXEDLENGTH + ISFLOAT)
                             IF sourcetyp2 <> targettyp2 THEN Give_Error "Incorrect array type passed to function": EXIT FUNCTION
 
                             'check arrayname was followed by '()'
@@ -21335,8 +21336,8 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                                 passudtelement = 0: IF (targettyp2 AND ISUDT) = 0 AND (sourcetyp2 AND ISUDT) <> 0 THEN passudtelement = 1: sourcetyp2 = sourcetyp2 - ISUDT
 
                                 'remove flags irrelevant for comparison... ISPOINTER,ISREFERENCE,ISINCONVENTIONALMEMORY,ISARRAY
-                                targettyp2 = targettyp2 AND (511 + ISOFFSETINBITS + ISUDT + ISFLOAT + ISSTRING)
-                                sourcetyp2 = sourcetyp2 AND (511 + ISOFFSETINBITS + ISUDT + ISFLOAT + ISSTRING)
+                                targettyp2 = targettyp2 AND (UDTMASK + ISOFFSETINBITS + ISUDT + ISFLOAT + ISSTRING)
+                                sourcetyp2 = sourcetyp2 AND (UDTMASK + ISOFFSETINBITS + ISUDT + ISFLOAT + ISSTRING)
 
                                 'compare types
                                 IF sourcetyp2 = targettyp2 THEN
@@ -21501,7 +21502,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                     IF targettyp AND ISUDT THEN
                         nth = curarg
                         IF skipFirstArg THEN nth = nth - 1
-                        x$ = "'" + RTRIM$(udtxcname(targettyp AND 511)) + "'"
+                        x$ = "'" + RTRIM$(udtxcname(targettyp AND UDTMASK)) + "'"
                         IF ids(targetid).args = 1 THEN Give_Error "TYPE " + x$ + " required for function": EXIT FUNCTION
                         Give_Error str_nth$(nth) + " function argument requires TYPE " + x$: EXIT FUNCTION
                     END IF
@@ -21513,7 +21514,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                 IF (sourcetyp AND ISFLOAT) THEN
                     IF (targettyp AND ISFLOAT) = 0 THEN
                         '**32 rounding fix
-                        bits = targettyp AND 511
+                        bits = targettyp AND UDTMASK
                         IF bits <= 16 THEN e$ = "qbr_float_to_long(" + e$ + ")"
                         IF bits > 16 AND bits < 32 THEN e$ = "qbr_double_to_long(" + e$ + ")"
                         IF bits >= 32 THEN e$ = "qbr(" + e$ + ")"
@@ -21526,20 +21527,20 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                         e$ = "(int64)(" + e$ + ")"
                     ELSE
                         IF (targettyp AND ISFLOAT) THEN
-                            IF (targettyp AND 511) = 32 THEN e$ = "(float)(" + e$ + ")"
-                            IF (targettyp AND 511) = 64 THEN e$ = "(double)(" + e$ + ")"
-                            IF (targettyp AND 511) = 256 THEN e$ = "(long double)(" + e$ + ")"
+                            IF (targettyp AND UDTMASK) = 32 THEN e$ = "(float)(" + e$ + ")"
+                            IF (targettyp AND UDTMASK) = 64 THEN e$ = "(double)(" + e$ + ")"
+                            IF (targettyp AND UDTMASK) = 256 THEN e$ = "(long double)(" + e$ + ")"
                         ELSE
                             IF (targettyp AND ISUNSIGNED) THEN
-                                IF (targettyp AND 511) = 8 THEN e$ = "(uint8)(" + e$ + ")"
-                                IF (targettyp AND 511) = 16 THEN e$ = "(uint16)(" + e$ + ")"
-                                IF (targettyp AND 511) = 32 THEN e$ = "(uint32)(" + e$ + ")"
-                                IF (targettyp AND 511) = 64 THEN e$ = "(uint64)(" + e$ + ")"
+                                IF (targettyp AND UDTMASK) = 8 THEN e$ = "(uint8)(" + e$ + ")"
+                                IF (targettyp AND UDTMASK) = 16 THEN e$ = "(uint16)(" + e$ + ")"
+                                IF (targettyp AND UDTMASK) = 32 THEN e$ = "(uint32)(" + e$ + ")"
+                                IF (targettyp AND UDTMASK) = 64 THEN e$ = "(uint64)(" + e$ + ")"
                             ELSE
-                                IF (targettyp AND 511) = 8 THEN e$ = "(int8)(" + e$ + ")"
-                                IF (targettyp AND 511) = 16 THEN e$ = "(int16)(" + e$ + ")"
-                                IF (targettyp AND 511) = 32 THEN e$ = "(int32)(" + e$ + ")"
-                                IF (targettyp AND 511) = 64 THEN e$ = "(int64)(" + e$ + ")"
+                                IF (targettyp AND UDTMASK) = 8 THEN e$ = "(int8)(" + e$ + ")"
+                                IF (targettyp AND UDTMASK) = 16 THEN e$ = "(int16)(" + e$ + ")"
+                                IF (targettyp AND UDTMASK) = 32 THEN e$ = "(int32)(" + e$ + ")"
+                                IF (targettyp AND UDTMASK) = 64 THEN e$ = "(int64)(" + e$ + ")"
                             END IF
                         END IF 'float?
                     END IF 'offset in bits?
@@ -21554,7 +21555,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
                     v$ = "pass" + _TOSTR$(uniquenumber)
                     'assume numeric type
                     IF MID$(sfcmemargs(targetid), curarg, 1) = CHR$(1) THEN 'cmem required?
-                        bytesreq = ((targettyp AND 511) + 7) \ 8
+                        bytesreq = ((targettyp AND UDTMASK) + 7) \ 8
                         WriteBufLine defdatahandle, t$ + " *" + v$ + "=NULL;"
                         WriteBufLine DataTxtBuf, "if(" + v$ + "==NULL){"
                         WriteBufLine DataTxtBuf, "cmem_sp-=" + _TOSTR$(bytesreq) + ";"
@@ -21699,7 +21700,7 @@ FUNCTION evaluatefunc$ (a2$, args AS LONG, typ AS LONG)
 
     'QB-like conversion of math functions returning floating point values
     IF n$ = "SIN" OR n$ = "COS" OR n$ = "TAN" OR n$ = "ATN" OR n$ = "SQR" OR n$ = "LOG" THEN
-        b = sourcetyp AND 511
+        b = sourcetyp AND UDTMASK
         IF sourcetyp AND ISFLOAT THEN
             'Default is FLOATTYPE
             IF b = 64 THEN typ& = DOUBLETYPE - ISPOINTER
@@ -21734,10 +21735,10 @@ FUNCTION variablesize$ (i AS LONG) 'ID or -1 (if ID already 'loaded')
     IF Error_Happened THEN EXIT FUNCTION
     'find base size from type
     t = id.t: IF t = 0 THEN t = id.arraytype
-    bytes = (t AND 511) \ 8
+    bytes = (t AND UDTMASK) \ 8
 
     IF t AND ISUDT THEN 'correct size for UDTs
-        u = t AND 511
+        u = t AND UDTMASK
         bytes = udtxsize(u) \ 8
         IF id.dynudt THEN bytes = UDTDynLayoutSize&(u, id.dynudtmode) \ 8
     END IF
@@ -21848,7 +21849,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
         END IF
 
         IF (sourcetyp AND ISUDT) THEN 'User Defined Type -> byte_element(offset,bytes)
-            IF udtxvariable(sourcetyp AND 511) THEN Give_Error "UDT must have fixed size": EXIT FUNCTION
+            IF udtxvariable(sourcetyp AND UDTMASK) THEN Give_Error "UDT must have fixed size": EXIT FUNCTION
             idnumber = VAL(e$)
             i = INSTR(e$, sp3): e$ = RIGHT$(e$, LEN(e$) - i)
             u = VAL(e$) 'closest parent
@@ -21988,7 +21989,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
             e$ = refer(e$, sourcetyp, 0)
             IF Error_Happened THEN EXIT FUNCTION
             e$ = "(&(" + e$ + "))"
-            bytes$ = _TOSTR$((sourcetyp AND 511) \ 8)
+            bytes$ = _TOSTR$((sourcetyp AND UDTMASK) \ 8)
             evaluatetotyp$ = "byte_element((uint64)" + e$ + "," + bytes$ + "," + NewByteElement$ + ")"
             IF targettyp = -5 THEN evaluatetotyp$ = bytes$
             IF targettyp = -6 THEN evaluatetotyp$ = e$
@@ -22017,7 +22018,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
         'Standard variable -> byte_element(offset,bytes)
         e$ = refer(e$, sourcetyp, 1) 'get the variable's formal name
         IF Error_Happened THEN EXIT FUNCTION
-        size = (sourcetyp AND 511) \ 8 'calculate its size in bytes
+        size = (sourcetyp AND UDTMASK) \ 8 'calculate its size in bytes
         evaluatetotyp$ = "byte_element((uint64)" + e$ + "," + _TOSTR$(size) + "," + NewByteElement$ + ")"
         IF targettyp = -5 THEN evaluatetotyp$ = _TOSTR$(size)
         IF targettyp = -6 THEN evaluatetotyp$ = e$
@@ -22252,7 +22253,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
             getid idnumber
             IF Error_Happened THEN EXIT FUNCTION
             IF (id.arraytype AND ISUDT) <> 0 THEN
-                u = id.arraytype AND 511
+                u = id.arraytype AND UDTMASK
                 IF id.dynudt AND UDTDynHasMemberArrays%(u, id.dynudtmode) THEN Give_Error "_MEM cannot reference descriptor-owning user-defined type elements": EXIT FUNCTION
                 IF id.dynudt AND udtxvariable(u) THEN Give_Error "_MEM cannot reference variable-length strings": EXIT FUNCTION
             END IF
@@ -22284,7 +22285,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
             e$ = refer(e$, sourcetyp, 0)
             IF Error_Happened THEN EXIT FUNCTION
             e$ = "(&(" + e$ + "))"
-            bytes$ = _TOSTR$((sourcetyp AND 511) \ 8)
+            bytes$ = _TOSTR$((sourcetyp AND UDTMASK) \ 8)
             'evaluatetotyp$ = "byte_element((uint64)" + e$ + "," + bytes$ + "," + NewByteElement$ + ")"
             'IF targettyp = -5 THEN evaluatetotyp$ = bytes$
             'IF targettyp = -6 THEN evaluatetotyp$ = e$
@@ -22299,7 +22300,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
             IF (sourcetyp AND ISARRAY) = 0 AND (sourcetyp AND ISUDT) = 0 AND (sourcetyp AND ISSTRING) = 0 THEN
                 e$ = refer(e$, sourcetyp, 1)
                 IF Error_Happened THEN EXIT FUNCTION
-                size = (sourcetyp AND 511) \ 8
+                size = (sourcetyp AND UDTMASK) \ 8
                 t = Type2MemTypeValue(sourcetyp)
                 evaluatetotyp$ = "(ptrszint)" + e$ + "," + _TOSTR$(size) + "," + _TOSTR$(t) + "," + _TOSTR$(size) + "," + dynmemlockexpr
                 EXIT FUNCTION
@@ -22331,7 +22332,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
         'Standard variable -> byte_element(offset,bytes)
         e$ = refer(e$, sourcetyp, 1) 'get the variable's formal name
         IF Error_Happened THEN EXIT FUNCTION
-        size = (sourcetyp AND 511) \ 8 'calculate its size in bytes
+        size = (sourcetyp AND UDTMASK) \ 8 'calculate its size in bytes
         'evaluatetotyp$ = "byte_element((uint64)" + e$ + "," + _TOSTR$(size) + "," + NewByteElement$ + ")"
         'IF targettyp = -5 THEN evaluatetotyp$ = _TOSTR$(size)
         'IF targettyp = -6 THEN evaluatetotyp$ = e$
@@ -22587,7 +22588,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
             getid idnumber
             IF Error_Happened THEN EXIT FUNCTION
             IF (id.arraytype AND ISUDT) <> 0 THEN
-                u = id.arraytype AND 511
+                u = id.arraytype AND UDTMASK
                 IF id.dynudt AND UDTDynHasMemberArrays%(u, id.dynudtmode) THEN Give_Error "_MEM cannot reference descriptor-owning user-defined type elements": EXIT FUNCTION
                 IF id.dynudt AND udtxvariable(u) THEN Give_Error "_MEM cannot reference variable-length strings": EXIT FUNCTION
             END IF
@@ -22614,7 +22615,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
             IF sourcetyp AND ISSTRING THEN
                 bytes = tsize
             ELSE
-                bytes = (sourcetyp AND 511) \ 8
+                bytes = (sourcetyp AND UDTMASK) \ 8
             END IF
             bytes$ = bytes$ + "-(" + _TOSTR$(bytes) + "*(" + index$ + "))"
 
@@ -22628,7 +22629,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
             IF (sourcetyp AND ISARRAY) = 0 AND (sourcetyp AND ISUDT) = 0 AND (sourcetyp AND ISSTRING) = 0 THEN
                 e$ = refer(e$, sourcetyp, 1)
                 IF Error_Happened THEN EXIT FUNCTION
-                size = (sourcetyp AND 511) \ 8
+                size = (sourcetyp AND UDTMASK) \ 8
                 t = Type2MemTypeValue(sourcetyp)
                 evaluatetotyp$ = "(ptrszint)" + e$ + "," + _TOSTR$(size) + "," + _TOSTR$(t) + "," + _TOSTR$(size) + "," + dynmemlockexpr
                 EXIT FUNCTION
@@ -22653,7 +22654,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
         'Standard variable -> byte_element(offset,bytes)
         e$ = refer(e$, sourcetyp, 1) 'get the variable's formal name
         IF Error_Happened THEN EXIT FUNCTION
-        size = (sourcetyp AND 511) \ 8 'calculate its size in bytes
+        size = (sourcetyp AND UDTMASK) \ 8 'calculate its size in bytes
 
         t = Type2MemTypeValue(sourcetyp)
         evaluatetotyp$ = "(ptrszint)" + e$ + "," + _TOSTR$(size) + "," + _TOSTR$(t) + "," + _TOSTR$(size) + ",sf_mem_lock"
@@ -22788,7 +22789,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
             IF sourcetyp AND ISSTRING THEN
                 bytes = tsize
             ELSE
-                bytes = (sourcetyp AND 511) \ 8
+                bytes = (sourcetyp AND UDTMASK) \ 8
             END IF
             bytes$ = "(" + bytes$ + "-(" + _TOSTR$(bytes) + "*(" + index$ + ")))"
             evaluatetotyp$ = "byte_element((uint64)" + e$ + "," + bytes$ + "," + NewByteElement$ + ")"
@@ -22821,7 +22822,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
         'Standard variable -> byte_element(offset,bytes)
         e$ = refer(e$, sourcetyp, 1) 'get the variable's formal name
         IF Error_Happened THEN EXIT FUNCTION
-        size = (sourcetyp AND 511) \ 8 'calculate its size in bytes
+        size = (sourcetyp AND UDTMASK) \ 8 'calculate its size in bytes
         evaluatetotyp$ = "byte_element((uint64)" + e$ + "," + _TOSTR$(size) + "," + NewByteElement$ + ")"
         IF targettyp = -5 THEN evaluatetotyp$ = _TOSTR$(size)
         IF targettyp = -6 THEN evaluatetotyp$ = e$
@@ -22865,7 +22866,7 @@ FUNCTION evaluatetotyp$ (a2$, targettyp AS LONG)
     'round to integer if required
     IF (sourcetyp AND ISFLOAT) THEN
         IF (targettyp AND ISFLOAT) = 0 THEN
-            bits = targettyp AND 511
+            bits = targettyp AND UDTMASK
             '**32 rounding fix
             IF bits <= 16 THEN e$ = "qbr_float_to_long(" + e$ + ")"
             IF bits > 16 AND bits < 32 THEN e$ = "qbr_double_to_long(" + e$ + ")"
@@ -23686,7 +23687,7 @@ FUNCTION fixoperationorder_rec$ (savea$, bare_arrays)
 
                                     'floats returned by str$ must be converted to qb64 standard format
                                     IF t AND ISFLOAT THEN
-                                        t2 = t AND 511
+                                        t2 = t AND UDTMASK
                                         'find E,D or F
                                         s$ = ""
                                         IF INSTR(e$, "E") THEN s$ = "E"
@@ -23840,7 +23841,7 @@ FUNCTION fixoperationorder_rec$ (savea$, bare_arrays)
                                         fooudt:
 
                                         f$ = f$ + sp + "." + sp
-                                        udtElem = udtxnext(t AND 511) 'next element to check
+                                        udtElem = udtxnext(t AND UDTMASK) 'next element to check
                                         i = i + 2
 
                                         'loop
@@ -25306,7 +25307,7 @@ FUNCTION refer$ (a2$, typ AS LONG, method AS LONG)
 
         IF id.t = 0 AND CheckingOn THEN
             IF udtearrayelements(udtElem) THEN
-                guard_udt = id.arraytype AND 511
+                guard_udt = id.arraytype AND UDTMASK
                 guard_mode = 0
                 IF id.dynudt THEN guard_mode = id.dynudtmode
                 data_ref$ = UDTRootDataGuard$(arr_desc_expr$, guard_udt, guard_mode)
@@ -25363,9 +25364,9 @@ FUNCTION refer$ (a2$, typ AS LONG, method AS LONG)
 
         IF (typ AND ISOFFSETINBITS) THEN
             'IF (typ AND ISUNSIGNED) THEN r$ = "getubits_" ELSE r$ = "getbits_"
-            'r$ = r$ + _TOSTR$(typ AND 511) + "("
+            'r$ = r$ + _TOSTR$(typ AND UDTMASK) + "("
             IF (typ AND ISUNSIGNED) THEN r$ = "getubits" ELSE r$ = "getbits"
-            r$ = r$ + "(" + _TOSTR$(typ AND 511) + ","
+            r$ = r$ + "(" + _TOSTR$(typ AND UDTMASK) + ","
             r$ = r$ + "(uint8*)(" + n$ + "[0])" + ","
             r$ = r$ + a$ + ")"
             refer$ = r$
@@ -25373,21 +25374,21 @@ FUNCTION refer$ (a2$, typ AS LONG, method AS LONG)
         ELSE
             t$ = ""
             IF (typ AND ISFLOAT) THEN
-                IF (typ AND 511) = 32 THEN t$ = "float"
-                IF (typ AND 511) = 64 THEN t$ = "double"
-                IF (typ AND 511) = 256 THEN t$ = "long double"
+                IF (typ AND UDTMASK) = 32 THEN t$ = "float"
+                IF (typ AND UDTMASK) = 64 THEN t$ = "double"
+                IF (typ AND UDTMASK) = 256 THEN t$ = "long double"
             ELSE
                 IF (typ AND ISUNSIGNED) THEN
-                    IF (typ AND 511) = 8 THEN t$ = "uint8"
-                    IF (typ AND 511) = 16 THEN t$ = "uint16"
-                    IF (typ AND 511) = 32 THEN t$ = "uint32"
-                    IF (typ AND 511) = 64 THEN t$ = "uint64"
+                    IF (typ AND UDTMASK) = 8 THEN t$ = "uint8"
+                    IF (typ AND UDTMASK) = 16 THEN t$ = "uint16"
+                    IF (typ AND UDTMASK) = 32 THEN t$ = "uint32"
+                    IF (typ AND UDTMASK) = 64 THEN t$ = "uint64"
                     IF typ AND ISOFFSET THEN t$ = "uptrszint"
                 ELSE
-                    IF (typ AND 511) = 8 THEN t$ = "int8"
-                    IF (typ AND 511) = 16 THEN t$ = "int16"
-                    IF (typ AND 511) = 32 THEN t$ = "int32"
-                    IF (typ AND 511) = 64 THEN t$ = "int64"
+                    IF (typ AND UDTMASK) = 8 THEN t$ = "int8"
+                    IF (typ AND UDTMASK) = 16 THEN t$ = "int16"
+                    IF (typ AND UDTMASK) = 32 THEN t$ = "int32"
+                    IF (typ AND UDTMASK) = 64 THEN t$ = "int64"
                     IF typ AND ISOFFSET THEN t$ = "ptrszint"
                 END IF
             END IF
@@ -25414,9 +25415,9 @@ FUNCTION refer$ (a2$, typ AS LONG, method AS LONG)
         'bit-length single variable?
         IF (t AND ISOFFSETINBITS) THEN
             IF (t AND ISUNSIGNED) THEN
-                r$ = "*" + scope$ + "UBIT" + _TOSTR$(t AND 511) + "_" + r$
+                r$ = "*" + scope$ + "UBIT" + _TOSTR$(t AND UDTMASK) + "_" + r$
             ELSE
-                r$ = "*" + scope$ + "BIT" + _TOSTR$(t AND 511) + "_" + r$
+                r$ = "*" + scope$ + "BIT" + _TOSTR$(t AND UDTMASK) + "_" + r$
             END IF
             GOTO ref
         END IF
@@ -25715,11 +25716,11 @@ SUB copy_preserve_udt_varstrings (dstbase$, srcbase$, u AS LONG, dstoff$, srcoff
                     srcq$ = "(*(qbs**)(" + srcmember$ + "))"
                     acc$ = acc$ + CRLF + "qbs_set(" + dstq$ + "," + srcq$ + ");"
                 NEXT
-            ELSEIF (t AND ISUDT) <> 0 AND udtxvariable(t AND 511) THEN
+            ELSEIF (t AND ISUDT) <> 0 AND udtxvariable(t AND UDTMASK) THEN
                 FOR i = 0 TO udtearrayelements(e) - 1
                     nextdstoff$ = "((" + dstoff$ + ")+" + _TOSTR$(offbytes + i * elembytes) + ")"
                     nextsrcoff$ = "((" + srcoff$ + ")+" + _TOSTR$(offbytes + i * elembytes) + ")"
-                    copy_preserve_udt_varstrings dstbase$, srcbase$, t AND 511, nextdstoff$, nextsrcoff$, acc$
+                    copy_preserve_udt_varstrings dstbase$, srcbase$, t AND UDTMASK, nextdstoff$, nextsrcoff$, acc$
                 NEXT
             ELSE
                 dstmember$ = "((char*)(" + dstbase$ + ")+((" + dstoff$ + ")+" + _TOSTR$(offbytes) + "))"
@@ -25735,8 +25736,8 @@ SUB copy_preserve_udt_varstrings (dstbase$, srcbase$, u AS LONG, dstoff$, srcoff
                 dstq$ = "(*(qbs**)(" + dstmember$ + "))"
                 srcq$ = "(*(qbs**)(" + srcmember$ + "))"
                 acc$ = acc$ + CRLF + "qbs_set(" + dstq$ + "," + srcq$ + ");"
-            ELSEIF (t AND ISUDT) <> 0 AND udtxvariable(t AND 511) THEN
-                copy_preserve_udt_varstrings dstbase$, srcbase$, t AND 511, "((" + dstoff$ + ")+" + _TOSTR$(offbytes) + ")", "((" + srcoff$ + ")+" + _TOSTR$(offbytes) + ")", acc$
+            ELSEIF (t AND ISUDT) <> 0 AND udtxvariable(t AND UDTMASK) THEN
+                copy_preserve_udt_varstrings dstbase$, srcbase$, t AND UDTMASK, "((" + dstoff$ + ")+" + _TOSTR$(offbytes) + ")", "((" + srcoff$ + ")+" + _TOSTR$(offbytes) + ")", acc$
             ELSE
                 acc$ = acc$ + CRLF + "memcpy((void*)(" + dstmember$ + "),(void*)(" + srcmember$ + ")," + _TOSTR$(memberbytes) + ");"
             END IF
@@ -26407,10 +26408,10 @@ SUB setrefer (a2$, typ2 AS LONG, e2$, method AS LONG)
             IF (t2 AND ISREFERENCE) = 0 THEN
                 IF t2 AND ISPOINTER THEN
                     src$ = "((char*)" + e$ + ")"
-                    e2 = 0: u2 = t2 AND 511
+                    e2 = 0: u2 = t2 AND UDTMASK
                 ELSE
                     src$ = "((char*)&" + e$ + ")"
-                    e2 = 0: u2 = t2 AND 511
+                    e2 = 0: u2 = t2 AND UDTMASK
                 END IF
                 GOTO directudt
             END IF
@@ -26515,8 +26516,8 @@ SUB setrefer (a2$, typ2 AS LONG, e2$, method AS LONG)
         END IF
 
         IF (typ AND ISOFFSETINBITS) THEN
-            'r$ = "setbits_" + _TOSTR$(typ AND 511) + "("
-            r$ = "setbits(" + _TOSTR$(typ AND 511) + ","
+            'r$ = "setbits_" + _TOSTR$(typ AND UDTMASK) + "("
+            r$ = "setbits(" + _TOSTR$(typ AND UDTMASK) + ","
             r$ = r$ + "(uint8*)(" + n$ + "[0])" + ",tmp_long,"
             WriteBufLine MainTxtBuf, "tmp_long=" + a$ + ";"
             IF method = 0 THEN
@@ -26531,21 +26532,21 @@ SUB setrefer (a2$, typ2 AS LONG, e2$, method AS LONG)
         ELSE
             t$ = ""
             IF (typ AND ISFLOAT) THEN
-                IF (typ AND 511) = 32 THEN t$ = "float"
-                IF (typ AND 511) = 64 THEN t$ = "double"
-                IF (typ AND 511) = 256 THEN t$ = "long double"
+                IF (typ AND UDTMASK) = 32 THEN t$ = "float"
+                IF (typ AND UDTMASK) = 64 THEN t$ = "double"
+                IF (typ AND UDTMASK) = 256 THEN t$ = "long double"
             ELSE
                 IF (typ AND ISUNSIGNED) THEN
-                    IF (typ AND 511) = 8 THEN t$ = "uint8"
-                    IF (typ AND 511) = 16 THEN t$ = "uint16"
-                    IF (typ AND 511) = 32 THEN t$ = "uint32"
-                    IF (typ AND 511) = 64 THEN t$ = "uint64"
+                    IF (typ AND UDTMASK) = 8 THEN t$ = "uint8"
+                    IF (typ AND UDTMASK) = 16 THEN t$ = "uint16"
+                    IF (typ AND UDTMASK) = 32 THEN t$ = "uint32"
+                    IF (typ AND UDTMASK) = 64 THEN t$ = "uint64"
                     IF typ AND ISOFFSET THEN t$ = "uptrszint"
                 ELSE
-                    IF (typ AND 511) = 8 THEN t$ = "int8"
-                    IF (typ AND 511) = 16 THEN t$ = "int16"
-                    IF (typ AND 511) = 32 THEN t$ = "int32"
-                    IF (typ AND 511) = 64 THEN t$ = "int64"
+                    IF (typ AND UDTMASK) = 8 THEN t$ = "int8"
+                    IF (typ AND UDTMASK) = 16 THEN t$ = "int16"
+                    IF (typ AND UDTMASK) = 32 THEN t$ = "int32"
+                    IF (typ AND UDTMASK) = 64 THEN t$ = "int64"
                     IF typ AND ISOFFSET THEN t$ = "ptrszint"
                 END IF
             END IF
@@ -26591,15 +26592,15 @@ SUB setrefer (a2$, typ2 AS LONG, e2$, method AS LONG)
 
         'bit-length variable?
         IF (t AND ISOFFSETINBITS) THEN
-            b = t AND 511
+            b = t AND UDTMASK
             IF (t AND ISUNSIGNED) THEN
-                r$ = "*" + scope$ + "UBIT" + _TOSTR$(t AND 511) + "_" + r$
+                r$ = "*" + scope$ + "UBIT" + _TOSTR$(t AND UDTMASK) + "_" + r$
                 IF method = 0 THEN e$ = evaluatetotyp(e$, 64& + ISUNSIGNED)
                 IF Error_Happened THEN EXIT SUB
                 l$ = r$ + "=(" + e$ + ")&" + _TOSTR$(bitmask(b)) + ";"
                 WriteBufLine MainTxtBuf, l$
             ELSE
-                r$ = "*" + scope$ + "BIT" + _TOSTR$(t AND 511) + "_" + r$
+                r$ = "*" + scope$ + "BIT" + _TOSTR$(t AND UDTMASK) + "_" + r$
                 IF method = 0 THEN e$ = evaluatetotyp(e$, 64&)
                 IF Error_Happened THEN EXIT SUB
                 l$ = "if ((" + r$ + "=" + e$ + ")&" + _TOSTR$(2 ^ (b - 1)) + "){"
@@ -26905,11 +26906,11 @@ SUB xfileprint (a$, ca$, n)
 
                         ELSE 'not a string
                             IF typ AND ISFLOAT THEN
-                                IF (typ AND 511) = 32 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_single(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
-                                IF (typ AND 511) = 64 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_double(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
-                                IF (typ AND 511) > 64 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_float(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
+                                IF (typ AND UDTMASK) = 32 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_single(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
+                                IF (typ AND UDTMASK) = 64 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_double(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
+                                IF (typ AND UDTMASK) > 64 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_float(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
                             ELSE
-                                IF ((typ AND 511) = 64) AND (typ AND ISUNSIGNED) <> 0 THEN
+                                IF ((typ AND UDTMASK) = 64) AND (typ AND ISUNSIGNED) <> 0 THEN
                                     WriteBufLine MainTxtBuf, "tmp_long=print_using_uinteger64(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
                                 ELSE
                                     WriteBufLine MainTxtBuf, "tmp_long=print_using_integer64(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
@@ -27350,11 +27351,11 @@ SUB xprint (a$, ca$, n)
 
                         ELSE 'not a string
                             IF typ AND ISFLOAT THEN
-                                IF (typ AND 511) = 32 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_single(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
-                                IF (typ AND 511) = 64 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_double(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
-                                IF (typ AND 511) > 64 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_float(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
+                                IF (typ AND UDTMASK) = 32 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_single(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
+                                IF (typ AND UDTMASK) = 64 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_double(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
+                                IF (typ AND UDTMASK) > 64 THEN WriteBufLine MainTxtBuf, "tmp_long=print_using_float(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
                             ELSE
-                                IF ((typ AND 511) = 64) AND (typ AND ISUNSIGNED) <> 0 THEN
+                                IF ((typ AND UDTMASK) = 64) AND (typ AND ISUNSIGNED) <> 0 THEN
                                     WriteBufLine MainTxtBuf, "tmp_long=print_using_uinteger64(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
                                 ELSE
                                     WriteBufLine MainTxtBuf, "tmp_long=print_using_integer64(" + puf$ + "," + e$ + ",tmp_long,tqbs);"
@@ -27501,7 +27502,7 @@ SUB xread (ca$, n)
                 stringprocessinghappened = 1
             ELSE
                 'numeric variable
-                IF (t AND ISFLOAT) <> 0 OR (t AND 511) <> 64 THEN
+                IF (t AND ISFLOAT) <> 0 OR (t AND UDTMASK) <> 64 THEN
                     IF (t AND ISOFFSETINBITS) THEN
                         setrefer e$, t, "((int64)func_read_float(data,&data_offset,data_size," + _TOSTR$(t) + "))", 1
                         IF Error_Happened THEN EXIT SUB

--- a/source/utilities/type.bas
+++ b/source/utilities/type.bas
@@ -20,7 +20,7 @@ SUB AppendDynUDTDescNullSlots (rootptr$, udt AS LONG, off$, acc$, layout_mode AS
             dynoffbytes = dynbitpos \ 8
             acc$ = acc$ + "*((ptrszint**)(((uint8*)(" + rootptr$ + "))+(" + off$ + "+" + _TOSTR$(dynoffbytes) + ")))=NULL;" + CHR$(13) + CHR$(10)
         ELSEIF (udtetype(elemnum) AND ISUDT) <> 0 THEN
-            nestedudt = udtetype(elemnum) AND 511
+            nestedudt = udtetype(elemnum) AND UDTMASK
             IF UDTDynHasMemberArrays%(nestedudt, layout_mode) THEN
                 IF dynbitpos MOD 8 THEN Give_Error "Non-byte aligned user defined type": EXIT SUB
                 dynoffbytes = dynbitpos \ 8
@@ -68,7 +68,7 @@ SUB AppendDynUDTDescCopy (dstbase$, srcbase$, udt AS LONG, dstoff$, srcoff$, byt
             nestedudt = 0
             elemudtvarstr = 0
             IF (udtetype(elemnum) AND ISUDT) <> 0 THEN
-                nestedudt = udtetype(elemnum) AND 511
+                nestedudt = udtetype(elemnum) AND UDTMASK
                 IF udtxvariable(nestedudt) THEN elemudtvarstr = -1
             END IF
 
@@ -163,7 +163,7 @@ SUB AppendDynUDTDescCopy (dstbase$, srcbase$, udt AS LONG, dstoff$, srcoff$, byt
             copycode = copycode + "}" + CHR$(13) + CHR$(10)
             acc$ = acc$ + copycode
         ELSEIF (udtetype(elemnum) AND ISUDT) <> 0 THEN
-            nestedudt = udtetype(elemnum) AND 511
+            nestedudt = udtetype(elemnum) AND UDTMASK
             IF UDTDynHasMemberArrays%(nestedudt, layout_mode) THEN
                 IF dynbitpos MOD 8 THEN Give_Error "Non-byte aligned user defined type": EXIT SUB
                 dynoffbytes = dynbitpos \ 8
@@ -215,7 +215,7 @@ FUNCTION typevalue2symbol$ (t)
 
     IF t AND ISUNSIGNED THEN s$ = "~"
 
-    b = t AND 511
+    b = t AND UDTMASK
 
     IF t AND ISOFFSETINBITS THEN
         IF b > 1 THEN s$ = s$ + "`" + _TOSTR$(b) ELSE s$ = s$ + "`"
@@ -243,9 +243,9 @@ FUNCTION id2fulltypename$
     t = id.t
     IF t = 0 THEN t = id.arraytype
     size = id.tsize
-    bits = t AND 511
+    bits = t AND UDTMASK
     IF t AND ISUDT THEN
-        a$ = RTRIM$(udtxcname(t AND 511))
+        a$ = RTRIM$(udtxcname(t AND UDTMASK))
         id2fulltypename$ = a$: EXIT FUNCTION
     END IF
     IF t AND ISSTRING THEN
@@ -279,9 +279,9 @@ FUNCTION id2shorttypename$
     t = id.t
     IF t = 0 THEN t = id.arraytype
     size = id.tsize
-    bits = t AND 511
+    bits = t AND UDTMASK
     IF t AND ISUDT THEN
-        a$ = RTRIM$(udtxcname(t AND 511))
+        a$ = RTRIM$(udtxcname(t AND UDTMASK))
         id2shorttypename$ = a$: EXIT FUNCTION
     END IF
     IF t AND ISSTRING THEN
@@ -461,7 +461,7 @@ FUNCTION typ2ctyp$ (t AS LONG, tstr AS STRING)
     IF tstr$ = "" THEN
         IF (t AND ISARRAY) THEN EXIT FUNCTION 'cannot return array types
         IF (t AND ISSTRING) THEN typ2ctyp$ = "qbs": EXIT FUNCTION
-        b = t AND 511
+        b = t AND UDTMASK
         IF (t AND ISUDT) THEN typ2ctyp$ = "void": EXIT FUNCTION
         IF (t AND ISOFFSETINBITS) THEN
             IF b <= 32 THEN ctyp$ = "int32" ELSE ctyp$ = "int64"
@@ -847,7 +847,7 @@ SUB BuildUDTDynLayoutM (udt_index AS LONG, layout_mode AS LONG)
 
     member_id = udtxnext(udt_index)
     dynbits = 0
-    ptrbits = OFFSETTYPE AND 511
+    ptrbits = OFFSETTYPE AND UDTMASK
 
     DO WHILE member_id
         IF layout_mode = 1 THEN
@@ -863,7 +863,7 @@ SUB BuildUDTDynLayoutM (udt_index AS LONG, layout_mode AS LONG)
             membersize = ptrbits
         ELSEIF udtearrayelements(member_id) THEN
             IF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 IF UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                     membersize = udtearrayelements(member_id) * UDTDynLayoutSize&(nested_udt, layout_mode)
                 ELSE
@@ -873,7 +873,7 @@ SUB BuildUDTDynLayoutM (udt_index AS LONG, layout_mode AS LONG)
                 membersize = udtesize(member_id)
             END IF
         ELSEIF udtetype(member_id) AND ISUDT THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             IF UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                 membersize = UDTDynLayoutSize&(nested_udt, layout_mode)
             ELSE
@@ -914,7 +914,7 @@ FUNCTION UDTDynHasMemberArrays% (udt_index AS LONG, layout_mode AS LONG)
             EXIT FUNCTION
         END IF
         IF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             IF UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                 UDTDynHasMemberArrays% = -1
                 EXIT FUNCTION
@@ -940,7 +940,7 @@ FUNCTION UDTDynHasRunArrays% (udt_index AS LONG, layout_mode AS LONG)
             END IF
         END IF
         IF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             IF UDTDynHasRunArrays%(nested_udt, layout_mode) THEN
                 UDTDynHasRunArrays% = -1
                 EXIT FUNCTION
@@ -988,7 +988,7 @@ FUNCTION UDTDynMembersOK% (udt_index AS LONG, layout_mode AS LONG)
                 END IF
             END IF
             IF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 ' A descriptor-backed UDT array whose element owns variable strings needs
                 ' the recursive owner helpers. Keep that path explicit so ordinary inline
                 ' UDT arrays remain compatible with legacy layout.
@@ -1024,7 +1024,7 @@ FUNCTION UDTDynMembersOK% (udt_index AS LONG, layout_mode AS LONG)
                 EXIT FUNCTION
             END IF
         ELSEIF udtetype(member_id) AND ISUDT THEN
-            IF UDTDynMembersOK%(udtetype(member_id) AND 511, layout_mode) = 0 THEN
+            IF UDTDynMembersOK%(udtetype(member_id) AND UDTMASK, layout_mode) = 0 THEN
                 UDTDynMembersOK% = 0
                 EXIT FUNCTION
             END IF
@@ -1054,7 +1054,7 @@ FUNCTION DynMemUDTVarStr% (member_id AS LONG)
     IF udtearrayelements(member_id) = 0 THEN EXIT FUNCTION
     IF udtearrayfieldmode(member_id) <> 2 THEN EXIT FUNCTION
     IF (udtetype(member_id) AND ISUDT) = 0 THEN EXIT FUNCTION
-    nested_udt = udtetype(member_id) AND 511
+    nested_udt = udtetype(member_id) AND UDTMASK
     IF udtxvariable(nested_udt) = 0 THEN EXIT FUNCTION
     DynMemUDTVarStr% = -1
 END FUNCTION
@@ -1075,7 +1075,7 @@ FUNCTION UDTDynHasVarDesc% (udt_index AS LONG, layout_mode AS LONG)
                 EXIT FUNCTION
             END IF
             IF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 IF udtxvariable(nested_udt) THEN
                     UDTDynHasVarDesc% = -1
                     EXIT FUNCTION
@@ -1086,7 +1086,7 @@ FUNCTION UDTDynHasVarDesc% (udt_index AS LONG, layout_mode AS LONG)
                 END IF
             END IF
         ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             IF UDTDynHasVarDesc%(nested_udt, layout_mode) THEN
                 UDTDynHasVarDesc% = -1
                 EXIT FUNCTION
@@ -1113,7 +1113,7 @@ FUNCTION UDTDynOwnerOK% (udt_index AS LONG, layout_mode AS LONG)
             'The descriptor helpers initialize/free/copy the qbs* element slots, while
             '_MEM and PUT/GET remain rejected through the existing variable-string guards.
             IF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 ' A descriptor-backed _Dynamic AS UDT element may itself be an owner
                 ' layout. The recursive owner lifecycle helpers below now initialize, free and
                 ' copy scalar variable STRINGs, _Dynamic AS STRING payloads, and nested
@@ -1137,7 +1137,7 @@ FUNCTION UDTDynOwnerOK% (udt_index AS LONG, layout_mode AS LONG)
             ' member arrays. Unsupported descriptor-owning member types are still rejected
             ' when their own _Dynamic member is visited.
         ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             IF UDTDynOwnerOK%(nested_udt, layout_mode) = 0 THEN
                 UDTDynOwnerOK% = 0
                 EXIT FUNCTION
@@ -1188,7 +1188,7 @@ SUB AppendDynUDTVarInitAt (base_expr AS STRING, udt_index AS LONG, root_offset A
                         acc = acc + cr + "*(qbs**)(((uint8*)(" + base_expr + "))+" + elem_bytes + "*(" + index_expr + ")+" + LTRIM$(STR$(array_offset)) + ")=qbs_new(0,0);"
                     END IF
                 ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                    nested_udt = udtetype(member_id) AND 511
+                    nested_udt = udtetype(member_id) AND UDTMASK
                     AppendDynUDTVarInitAt base_expr, nested_udt, array_offset, elem_bytes, index_expr, acc
                 END IF
             NEXT
@@ -1197,7 +1197,7 @@ SUB AppendDynUDTVarInitAt (base_expr AS STRING, udt_index AS LONG, root_offset A
                 acc = acc + cr + "*(qbs**)(((uint8*)(" + base_expr + "))+" + elem_bytes + "*(" + index_expr + ")+" + LTRIM$(STR$(member_offset)) + ")=qbs_new(0,0);"
             END IF
         ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             AppendDynUDTVarInitAt base_expr, nested_udt, member_offset, elem_bytes, index_expr, acc
         END IF
         member_offset = member_offset + udtesize(member_id) \ 8
@@ -1230,7 +1230,7 @@ SUB AppendDynUDTVarFreeAt (base_expr AS STRING, udt_index AS LONG, root_offset A
                         acc = acc + cr + "qbs_free(*(qbs**)(((uint8*)(" + base_expr + "))+" + elem_bytes + "*(" + index_expr + ")+" + LTRIM$(STR$(array_offset)) + "));"
                     END IF
                 ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                    nested_udt = udtetype(member_id) AND 511
+                    nested_udt = udtetype(member_id) AND UDTMASK
                     AppendDynUDTVarFreeAt base_expr, nested_udt, array_offset, elem_bytes, index_expr, acc
                 END IF
             NEXT
@@ -1239,7 +1239,7 @@ SUB AppendDynUDTVarFreeAt (base_expr AS STRING, udt_index AS LONG, root_offset A
                 acc = acc + cr + "qbs_free(*(qbs**)(((uint8*)(" + base_expr + "))+" + elem_bytes + "*(" + index_expr + ")+" + LTRIM$(STR$(member_offset)) + "));"
             END IF
         ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             AppendDynUDTVarFreeAt base_expr, nested_udt, member_offset, elem_bytes, index_expr, acc
         END IF
         member_offset = member_offset + udtesize(member_id) \ 8
@@ -1275,7 +1275,7 @@ SUB AppendDynUDTVarSetAt (dst_expr AS STRING, src_expr AS STRING, udt_index AS L
                     acc = acc + cr + "{qbs **dyn_udt_qbs_dst=(qbs**)(((uint8*)(" + dst_expr + "))+" + elem_bytes + "*(" + dst_index + ")+" + LTRIM$(STR$(dst_array_offset)) + "); qbs *dyn_udt_qbs_src=*(qbs**)(((uint8*)(" + src_expr + "))+" + elem_bytes + "*(" + src_index + ")+" + LTRIM$(STR$(src_array_offset)) + "); if(!*dyn_udt_qbs_dst) *dyn_udt_qbs_dst=qbs_new(0,0); if(dyn_udt_qbs_src) qbs_set(*dyn_udt_qbs_dst,dyn_udt_qbs_src);}" 
                 NEXT
             ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 IF udtxvariable(nested_udt) THEN
                     FOR array_idx = 0 TO udtearrayelements(member_id) - 1
                         dst_array_offset = dst_offset + array_idx * elem_step
@@ -1291,7 +1291,7 @@ SUB AppendDynUDTVarSetAt (dst_expr AS STRING, src_expr AS STRING, udt_index AS L
         ELSEIF ((udtetype(member_id) AND ISSTRING) <> 0) AND ((udtetype(member_id) AND ISFIXEDLENGTH) = 0) THEN
             acc = acc + cr + "{qbs **dyn_udt_qbs_dst=(qbs**)(((uint8*)(" + dst_expr + "))+" + elem_bytes + "*(" + dst_index + ")+" + LTRIM$(STR$(dst_offset)) + "); qbs *dyn_udt_qbs_src=*(qbs**)(((uint8*)(" + src_expr + "))+" + elem_bytes + "*(" + src_index + ")+" + LTRIM$(STR$(src_offset)) + "); if(!*dyn_udt_qbs_dst) *dyn_udt_qbs_dst=qbs_new(0,0); if(dyn_udt_qbs_src) qbs_set(*dyn_udt_qbs_dst,dyn_udt_qbs_src);}" 
         ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             IF udtxvariable(nested_udt) THEN
                 AppendDynUDTVarSetAt dst_expr, src_expr, nested_udt, dst_offset, src_offset, elem_bytes, dst_index, src_index, acc
             ELSE
@@ -1371,7 +1371,7 @@ SUB AppendDynUDTOwnInitAt (base_expr AS STRING, udt_index AS LONG, root_offset A
                     acc = acc + cr + "*(qbs**)(((uint8*)(" + base_expr + "))+" + elem_bytes + "*(" + index_expr + ")+" + LTRIM$(STR$(array_offset)) + ")=qbs_new(0,0);"
                 NEXT
             ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 IF udtxvariable(nested_udt) OR UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                     FOR array_idx = 0 TO udtearrayelements(member_id) - 1
                         array_offset = member_offset + array_idx * elem_step
@@ -1383,7 +1383,7 @@ SUB AppendDynUDTOwnInitAt (base_expr AS STRING, udt_index AS LONG, root_offset A
         ELSEIF ((udtetype(member_id) AND ISSTRING) <> 0) AND ((udtetype(member_id) AND ISFIXEDLENGTH) = 0) THEN
             acc = acc + cr + "*(qbs**)(((uint8*)(" + base_expr + "))+" + elem_bytes + "*(" + index_expr + ")+" + LTRIM$(STR$(member_offset)) + ")=qbs_new(0,0);"
         ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             IF udtxvariable(nested_udt) OR UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                 AppendDynUDTOwnInitAt base_expr, nested_udt, member_offset, elem_bytes, index_expr, acc, prep_prefix, layout_mode
                 IF Error_Happened THEN EXIT SUB
@@ -1425,7 +1425,7 @@ SUB AppendDynUDTOwnFreeAt (base_expr AS STRING, udt_index AS LONG, root_offset A
                     acc = acc + cr + "qbs_free(*(qbs**)(((uint8*)(" + base_expr + "))+" + elem_bytes + "*(" + index_expr + ")+" + LTRIM$(STR$(array_offset)) + "));"
                 NEXT
             ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 IF udtxvariable(nested_udt) OR UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                     FOR array_idx = 0 TO udtearrayelements(member_id) - 1
                         array_offset = member_offset + array_idx * elem_step
@@ -1437,7 +1437,7 @@ SUB AppendDynUDTOwnFreeAt (base_expr AS STRING, udt_index AS LONG, root_offset A
         ELSEIF ((udtetype(member_id) AND ISSTRING) <> 0) AND ((udtetype(member_id) AND ISFIXEDLENGTH) = 0) THEN
             acc = acc + cr + "qbs_free(*(qbs**)(((uint8*)(" + base_expr + "))+" + elem_bytes + "*(" + index_expr + ")+" + LTRIM$(STR$(member_offset)) + "));"
         ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             IF udtxvariable(nested_udt) OR UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                 AppendDynUDTOwnFreeAt base_expr, nested_udt, member_offset, elem_bytes, index_expr, acc, layout_mode
                 IF Error_Happened THEN EXIT SUB
@@ -1472,7 +1472,7 @@ SUB AppendDynUDTOwnSetAt (dst_expr AS STRING, src_expr AS STRING, udt_index AS L
         IF UDTMemberDynDesc%(member_id, layout_mode) THEN
             member_elem_bytes = udt_dyn_array_elem_bytes(member_id, layout_mode)
             nested_udt = 0
-            IF (udtetype(member_id) AND ISUDT) <> 0 THEN nested_udt = udtetype(member_id) AND 511
+            IF (udtetype(member_id) AND ISUDT) <> 0 THEN nested_udt = udtetype(member_id) AND UDTMASK
             dst_slot = "((uint8*)" + dst_expr + "+" + elem_bytes + "*(" + dst_index + ")+" + LTRIM$(STR$(dst_offset)) + ")"
             src_slot = "((uint8*)" + src_expr + "+" + elem_bytes + "*(" + src_index + ")+" + LTRIM$(STR$(src_offset)) + ")"
             AppendDynMemberEraseEx dst_slot, member_elem_bytes, nested_udt, DynMemVarStr%(member_id), acc, layout_mode
@@ -1488,7 +1488,7 @@ SUB AppendDynUDTOwnSetAt (dst_expr AS STRING, src_expr AS STRING, udt_index AS L
                     acc = acc + cr + "{qbs **dyn_udt_qbs_dst=(qbs**)(((uint8*)(" + dst_expr + "))+" + elem_bytes + "*(" + dst_index + ")+" + LTRIM$(STR$(dst_array_offset)) + "); qbs *dyn_udt_qbs_src=*(qbs**)(((uint8*)(" + src_expr + "))+" + elem_bytes + "*(" + src_index + ")+" + LTRIM$(STR$(src_array_offset)) + "); if(!*dyn_udt_qbs_dst) *dyn_udt_qbs_dst=qbs_new(0,0); if(dyn_udt_qbs_src) qbs_set(*dyn_udt_qbs_dst,dyn_udt_qbs_src);}" 
                 NEXT
             ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 FOR array_idx = 0 TO udtearrayelements(member_id) - 1
                     dst_array_offset = dst_offset + array_idx * elem_step
                     src_array_offset = src_offset + array_idx * elem_step
@@ -1505,7 +1505,7 @@ SUB AppendDynUDTOwnSetAt (dst_expr AS STRING, src_expr AS STRING, udt_index AS L
         ELSEIF ((udtetype(member_id) AND ISSTRING) <> 0) AND ((udtetype(member_id) AND ISFIXEDLENGTH) = 0) THEN
             acc = acc + cr + "{qbs **dyn_udt_qbs_dst=(qbs**)(((uint8*)(" + dst_expr + "))+" + elem_bytes + "*(" + dst_index + ")+" + LTRIM$(STR$(dst_offset)) + "); qbs *dyn_udt_qbs_src=*(qbs**)(((uint8*)(" + src_expr + "))+" + elem_bytes + "*(" + src_index + ")+" + LTRIM$(STR$(src_offset)) + "); if(!*dyn_udt_qbs_dst) *dyn_udt_qbs_dst=qbs_new(0,0); if(dyn_udt_qbs_src) qbs_set(*dyn_udt_qbs_dst,dyn_udt_qbs_src);}" 
         ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             IF udtxvariable(nested_udt) OR UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                 AppendDynUDTOwnSetAt dst_expr, src_expr, nested_udt, dst_offset, src_offset, elem_bytes, dst_index, src_index, acc, layout_mode
             ELSE
@@ -1547,7 +1547,7 @@ SUB AppendDynUDTOwnCloneAt (dst_expr AS STRING, src_expr AS STRING, udt_index AS
         IF UDTMemberDynDesc%(member_id, layout_mode) THEN
             member_elem_bytes = udt_dyn_array_elem_bytes(member_id, layout_mode)
             nested_udt = 0
-            IF (udtetype(member_id) AND ISUDT) <> 0 THEN nested_udt = udtetype(member_id) AND 511
+            IF (udtetype(member_id) AND ISUDT) <> 0 THEN nested_udt = udtetype(member_id) AND UDTMASK
             dst_slot = "((uint8*)" + dst_expr + "+" + elem_bytes + "*(" + dst_index + ")+" + LTRIM$(STR$(dst_offset)) + ")"
             src_slot = "((uint8*)" + src_expr + "+" + elem_bytes + "*(" + src_index + ")+" + LTRIM$(STR$(src_offset)) + ")"
             AppendDynMemberCloneAfterRaw src_slot, dst_slot, member_elem_bytes, nested_udt, DynMemVarStr%(member_id), acc, layout_mode
@@ -1561,7 +1561,7 @@ SUB AppendDynUDTOwnCloneAt (dst_expr AS STRING, src_expr AS STRING, udt_index AS
                     acc = acc + cr + "{qbs **dyn_udt_qbs_dst=(qbs**)(((uint8*)(" + dst_expr + "))+" + elem_bytes + "*(" + dst_index + ")+" + LTRIM$(STR$(dst_array_offset)) + "); qbs *dyn_udt_qbs_src=*(qbs**)(((uint8*)(" + src_expr + "))+" + elem_bytes + "*(" + src_index + ")+" + LTRIM$(STR$(src_array_offset)) + "); if(!*dyn_udt_qbs_dst) *dyn_udt_qbs_dst=qbs_new(0,0); if(dyn_udt_qbs_src) qbs_set(*dyn_udt_qbs_dst,dyn_udt_qbs_src);}" 
                 NEXT
             ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 FOR array_idx = 0 TO udtearrayelements(member_id) - 1
                     dst_array_offset = dst_offset + array_idx * elem_step
                     src_array_offset = src_offset + array_idx * elem_step
@@ -1578,7 +1578,7 @@ SUB AppendDynUDTOwnCloneAt (dst_expr AS STRING, src_expr AS STRING, udt_index AS
         ELSEIF ((udtetype(member_id) AND ISSTRING) <> 0) AND ((udtetype(member_id) AND ISFIXEDLENGTH) = 0) THEN
             acc = acc + cr + "{qbs **dyn_udt_qbs_dst=(qbs**)(((uint8*)(" + dst_expr + "))+" + elem_bytes + "*(" + dst_index + ")+" + LTRIM$(STR$(dst_offset)) + "); qbs *dyn_udt_qbs_src=*(qbs**)(((uint8*)(" + src_expr + "))+" + elem_bytes + "*(" + src_index + ")+" + LTRIM$(STR$(src_offset)) + "); if(!*dyn_udt_qbs_dst) *dyn_udt_qbs_dst=qbs_new(0,0); if(dyn_udt_qbs_src) qbs_set(*dyn_udt_qbs_dst,dyn_udt_qbs_src);}" 
         ELSEIF (udtetype(member_id) AND ISUDT) <> 0 THEN
-            nested_udt = udtetype(member_id) AND 511
+            nested_udt = udtetype(member_id) AND UDTMASK
             IF udtxvariable(nested_udt) OR UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                 AppendDynUDTOwnCloneAt dst_expr, src_expr, nested_udt, dst_offset, src_offset, elem_bytes, dst_index, src_index, acc, layout_mode
             ELSE
@@ -1739,7 +1739,7 @@ SUB AppendDynUDTDescInitAt (data_expr AS STRING, udt_index AS LONG, root_offset 
             END IF
 
             IF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 IF DynMemUDTVarStr%(member_id) OR UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                     elem_idx = "dyn_udt_own_m" + LTRIM$(STR$(member_id))
                     acc = acc + cr + "for(ptrszint " + elem_idx + "=0;" + elem_idx + "<" + total_expr + ";" + elem_idx + "++){"
@@ -1752,7 +1752,7 @@ SUB AppendDynUDTDescInitAt (data_expr AS STRING, udt_index AS LONG, root_offset 
             acc = acc + cr + "}"
         ELSEIF udtearrayelements(member_id) THEN
             IF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 IF UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                     inline_bytes = UDTDynInlineElemBytes&(member_id, layout_mode)
                     FOR array_idx = 0 TO udtearrayelements(member_id) - 1
@@ -1763,7 +1763,7 @@ SUB AppendDynUDTDescInitAt (data_expr AS STRING, udt_index AS LONG, root_offset 
                 END IF
             END IF
         ELSEIF udtetype(member_id) AND ISUDT THEN
-            AppendDynUDTDescInitAt data_expr, udtetype(member_id) AND 511, member_offset, bytesperelement, index_expr, acc, prep_prefix, layout_mode
+            AppendDynUDTDescInitAt data_expr, udtetype(member_id) AND UDTMASK, member_offset, bytesperelement, index_expr, acc, prep_prefix, layout_mode
             IF Error_Happened THEN EXIT SUB
         END IF
 
@@ -1869,12 +1869,12 @@ SUB AppendDynUDTDescFreeAt (data_expr AS STRING, udt_index AS LONG, root_offset 
             member_slot = "((uint8*)(" + data_expr + ")+" + bytesperelement + "*(" + index_expr + ")+" + LTRIM$(STR$(member_offset)) + ")"
             elem_bytes = udt_dyn_array_elem_bytes(member_id, layout_mode)
             nested_udt = 0
-            IF (udtetype(member_id) AND ISUDT) <> 0 THEN nested_udt = udtetype(member_id) AND 511
+            IF (udtetype(member_id) AND ISUDT) <> 0 THEN nested_udt = udtetype(member_id) AND UDTMASK
             AppendDynMemberEraseEx member_slot, elem_bytes, nested_udt, DynMemVarStr%(member_id), acc, layout_mode
             IF Error_Happened THEN EXIT SUB
         ELSEIF udtearrayelements(member_id) THEN
             IF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 IF UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                     inline_bytes = UDTDynInlineElemBytes&(member_id, layout_mode)
                     FOR array_idx = 0 TO udtearrayelements(member_id) - 1
@@ -1885,7 +1885,7 @@ SUB AppendDynUDTDescFreeAt (data_expr AS STRING, udt_index AS LONG, root_offset 
                 END IF
             END IF
         ELSEIF udtetype(member_id) AND ISUDT THEN
-            AppendDynUDTDescFreeAt data_expr, udtetype(member_id) AND 511, member_offset, bytesperelement, index_expr, acc, layout_mode
+            AppendDynUDTDescFreeAt data_expr, udtetype(member_id) AND UDTMASK, member_offset, bytesperelement, index_expr, acc, layout_mode
             IF Error_Happened THEN EXIT SUB
         END IF
 
@@ -2035,14 +2035,14 @@ SUB AppendDynUDTDescCloneAfterRaw (src_base AS STRING, dst_base AS STRING, udt_i
         IF UDTMemberDynDesc%(member_id, layout_mode) THEN
             elem_bytes = udt_dyn_array_elem_bytes(member_id, layout_mode)
             nested_udt = 0
-            IF (udtetype(member_id) AND ISUDT) <> 0 THEN nested_udt = udtetype(member_id) AND 511
+            IF (udtetype(member_id) AND ISUDT) <> 0 THEN nested_udt = udtetype(member_id) AND UDTMASK
             src_slot = "((uint8*)" + src_base + "+" + bytesperelement + "*(" + src_index + ")+" + LTRIM$(STR$(member_offset)) + ")"
             dst_slot = "((uint8*)" + dst_base + "+" + bytesperelement + "*(" + dst_index + ")+" + LTRIM$(STR$(member_offset)) + ")"
             AppendDynMemberCloneAfterRaw src_slot, dst_slot, elem_bytes, nested_udt, DynMemVarStr%(member_id), acc, layout_mode
             IF Error_Happened THEN EXIT SUB
         ELSEIF udtearrayelements(member_id) THEN
             IF (udtetype(member_id) AND ISUDT) <> 0 THEN
-                nested_udt = udtetype(member_id) AND 511
+                nested_udt = udtetype(member_id) AND UDTMASK
                 IF UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
                     inline_bytes = UDTDynInlineElemBytes&(member_id, layout_mode)
                     FOR array_idx = 0 TO udtearrayelements(member_id) - 1
@@ -2053,7 +2053,7 @@ SUB AppendDynUDTDescCloneAfterRaw (src_base AS STRING, dst_base AS STRING, udt_i
                 END IF
             END IF
         ELSEIF udtetype(member_id) AND ISUDT THEN
-            AppendDynUDTDescCloneAfterRaw src_base, dst_base, udtetype(member_id) AND 511, member_offset, bytesperelement, src_index, dst_index, acc, layout_mode
+            AppendDynUDTDescCloneAfterRaw src_base, dst_base, udtetype(member_id) AND UDTMASK, member_offset, bytesperelement, src_index, dst_index, acc, layout_mode
             IF Error_Happened THEN EXIT SUB
         END IF
 
@@ -2245,7 +2245,7 @@ END SUB
 FUNCTION udt_dyn_array_elem_bytes& (element, layout_mode AS LONG)
     IF udtearrayelements(element) = 0 THEN EXIT FUNCTION
     IF (udtetype(element) AND ISUDT) <> 0 THEN
-        udt_dyn_array_elem_bytes& = UDTDynLayoutSize&(udtetype(element) AND 511, layout_mode) \ 8
+        udt_dyn_array_elem_bytes& = UDTDynLayoutSize&(udtetype(element) AND UDTMASK, layout_mode) \ 8
     ELSE
         udt_dyn_array_elem_bytes& = (udtesize(element) \ 8) \ udtearrayelements(element)
     END IF
@@ -2259,7 +2259,7 @@ FUNCTION UDTDynInlineElemBytes& (element, layout_mode AS LONG)
 
     IF udtearrayelements(element) = 0 THEN EXIT FUNCTION
     IF (udtetype(element) AND ISUDT) <> 0 THEN
-        nested_udt = udtetype(element) AND 511
+        nested_udt = udtetype(element) AND UDTMASK
         IF UDTDynHasMemberArrays%(nested_udt, layout_mode) THEN
             UDTDynInlineElemBytes& = UDTDynLayoutSize&(nested_udt, layout_mode) \ 8
         ELSE
@@ -2289,7 +2289,7 @@ SUB initialise_udt_varstrings (n$, udt, buf, base_offset)
                         WriteBufLine buf, "*(qbs**)(((char*)" + n$ + ")+" + STR$(array_offset) + ") = qbs_new(0,0);"
                     END IF
                 ELSEIF udtetype(element) AND ISUDT THEN
-                    initialise_udt_varstrings n$, udtetype(element) AND 511, buf, array_offset
+                    initialise_udt_varstrings n$, udtetype(element) AND UDTMASK, buf, array_offset
                 END IF
             NEXT
         ELSEIF udtetype(element) AND ISSTRING THEN
@@ -2297,7 +2297,7 @@ SUB initialise_udt_varstrings (n$, udt, buf, base_offset)
                 WriteBufLine buf, "*(qbs**)(((char*)" + n$ + ")+" + STR$(offset) + ") = qbs_new(0,0);"
             END IF
         ELSEIF udtetype(element) AND ISUDT THEN
-            initialise_udt_varstrings n$, udtetype(element) AND 511, buf, offset
+            initialise_udt_varstrings n$, udtetype(element) AND UDTMASK, buf, offset
         END IF
         offset = offset + udtesize(element) \ 8
         element = udtenext(element)
@@ -2318,7 +2318,7 @@ SUB free_udt_varstrings (n$, udt, buf, base_offset)
                         WriteBufLine buf, "qbs_free(*((qbs**)(((char*)" + n$ + ")+" + STR$(array_offset) + ")));"
                     END IF
                 ELSEIF udtetype(element) AND ISUDT THEN
-                    free_udt_varstrings n$, udtetype(element) AND 511, buf, array_offset
+                    free_udt_varstrings n$, udtetype(element) AND UDTMASK, buf, array_offset
                 END IF
             NEXT
         ELSEIF udtetype(element) AND ISSTRING THEN
@@ -2326,7 +2326,7 @@ SUB free_udt_varstrings (n$, udt, buf, base_offset)
                 WriteBufLine buf, "qbs_free(*((qbs**)(((char*)" + n$ + ")+" + STR$(offset) + ")));"
             END IF
         ELSEIF udtetype(element) AND ISUDT THEN
-            free_udt_varstrings n$, udtetype(element) AND 511, buf, offset
+            free_udt_varstrings n$, udtetype(element) AND UDTMASK, buf, offset
         END IF
         offset = offset + udtesize(element) \ 8
         element = udtenext(element)
@@ -2353,7 +2353,7 @@ SUB clear_udt_with_varstrings (n$, udt, buf, base_offset)
             ELSEIF udtetype(element) AND ISUDT THEN
                 FOR array_i = 0 TO udtearrayelements(element) - 1
                     array_offset = offset + array_i * elem_bytes
-                    clear_udt_with_varstrings n$, udtetype(element) AND 511, buf, array_offset
+                    clear_udt_with_varstrings n$, udtetype(element) AND UDTMASK, buf, array_offset
                 NEXT
             ELSE
                 WriteBufLine buf, "memset((char*)" + n$ + "+" + STR$(offset) + ",0," + STR$(udtesize(element) \ 8) + ");"
@@ -2365,7 +2365,7 @@ SUB clear_udt_with_varstrings (n$, udt, buf, base_offset)
                 WriteBufLine buf, "memset((char*)" + n$ + "+" + STR$(offset) + ",0," + STR$(udtesize(element) \ 8) + ");"
             END IF
         ELSEIF udtetype(element) AND ISUDT THEN
-            clear_udt_with_varstrings n$, udtetype(element) AND 511, buf, offset
+            clear_udt_with_varstrings n$, udtetype(element) AND UDTMASK, buf, offset
         ELSE
             WriteBufLine buf, "memset((char*)" + n$ + "+" + STR$(offset) + ",0," + STR$(udtesize(element) \ 8) + ");"
         END IF
@@ -2395,7 +2395,7 @@ SUB clear_array_udt_varstrings (n$, udt, base_offset, bytesperelement$, acc$)
             ELSEIF udtetype(element) AND ISUDT THEN
                 FOR array_i = 0 TO udtearrayelements(element) - 1
                     array_offset = offset + array_i * elem_bytes
-                    clear_array_udt_varstrings n$, udtetype(element) AND 511, array_offset, bytesperelement$, acc$
+                    clear_array_udt_varstrings n$, udtetype(element) AND UDTMASK, array_offset, bytesperelement$, acc$
                 NEXT
             ELSE
                 acc$ = acc$ + CHR$(13) + CHR$(10) + "memset((void*)(" + n$ + "[0]+" + bytesperelement$ + "*tmp_long+" + STR$(offset) + "),0," + STR$(udtesize(element) \ 8) + ");"
@@ -2407,7 +2407,7 @@ SUB clear_array_udt_varstrings (n$, udt, base_offset, bytesperelement$, acc$)
                 acc$ = acc$ + CHR$(13) + CHR$(10) + "memset((void*)(" + n$ + "[0]+" + bytesperelement$ + "*tmp_long+" + STR$(offset) + "),0," + STR$(udtesize(element) \ 8) + ");"
             END IF
         ELSEIF udtetype(element) AND ISUDT THEN
-            clear_array_udt_varstrings n$, udtetype(element) AND 511, offset, bytesperelement$, acc$
+            clear_array_udt_varstrings n$, udtetype(element) AND UDTMASK, offset, bytesperelement$, acc$
         ELSE
             acc$ = acc$ + CHR$(13) + CHR$(10) + "memset((void*)(" + n$ + "[0]+" + bytesperelement$ + "*tmp_long+" + STR$(offset) + "),0," + STR$(udtesize(element) \ 8) + ");"
         END IF
@@ -2430,7 +2430,7 @@ SUB initialise_array_udt_varstrings (n$, udt, base_offset, bytesperelement$, acc
                         acc$ = acc$ + CHR$(13) + CHR$(10) + "*(qbs**)(" + n$ + "[0]+" + bytesperelement$ + "*tmp_long+" + STR$(array_offset) + ")=qbs_new(0,0);"
                     END IF
                 ELSEIF udtetype(element) AND ISUDT THEN
-                    initialise_array_udt_varstrings n$, udtetype(element) AND 511, array_offset, bytesperelement$, acc$
+                    initialise_array_udt_varstrings n$, udtetype(element) AND UDTMASK, array_offset, bytesperelement$, acc$
                 END IF
             NEXT
         ELSEIF udtetype(element) AND ISSTRING THEN
@@ -2438,7 +2438,7 @@ SUB initialise_array_udt_varstrings (n$, udt, base_offset, bytesperelement$, acc
                 acc$ = acc$ + CHR$(13) + CHR$(10) + "*(qbs**)(" + n$ + "[0]+" + bytesperelement$ + "*tmp_long+" + STR$(offset) + ")=qbs_new(0,0);"
             END IF
         ELSEIF udtetype(element) AND ISUDT THEN
-            initialise_array_udt_varstrings n$, udtetype(element) AND 511, offset, bytesperelement$, acc$
+            initialise_array_udt_varstrings n$, udtetype(element) AND UDTMASK, offset, bytesperelement$, acc$
         END IF
         offset = offset + udtesize(element) \ 8
         element = udtenext(element)
@@ -2462,7 +2462,7 @@ SUB free_array_udt_varstrings (n$, udt, base_offset, bytesperelement$, acc$)
                         acc$ = acc$ + CHR$(13) + CHR$(10) + "qbs_free(*(qbs**)(" + n$ + "[0]+" + bytesperelement$ + "*tmp_long+" + STR$(array_offset) + "));"
                     END IF
                 ELSEIF udtetype(element) AND ISUDT THEN
-                    free_array_udt_varstrings n$, udtetype(element) AND 511, array_offset, bytesperelement$, acc$
+                    free_array_udt_varstrings n$, udtetype(element) AND UDTMASK, array_offset, bytesperelement$, acc$
                 END IF
             NEXT
         ELSEIF udtetype(element) AND ISSTRING THEN
@@ -2470,7 +2470,7 @@ SUB free_array_udt_varstrings (n$, udt, base_offset, bytesperelement$, acc$)
                 acc$ = acc$ + CHR$(13) + CHR$(10) + "qbs_free(*(qbs**)(" + n$ + "[0]+" + bytesperelement$ + "*tmp_long+" + STR$(offset) + "));"
             END IF
         ELSEIF udtetype(element) AND ISUDT THEN
-            free_array_udt_varstrings n$, udtetype(element) AND 511, offset, bytesperelement$, acc$
+            free_array_udt_varstrings n$, udtetype(element) AND UDTMASK, offset, bytesperelement$, acc$
         END IF
         offset = offset + udtesize(element) \ 8
         element = udtenext(element)
@@ -2493,10 +2493,10 @@ SUB copy_full_udt (dst$, src$, buf, base_offset, udt)
                     WriteBufLine buf, "qbs_set(*(qbs**)(" + dst$ + "+" + STR$(array_offset) + "), *(qbs**)(" + src$ + "+" + STR$(array_offset) + "));"
                 NEXT
             ELSEIF ((udtetype(element) AND ISUDT) > 0) THEN
-                IF udtxvariable(udtetype(element) AND 511) THEN
+                IF udtxvariable(udtetype(element) AND UDTMASK) THEN
                     FOR array_i = 0 TO udtearrayelements(element) - 1
                         array_offset = offset + array_i * elem_bytes
-                        copy_full_udt dst$, src$, buf, array_offset, udtetype(element) AND 511
+                        copy_full_udt dst$, src$, buf, array_offset, udtetype(element) AND UDTMASK
                     NEXT
                 ELSE
                     WriteBufLine buf, "memcpy((" + dst$ + "+" + STR$(offset) + "),(" + src$ + "+" + STR$(offset) + ")," + STR$(udtesize(element) \ 8) + ");"
@@ -2507,7 +2507,7 @@ SUB copy_full_udt (dst$, src$, buf, base_offset, udt)
         ELSEIF ((udtetype(element) AND ISSTRING) > 0) AND (udtetype(element) AND ISFIXEDLENGTH) = 0 THEN
             WriteBufLine buf, "qbs_set(*(qbs**)(" + dst$ + "+" + STR$(offset) + "), *(qbs**)(" + src$ + "+" + STR$(offset) + "));"
         ELSEIF ((udtetype(element) AND ISUDT) > 0) THEN
-            copy_full_udt dst$, src$, buf, offset, udtetype(element) AND 511
+            copy_full_udt dst$, src$, buf, offset, udtetype(element) AND UDTMASK
         ELSE
             WriteBufLine buf, "memcpy((" + dst$ + "+" + STR$(offset) + "),(" + src$ + "+" + STR$(offset) + ")," + STR$(udtesize(element) \ 8) + ");"
         END IF
@@ -2557,7 +2557,7 @@ SUB copy_dyn_udt_scalars (dst$, src$, buf, base_offset, udt, layout_mode AS LONG
             'Descriptor slots are handled by AppendDynUDTDescCopy(). Do not memcpy them.
         ELSEIF udtearrayelements(member_id&) THEN
             IF (udtetype(member_id&) AND ISUDT) <> 0 THEN
-                nested_udt& = udtetype(member_id&) AND 511
+                nested_udt& = udtetype(member_id&) AND UDTMASK
                 IF udtxvariable(nested_udt&) OR UDTDynHasMemberArrays%(nested_udt&, layout_mode) THEN
                     inline_bytes& = UDTDynInlineElemBytes&(member_id&, layout_mode)
                     FOR arr_idx& = 0 TO udtearrayelements(member_id&) - 1
@@ -2585,7 +2585,7 @@ SUB copy_dyn_udt_scalars (dst$, src$, buf, base_offset, udt, layout_mode AS LONG
         ELSEIF ((udtetype(member_id&) AND ISSTRING) <> 0) AND ((udtetype(member_id&) AND ISFIXEDLENGTH) = 0) THEN
             WriteBufLine buf, "qbs_set(*(qbs**)(" + dst$ + "+" + LTRIM$(STR$(copyoff&)) + "), *(qbs**)(" + src$ + "+" + LTRIM$(STR$(copyoff&)) + "));"
         ELSEIF (udtetype(member_id&) AND ISUDT) <> 0 THEN
-            nested_udt& = udtetype(member_id&) AND 511
+            nested_udt& = udtetype(member_id&) AND UDTMASK
             IF udtxvariable(nested_udt&) THEN
                 static_copy$ = ""
                 AppendDynUDTOwnSetAt dst$, src$, nested_udt&, copyoff&, copyoff&, LTRIM$(STR$(UDTDynMemberSize&(member_id&, layout_mode) \ 8)), "0", "0", static_copy$, layout_mode
@@ -2727,7 +2727,7 @@ FUNCTION Type_StripContextFlags& (typeId AS LONG)
 END FUNCTION
 
 FUNCTION Type_GetSizeInBits~& (typeId AS LONG)
-    Type_GetSizeInBits = typeId AND 511
+    Type_GetSizeInBits = typeId AND UDTMASK
 END FUNCTION
 
 FUNCTION Type_IsString%% (typeId AS LONG)

--- a/source/utilities/type.bi
+++ b/source/utilities/type.bi
@@ -1,4 +1,11 @@
 
+'Width of the low bit-field of an encoded type id. For primitives it holds the
+'size in bits (max 256); when ISUDT is set it holds the UDT index. Bits above
+'this mask up to ISOFFSET (bit 20) are unused, so the field can grow to &HFFFFF
+'if ever needed. Was 511 (9 bits), which silently aliased user-defined TYPEs
+'past #511; TYPE registration now errors out honestly at UDTMASK.
+CONST UDTMASK = 4095
+
 DIM SHARED ISSTRING AS LONG
 DIM SHARED ISFLOAT AS LONG
 DIM SHARED ISUNSIGNED AS LONG


### PR DESCRIPTION
Related: #745 (same discovery session; independent change — this does not depend on #746).

## Problem

User-defined TYPEs are silently capped at **511**. The low bit-field of an encoded type id (`AND 511`) holds either a primitive's size in bits or, when `ISUDT` is set, the UDT index. The `udtx*` storage tables grow automatically (`increaseUDTArrays`), so nothing stops you *defining* TYPE #512 — but every `AS Type512` reference encodes as `ISUDT + 512`, and `512 AND 511 = 0` aliases it to the wrong slot. Depending on what lives there, this surfaces as "Element not defined", "Invalid expression", or **silent wrong-type codegen**, with no diagnostic pointing at the real cause. Large data-driven programs do hit this (ours has ~500 TYPEs across 190K LOC).

## Why this is a small change

All `IS*` flags start at bit 20 (`ISOFFSET = 2^20`), and bits 9–19 of the type word are **unused** — the index field can widen without moving a single flag constant. Primitive sizes max out at 256 bits (`FLOATTYPE`), so a wider extraction mask is value-neutral for non-UDT types.

## What this PR does

- Adds `CONST UDTMASK = 4095` (12 bits → 4,095 TYPEs; documented headroom to `&HFFFFF` if ever needed) in `source/utilities/type.bi`.
- Replaces every low-field extraction (`AND 511`, plus the composite masks like `AND (ISFLOAT + ISUDT + 511 + ...)`) with `UDTMASK` across `qb64pe.bas`, `utilities/type.bas`, and `ide/ide_methods.bas` — 280 occurrences, byte-level replace, no other content touched.
- Adds an explicit compile error — `Too many user-defined types (maximum 4095)` — at TYPE registration, so exceeding the (new) cap is an honest diagnostic instead of silent aliasing.

Write sites need no change: type words are built as `ISUDT + index`, which already carries indexes up to 2^20 uncorrupted; only the read masks truncated. The runtime's own `& 511` sites in `libqb.cpp` all operate on `qbs_input_variabletypes`, which never carries UDT-indexed words (UDTs cannot be `INPUT`/`READ` targets), so no runtime change is needed.

## Verification

- Generated torture program: 600 TYPEs, with types #512+ exercised through scalars, nested UDTs, static and dynamic arrays (incl. `REDIM _PRESERVE`), member arrays with `LBOUND`/`UBOUND`, fixed-string members, and `_MEM`/`_MEMGET`. Unpatched compiler: fails with `Element not defined` at the first `v512.a` reference. Patched compiler: compiles; all runtime assertions pass. Happy to attach the generator script.
- A real-world 190K-LOC / ~500-TYPE / ~3,500-routine project compiles cleanly with the patched compiler and passes its full test suite (42/42).

Functionally the same patch was validated on v4.5.0 sources; this branch applies it to current `main` (the idiom is unchanged, occurrence count differs).
