### PR TITLE
Updated to automatically include qb64pe compatibility library

### DIFF
--- a/source/ide/ide_methods.bas
+++ b/source/ide/ide_methods.bas
@@ -14404,6 +14404,8 @@ SUB ideQBJSBuildBox
             IF _FILEEXISTS(tempSrcFile$) THEN KILL tempSrcFile$
             OPEN tempSrcFile$ FOR BINARY AS #150
             IF INSTR(_OS$, "WIN") THEN LineEnding$ = CHR$(13) + CHR$(10) ELSE LineEnding$ = CHR$(10)
+            peInclude$ = "'$Include: 'lib/compatibility/qb64pe.bi'" + LineEnding$
+            PUT #150, , peInclude$
             FOR i = 1 TO iden
                 outfile$ = idegetline(i) + LineEnding$
                 PUT #150, , outfile$


### PR DESCRIPTION
I originally considered adding an option to enable/disable including the [QB64PE compatibility library](https://github.com/boxgaming/qbjs/wiki/Supported-Keywords#qb64pe-keywords), but I think it probably makes more sense in this context to just automatically include it.