### PR TITLE
Add QB64PE_NOPROMPT

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,6 +28,13 @@ sure the test output ends with the last meaningful line.
 Tests can also have an optional `*.flags` file. The contents of this file will
 be provide as command line arguments to QB64-PE when compiling the test source.
 
+The tests run with `QB64PE_NOPROMPT=y` set, this ensures that any unhandled or
+critical errors do not prompt and wait for input (which would hang the test
+runner). To change this behavior tests can have an optional `*.noprompt` file,
+the contents of this file will be provided as the value of `QB64PE_NOPROMPT`
+when running the test executable. This is mostly useful for testing the
+'Continue' behavior.
+
 Tests are compiled from the directory the `.bas` file is in. That is, they are
 compiled as though the user `cd`'d into the directory the `.bas` file is in,
 and then ran the compiler from that starting location to compile the `.bas`. If

--- a/internal/c/libqb/src/error_handle.cpp
+++ b/internal/c/libqb/src/error_handle.cpp
@@ -292,6 +292,73 @@ static void exit_after_fatal_error() {
     libqb_exit(0);
 }
 
+// QB64PE_NOPROMPT suppresses the dialogs that report a runtime error, which
+// avoids the need to interactively interact with the program on unhandled
+// errors.
+//
+//   =y              Reports to stderr and does not prompt, then exits.
+//
+//   =Continue       Reports to stderr and does not prompt, then for
+//                   non-critical errors we will continue to the next line.
+//
+//   unset or other  Reports and prompts as usual
+//
+// A critical error ends the program under either y or continue.
+enum noprompt_mode { NOPROMPT_NONE, NOPROMPT_UNSET, NOPROMPT_STOP, NOPROMPT_CONTINUE };
+
+static noprompt_mode noprompt_setting() {
+    static int cached = NOPROMPT_NONE;
+
+    if (cached == NOPROMPT_NONE) {
+        const char *value = getenv("QB64PE_NOPROMPT");
+
+        if (!value)
+            cached = NOPROMPT_UNSET;
+        else if (*value == 'Y' || *value == 'y')
+            cached = NOPROMPT_STOP;
+#if defined(_MSC_VER) || defined(__DMC__)
+        else if (_stricmp(value, "continue") == 0)
+#else
+        else if (strcasecmp(value, "continue") == 0)
+#endif
+            cached = NOPROMPT_CONTINUE;
+        else
+            cached = NOPROMPT_UNSET;
+    }
+
+    return (noprompt_mode)cached;
+}
+
+static bool noprompt_on_fatal_error() {
+    return noprompt_setting() != NOPROMPT_UNSET;
+}
+
+// Report a fatal error and waits for the user to acknowledge it. 
+// Respects the QB64PE_NOPROMPT setting if set.
+static void fatal_error_alert(const char *message, const char *title) {
+    if (!noprompt_on_fatal_error()) {
+        gui_alert(message, title, "ok");
+        return;
+    }
+    fprintf(stderr, "\nRuntime error: %s\n", message);
+    fflush(stderr);
+}
+
+// Report an unhandled error and ask whether to carry on regardless. Returns the
+// same values gui_alert's "yesno" does.
+//
+// Respects the QB64PE_NOPROMPT setting
+static int unhandled_error_alert(const char *message, const char *title) {
+    noprompt_mode mode = noprompt_setting();
+
+    if (mode == NOPROMPT_UNSET)
+        return gui_alert(message, title, "yesno");
+
+    fprintf(stderr, "\nRuntime error: %s\n", message);
+    fflush(stderr);
+    return mode == NOPROMPT_CONTINUE ? 1 : 2; // "yes" : "no"
+}
+
 extern void QBMAIN(void *);
 
 void fix_error() {
@@ -323,14 +390,14 @@ void fix_error() {
 #define FIXERRMSG_CRIT "Critical Error #"
 
         len = snprintf(errmess, 0, FIXERRMSG_BODY, (inclercl ? inclercl : ercl), (inclercl ? includedfilename : FIXERRMSG_MAINFILE), cp,
-                       (!prevent_handling ? FIXERRMSG_CONT : ""));
+                       ((!prevent_handling && !noprompt_on_fatal_error()) ? FIXERRMSG_CONT : ""));
         errmess = (char *)malloc(len + 1);
         if (!errmess) {
             exit_after_fatal_error(); // At this point we just give up
             return;
         }
         snprintf(errmess, len + 1, FIXERRMSG_BODY, (inclercl ? inclercl : ercl), (inclercl ? includedfilename : FIXERRMSG_MAINFILE), cp,
-                 (!prevent_handling ? FIXERRMSG_CONT : ""));
+                 ((!prevent_handling && !noprompt_on_fatal_error()) ? FIXERRMSG_CONT : ""));
 
         len = snprintf(errtitle, 0, FIXERRMSG_TITLE, (!prevent_handling ? FIXERRMSG_UNHAND : FIXERRMSG_CRIT), new_error, binary_name->chr);
         errtitle = (char *)malloc(len + 1);
@@ -341,11 +408,11 @@ void fix_error() {
         snprintf(errtitle, len + 1, FIXERRMSG_TITLE, (!prevent_handling ? FIXERRMSG_UNHAND : FIXERRMSG_CRIT), new_error, binary_name->chr);
 
         if (prevent_handling) {
-            v = gui_alert(errmess, errtitle, "ok");
+            fatal_error_alert(errmess, errtitle);
             exit_after_fatal_error();
             return;
         } else {
-            v = gui_alert(errmess, errtitle, "yesno");
+            v = unhandled_error_alert(errmess, errtitle);
         }
 
         if ((v == 2) || (v == 0)) {
@@ -391,7 +458,7 @@ void error(int32_t error_number) {
             snprintf(errmess, sizeof(errmess), "Out of memory\nEnable $ErrorLocation:ON for source location details.");
 
         snprintf(errtitle, sizeof(errtitle), "Critical Error #%d", critical_number);
-        gui_alert(errmess, errtitle, "ok");
+        fatal_error_alert(errmess, errtitle);
         exit_after_fatal_error();
         return;
     }
@@ -424,7 +491,7 @@ void error(int32_t error_number) {
     }
 
     if (critical_message) {
-        gui_alert(critical_error_message(critical_message), "Critical Error", "ok");
+        fatal_error_alert(critical_error_message(critical_message), "Critical Error");
         exit_after_fatal_error();
         return;
     }

--- a/tests/compile_tests.sh
+++ b/tests/compile_tests.sh
@@ -132,6 +132,14 @@ do
         checkLicense=y
     fi
 
+    # A .noprompt file overrides the QB64PE_NOPROMPT value used when running this
+    # test. The default stops the program at an unhandled error; a test that needs
+    # the 'continue' behavior can put "Continue" in this file to get it.
+    nopromptValue=y
+    if test -f "./tests/compile_tests/$category/$testName.noprompt"; then
+        nopromptValue=$(cat "./tests/compile_tests/$category/$testName.noprompt")
+    fi
+
     # If the "compile-from-base" file exists, then this test should be compiled
     # from the ./qb64pe directory instead of the test directory
     compileFromBase=
@@ -181,6 +189,7 @@ do
 
         pushd . > /dev/null
         cd "./tests/compile_tests/$category"
+        QB64PE_NOPROMPT="$nopromptValue" \
         QB64PE_LOG_HANDLERS=file \
         QB64PE_LOG_SCOPES="qb64,libqb,libqb-image,libqb-audio" \
         QB64PE_LOG_FILE_PATH="../../../$RESULTS_DIR/$category-$testName-log.txt" \

--- a/tests/compile_tests/noprompt/noprompt-continue-fatal.bas
+++ b/tests/compile_tests/noprompt/noprompt-continue-fatal.bas
@@ -1,0 +1,7 @@
+$CONSOLE:ONLY
+
+' QB64PE_NOPROMPT=Continue cannot continue past a fatal error
+PRINT 1 \ 0
+PRINT "We should not reach this line"
+
+SYSTEM

--- a/tests/compile_tests/noprompt/noprompt-continue-fatal.noprompt
+++ b/tests/compile_tests/noprompt/noprompt-continue-fatal.noprompt
@@ -1,0 +1,1 @@
+Continue

--- a/tests/compile_tests/noprompt/noprompt-continue-fatal.output
+++ b/tests/compile_tests/noprompt/noprompt-continue-fatal.output
@@ -1,0 +1,3 @@
+
+Runtime error: Division by zero
+Enable $ErrorLocation:ON for source location details.

--- a/tests/compile_tests/noprompt/noprompt-continue.bas
+++ b/tests/compile_tests/noprompt/noprompt-continue.bas
@@ -1,0 +1,8 @@
+$CONSOLE:ONLY
+
+' We set 'Continue' behavior via QB64PE_NOPROMPT=Continue, this should allow
+' the program to continue past the ERROR 100
+ERROR 100
+PRINT "This line should print."
+
+SYSTEM

--- a/tests/compile_tests/noprompt/noprompt-continue.noprompt
+++ b/tests/compile_tests/noprompt/noprompt-continue.noprompt
@@ -1,0 +1,1 @@
+Continue

--- a/tests/compile_tests/noprompt/noprompt-continue.output
+++ b/tests/compile_tests/noprompt/noprompt-continue.output
@@ -1,0 +1,4 @@
+
+Runtime error: Line: 5 (in main module)
+Unprintable error
+This line should print.

--- a/tests/compile_tests/noprompt/noprompt-y.bas
+++ b/tests/compile_tests/noprompt/noprompt-y.bas
@@ -1,0 +1,8 @@
+$CONSOLE:ONLY
+
+' With QB64PE_NOPROMPT=y, the ERROR 100 should exit the program without waiting
+' for any input
+ERROR 100
+PRINT "This line should not appear"
+
+SYSTEM

--- a/tests/compile_tests/noprompt/noprompt-y.output
+++ b/tests/compile_tests/noprompt/noprompt-y.output
@@ -1,0 +1,3 @@
+
+Runtime error: Line: 5 (in main module)
+Unprintable error


### PR DESCRIPTION
This give a way to tell the runtime that unhandled errors should not bring up an interactive prompt. The output text appears the same as with the prompt, but we do not wait for input and instead use the indicated action:

QB64PE_NOPROMPT=y
QB64PE_NOPROMPT=Continue

Both trigger their corresponding options on the dialog, 'y' exits the program on an unhandled error, 'continue' lets the program continue past it to the next line.

Tests will normally run with `y` so that unhandled errors cannot hang the test runner. I also added logic to the test scripts where a .noprompt file lets a tests configure the value (so it can test the 'continue' option).