### PR TITLE
Store qbs* array elements in pointer-sized slots on each platform

### DIFF
--- a/source/qb64pe.bas
+++ b/source/qb64pe.bas
@@ -8546,7 +8546,13 @@ DO
                 n$ = RTRIM$(id.callname)
                 bytesperelement$ = _TOSTR$((id.arraytype AND UDTMASK) \ 8)
                 udt = 0
-                IF id.arraytype AND ISSTRING THEN bytesperelement$ = _TOSTR$(id.tsize)
+                IF id.arraytype AND ISSTRING THEN
+                    IF id.arraytype AND ISFIXEDLENGTH THEN
+                        bytesperelement$ = _TOSTR$(id.tsize)
+                    ELSE
+                        bytesperelement$ = _TOSTR$(TARGET_BITS \ 8)
+                    END IF
+                END IF
                 IF id.arraytype AND ISOFFSETINBITS THEN bytesperelement$ = _TOSTR$((id.arraytype AND UDTMASK)) + "/8+1"
                 IF id.arraytype AND ISUDT THEN
                     udt = id.arraytype AND UDTMASK
@@ -8583,7 +8589,7 @@ DO
                     NEXT
                     WriteBufLineCpp MainTxtBuf, ";"
                     WriteBufLineCpp MainTxtBuf, "while(tmp_long--){"
-                    WriteBufLineCpp MainTxtBuf, "((qbs*)(((uint64*)(" + n$ + "[0]))[tmp_long]))->len=0;"
+                    WriteBufLineCpp MainTxtBuf, "(((qbs**)(" + n$ + "[0]))[tmp_long])->len=0;"
                     WriteBufLineCpp MainTxtBuf, "}"
                 ELSEIF udt > 0 AND udtxvariable(udt) AND NOT (id.dynudt AND UDTDynHasMemberArrays%(udt, id.dynudtmode)) THEN
                     ' Static arrays of UDTs must clear nested variable members element-by-element.
@@ -8619,7 +8625,7 @@ DO
                     NEXT
                     WriteBufLineCpp MainTxtBuf, ";"
                     WriteBufLineCpp MainTxtBuf, "while(tmp_long--){"
-                    WriteBufLineCpp MainTxtBuf, "qbs_free((qbs*)(((uint64*)(" + n$ + "[0]))[tmp_long]));"
+                    WriteBufLineCpp MainTxtBuf, "qbs_free(((qbs**)(" + n$ + "[0]))[tmp_long]);"
                     WriteBufLineCpp MainTxtBuf, "}"
                     'free memory
                     WriteBufLineCpp MainTxtBuf, "free((void*)(" + n$ + "[0]));"
@@ -13245,7 +13251,7 @@ FOR x = 1 TO commonarraylistn
             WriteBufLineCpp MainTxtBuf, "bytei=0;"
             WriteBufLineCpp MainTxtBuf, "while(bytei<bytes){"
             WriteBufLineCpp MainTxtBuf, "sub_get(FF,NULL,byte_element((uint64)&int64val,8," + NewByteElement$ + "),0);" 'get size
-            WriteBufLineCpp MainTxtBuf, "tqbs=((qbs*)(((uint64*)(" + n2$ + "[0]))[bytei]));" 'get element
+            WriteBufLineCpp MainTxtBuf, "tqbs=((qbs**)(" + n2$ + "[0]))[bytei];" 'get element
             WriteBufLineCpp MainTxtBuf, "qbs_set(tqbs,qbs_new(int64val>>3,1));" 'change string size
             WriteBufLineCpp MainTxtBuf, "sub_get(FF,NULL,byte_element((uint64)tqbs->chr,int64val>>3," + NewByteElement$ + "),0);" 'get size
             WriteBufLineCpp MainTxtBuf, "bytei++;"
@@ -13325,7 +13331,7 @@ FOR x = 1 TO commonarraylistn
 
             WriteBufLineCpp MainTxtBuf, "bytei=0;"
             WriteBufLineCpp MainTxtBuf, "while(bytei<bytes){"
-            WriteBufLineCpp MainTxtBuf, "tqbs=((qbs*)(((uint64*)(" + n2$ + "[0]))[bytei]));" 'get element
+            WriteBufLineCpp MainTxtBuf, "tqbs=((qbs**)(" + n2$ + "[0]))[bytei];" 'get element
             WriteBufLineCpp MainTxtBuf, "int64val=tqbs->len; int64val<<=3;"
             WriteBufLineCpp MainTxtBuf, "sub_put(FF,NULL,byte_element((uint64)&int64val,8," + NewByteElement$ + "),0);" 'size of element
             WriteBufLineCpp MainTxtBuf, "sub_put(FF,NULL,byte_element((uint64)tqbs->chr,tqbs->len," + NewByteElement$ + "),0);" 'element data
@@ -14683,7 +14689,7 @@ FUNCTION allocarray (n2$, elements$, elementsize, udt)
     'added 4 to [2] to indicate cmem array where appropriate
 
     e$ = elements$: n$ = n2$
-    IF elementsize = -2147483647 THEN stringarray = 1: elementsize = 8
+    IF elementsize = -2147483647 THEN stringarray = 1: elementsize = TARGET_BITS \ 8
 
     IF ASC(e$) = 63 THEN '?
         l$ = "(" + sp2 + ")"
@@ -14916,9 +14922,9 @@ FUNCTION allocarray (n2$, elements$, elementsize, udt)
                 WriteBufLineCpp DataTxtBuf, "tmp_long=" + elesizestr$ + ";"
                 WriteBufLineCpp DataTxtBuf, "while(tmp_long--){"
                 IF cmem THEN
-                    WriteBufLineCpp DataTxtBuf, "((uint64*)(" + n$ + "[0]))[tmp_long]=(uint64)qbs_new_cmem(0,0);"
+                    WriteBufLineCpp DataTxtBuf, "((qbs**)(" + n$ + "[0]))[tmp_long]=qbs_new_cmem(0,0);"
                 ELSE
-                    WriteBufLineCpp DataTxtBuf, "((uint64*)(" + n$ + "[0]))[tmp_long]=(uint64)qbs_new(0,0);"
+                    WriteBufLineCpp DataTxtBuf, "((qbs**)(" + n$ + "[0]))[tmp_long]=qbs_new(0,0);"
                 END IF
                 WriteBufLineCpp DataTxtBuf, "}"
             ELSE
@@ -15079,9 +15085,9 @@ FUNCTION allocarray (n2$, elements$, elementsize, udt)
                     'init individual strings / var-len UDT members in the NEW array
                     IF stringarray THEN
                         WriteBufLine f12Buf%, "if (" + n$ + "[2]&4){" 'array/string content in cmem
-                        WriteBufLine f12Buf%, "while(tmp_long--) ((uint64*)(" + n$ + "[0]))[tmp_long]=(uint64)qbs_new_cmem(0,0);"
+                        WriteBufLine f12Buf%, "while(tmp_long--) ((qbs**)(" + n$ + "[0]))[tmp_long]=qbs_new_cmem(0,0);"
                         WriteBufLine f12Buf%, "}else{" 'not in cmem
-                        WriteBufLine f12Buf%, "while(tmp_long--) ((uint64*)(" + n$ + "[0]))[tmp_long]=(uint64)qbs_new(0,0);"
+                        WriteBufLine f12Buf%, "while(tmp_long--) ((qbs**)(" + n$ + "[0]))[tmp_long]=qbs_new(0,0);"
                         WriteBufLine f12Buf%, "}" 'not in cmem
                     ELSE
                         WriteBufLine f12Buf%, "ZeroMemory((uint8*)(" + n$ + "[0]),tmp_long*" + bytesperelement$ + ");"
@@ -15095,7 +15101,7 @@ FUNCTION allocarray (n2$, elements$, elementsize, udt)
                         WriteBufLine f12Buf%, "tmp_long=preserve_copy_count;"
                         WriteBufLine f12Buf%, "while(tmp_long--){"
                         IF stringarray THEN
-                            WriteBufLine f12Buf%, "qbs_set((qbs*)((uint64*)(preserve_new_ptr))[tmp_long],(qbs*)((uint64*)(preserve_old_ptr))[tmp_long]);"
+                            WriteBufLine f12Buf%, "qbs_set(((qbs**)(preserve_new_ptr))[tmp_long],((qbs**)(preserve_old_ptr))[tmp_long]);"
                         ELSE
                             acc$ = ""
                             copy_preserve_udt_varstrings "preserve_new_ptr", "preserve_old_ptr", udt, "(tmp_long*" + bytesperelement$ + ")", "(tmp_long*" + bytesperelement$ + ")", acc$
@@ -15119,7 +15125,7 @@ FUNCTION allocarray (n2$, elements$, elementsize, udt)
                         NEXT
 
                         IF stringarray THEN
-                            WriteBufLine f12Buf%, "qbs_set((qbs*)((uint64*)(preserve_new_ptr))[preserve_new_off],(qbs*)((uint64*)(preserve_old_ptr))[preserve_old_off]);"
+                            WriteBufLine f12Buf%, "qbs_set(((qbs**)(preserve_new_ptr))[preserve_new_off],((qbs**)(preserve_old_ptr))[preserve_old_off]);"
                         ELSE
                             acc$ = ""
                             copy_preserve_udt_varstrings "preserve_new_ptr", "preserve_old_ptr", udt, "(preserve_new_off*" + bytesperelement$ + ")", "(preserve_old_off*" + bytesperelement$ + ")", acc$
@@ -15141,7 +15147,7 @@ FUNCTION allocarray (n2$, elements$, elementsize, udt)
                     'free OLD array content and OLD raw block
                     IF stringarray THEN
                         WriteBufLine f12Buf%, "tmp_long=preserve_old_total;"
-                        WriteBufLine f12Buf%, "while(tmp_long--) qbs_free((qbs*)((uint64*)(preserve_old_ptr))[tmp_long]);"
+                        WriteBufLine f12Buf%, "while(tmp_long--) qbs_free(((qbs**)(preserve_old_ptr))[tmp_long]);"
                         WriteBufLine f12Buf%, "free((void*)(preserve_old_ptr));"
                     ELSE
                         WriteBufLine f12Buf%, n$ + "[0]=preserve_old_ptr;"
@@ -15167,9 +15173,9 @@ FUNCTION allocarray (n2$, elements$, elementsize, udt)
                 'init individual strings
                 IF stringarray THEN
                     WriteBufLine f12Buf%, "if (" + n$ + "[2]&4){" 'array is in cmem
-                    WriteBufLine f12Buf%, "while(tmp_long--) ((uint64*)(" + n$ + "[0]))[tmp_long]=(uint64)qbs_new_cmem(0,0);"
+                    WriteBufLine f12Buf%, "while(tmp_long--) ((qbs**)(" + n$ + "[0]))[tmp_long]=qbs_new_cmem(0,0);"
                     WriteBufLine f12Buf%, "}else{" 'not in cmem
-                    WriteBufLine f12Buf%, "while(tmp_long--) ((uint64*)(" + n$ + "[0]))[tmp_long]=(uint64)qbs_new(0,0);"
+                    WriteBufLine f12Buf%, "while(tmp_long--) ((qbs**)(" + n$ + "[0]))[tmp_long]=qbs_new(0,0);"
                     WriteBufLine f12Buf%, "}" 'not in cmem
                 ELSE 'initialise udt's
                     WriteBufLine f12Buf%, "ZeroMemory((uint8*)(" + n$ + "[0]),tmp_long*" + bytesperelement$ + ");"
@@ -15194,7 +15200,7 @@ FUNCTION allocarray (n2$, elements$, elementsize, udt)
                         free_array_udt_varstrings n$, udt, 0, bytesperelement$, acc$
                         WriteBufLine FreeTxtBuf, acc$ + "}"
                     ELSE
-                        WriteBufLine FreeTxtBuf, "while(tmp_long--) qbs_free((qbs*)((uint64*)(" + n$ + "[0]))[tmp_long]);"
+                        WriteBufLine FreeTxtBuf, "while(tmp_long--) qbs_free(((qbs**)(" + n$ + "[0]))[tmp_long]);"
                     END IF
                     WriteBufLine FreeTxtBuf, "free((void*)(" + n$ + "[0]));"
                     WriteBufLine FreeTxtBuf, "}"
@@ -17299,7 +17305,7 @@ SUB AppendWholeArrayAssign (dstarr AS STRING, srcarr AS STRING, arrtyp AS LONG, 
             WriteBufLine MainTxtBuf, "if (!is_error_pending()) memmove((void*)whole_arr_dst[0],(void*)whole_arr_src[0],(size_t)(whole_arr_total*(uint64)" + elemtext + "));"
         ELSE
             WriteBufLine MainTxtBuf, "for(ptrszint whole_arr_i=0; whole_arr_i<(ptrszint)whole_arr_total; whole_arr_i++){"
-            WriteBufLine MainTxtBuf, "qbs_set((qbs*)(((uint64*)whole_arr_dst[0])[whole_arr_i]),(qbs*)(((uint64*)whole_arr_src[0])[whole_arr_i]));"
+            WriteBufLine MainTxtBuf, "qbs_set(((qbs**)whole_arr_dst[0])[whole_arr_i],((qbs**)whole_arr_src[0])[whole_arr_i]);"
             WriteBufLine MainTxtBuf, "}"
         END IF
     ELSE
@@ -25678,7 +25684,7 @@ FUNCTION refer$ (a2$, typ AS LONG, method AS LONG)
                 offset$ = "&((uint8*)(" + n$ + "[0]))[(" + a$ + ")*" + _TOSTR$(id.tsize) + "]"
                 r$ = "qbs_new_fixed(" + offset$ + "," + _TOSTR$(id.tsize) + ",1)"
             ELSE
-                r$ = "((qbs*)(((uint64*)(" + n$ + "[0]))[" + a$ + "]))"
+                r$ = "(((qbs**)(" + n$ + "[0]))[" + a$ + "])"
             END IF
             stringprocessinghappened = 1
             refer$ = r$
@@ -26831,10 +26837,10 @@ SUB setrefer (a2$, typ2 AS LONG, e2$, method AS LONG)
             ELSE
                 WriteBufLineCpp MainTxtBuf, "tmp_long=" + a$ + ";"
                 IF method = 0 THEN
-                    l$ = "if (!is_error_pending()) qbs_set( ((qbs*)(((uint64*)(" + n$ + "[0]))[tmp_long]))," + evaluatetotyp(e$, typ) + ");"
+                    l$ = "if (!is_error_pending()) qbs_set( ((qbs**)(" + n$ + "[0]))[tmp_long]," + evaluatetotyp(e$, typ) + ");"
                     IF Error_Happened THEN EXIT SUB
                 ELSE
-                    l$ = "if (!is_error_pending()) qbs_set( ((qbs*)(((uint64*)(" + n$ + "[0]))[tmp_long]))," + e$ + ");"
+                    l$ = "if (!is_error_pending()) qbs_set( ((qbs**)(" + n$ + "[0]))[tmp_long]," + e$ + ");"
                 END IF
                 WriteBufLineCpp MainTxtBuf, l$
             END IF

--- a/source/utilities/type.bas
+++ b/source/utilities/type.bas
@@ -2069,14 +2069,8 @@ END SUB
 FUNCTION udt_dyn_array_elem_bytes& (element)
     IF udtearrayelements(element) = 0 THEN EXIT FUNCTION
 
-    ' Ordinary QB64 string arrays always store each qbs* in one uint64 slot,
-    ' including 32-bit builds. Descriptor-backed _Dynamic AS STRING payloads
-    ' must use the same 8-byte stride so they can be passed directly to a
-    ' normal items() AS STRING parameter. A pointer-sized stride would make
-    ' the parameter index the second element past the allocated payload on
-    ' 32-bit builds and can crash in qbs_set/qbs_free.
     IF DynMemVarStr%(element) THEN
-        udt_dyn_array_elem_bytes& = 8
+        udt_dyn_array_elem_bytes& = TARGET_BITS \ 8
         EXIT FUNCTION
     END IF
 

--- a/tests/compile_tests/arrays/erase_dynamic_string_array_reuse.bas
+++ b/tests/compile_tests/arrays/erase_dynamic_string_array_reuse.bas
@@ -1,0 +1,45 @@
+$CONSOLE:ONLY
+OPTION _EXPLICIT
+
+' Exercises the free/realloc/init cycle for a dynamic array of
+' variable-length strings, where each element is one qbs* slot.
+
+REDIM a(1 TO 3) AS STRING
+a(1) = "red"
+a(2) = "green"
+a(3) = "blue"
+AssertString "before erase", a(2), "green"
+
+REDIM a(1 TO 2) AS STRING
+AssertString "element after redim", a(1), ""
+
+a(1) = "again"
+a(2) = "once more"
+AssertString "assign after redim", a(1), "again"
+AssertString "assign after redim 2", a(2), "once more"
+
+ERASE a
+REDIM a(1 TO 1) ' We can't check for uninitialized arrays, so a REDIM after the ERASE is necessary
+AssertString "erase/redim clears array contents", a(1), ""
+
+REDIM a(0 TO 0) AS STRING
+a(0) = "single"
+AssertString "single element", a(0), "single"
+
+REDIM b(1 TO 4) AS STRING
+b(1) = "one"
+b(4) = "four"
+REDIM _PRESERVE b(1 TO 6) AS STRING
+AssertString "preserve keeps first", b(1), "one"
+AssertString "preserve keeps last", b(4), "four"
+AssertString "preserve clears grown", b(6), ""
+
+b(6) = "six"
+AssertString "grown element usable", b(6), "six"
+
+REDIM _PRESERVE b(1 TO 2) AS STRING
+AssertString "shrink keeps first", b(1), "one"
+
+SYSTEM
+
+'$include:'../utilities/assert.bm'

--- a/tests/compile_tests/arrays/erase_dynamic_string_array_reuse.output
+++ b/tests/compile_tests/arrays/erase_dynamic_string_array_reuse.output
@@ -1,0 +1,11 @@
+PASS:before erase
+PASS:element after redim
+PASS:assign after redim
+PASS:assign after redim 2
+PASS:erase/redim clears array contents
+PASS:single element
+PASS:preserve keeps first
+PASS:preserve keeps last
+PASS:preserve clears grown
+PASS:grown element usable
+PASS:shrink keeps first

--- a/tests/compile_tests/arrays/type_dynamic_string_member_array_param.bas
+++ b/tests/compile_tests/arrays/type_dynamic_string_member_array_param.bas
@@ -1,0 +1,47 @@
+$CONSOLE:ONLY
+$UNSTABLE:TypeFields
+OPTION _EXPLICIT
+
+' A _Dynamic AS STRING member array is handed straight to an ordinary
+' items() AS STRING parameter, so the descriptor payload must match that of an
+' ordinary STRING array.
+
+TYPE Leaf
+    labels(1) _DYNAMIC AS STRING
+    count AS LONG
+END TYPE
+
+DIM work AS Leaf
+REDIM work.labels(1 TO 3)
+work.labels(1) = "red"
+work.labels(2) = "green"
+work.labels(3) = "blue"
+work.count = 3
+
+AssertString "direct 1", work.labels(1), "red"
+AssertString "direct 3", work.labels(3), "blue"
+
+ReadBack work.labels()
+WriteThrough work.labels()
+
+AssertString "after write 1", work.labels(1), "RED"
+AssertString "after write 3", work.labels(3), "BLUE"
+AssertBool "sibling member intact", work.count = 3
+
+SYSTEM
+
+SUB ReadBack (items() AS STRING)
+    AssertString "param lbound", items(LBOUND(items)), "red"
+    AssertString "param 2", items(2), "green"
+    AssertString "param ubound", items(UBOUND(items)), "blue"
+END SUB
+
+SUB WriteThrough (items() AS STRING)
+    DIM i AS LONG
+    FOR i = LBOUND(items) TO UBOUND(items)
+        items(i) = UCASE$(items(i))
+    NEXT
+END SUB
+
+
+'$include:'../utilities/assert.bm'

--- a/tests/compile_tests/arrays/type_dynamic_string_member_array_param.output
+++ b/tests/compile_tests/arrays/type_dynamic_string_member_array_param.output
@@ -1,0 +1,8 @@
+PASS:direct 1
+PASS:direct 3
+PASS:param lbound
+PASS:param 2
+PASS:param ubound
+PASS:after write 1
+PASS:after write 3
+PASS:sibling member intact

--- a/tests/compile_tests/utilities/assert.bm
+++ b/tests/compile_tests/utilities/assert.bm
@@ -1,0 +1,16 @@
+
+SUB AssertString (label AS STRING, actual AS STRING, expected AS STRING)
+    IF actual = expected THEN
+        PRINT "PASS:"; label
+    ELSE
+        PRINT "FAIL:"; label; " expected=["; expected; "] actual=["; actual; "]"
+    END IF
+END SUB
+
+SUB AssertBool (label AS STRING, condition AS LONG)
+    IF condition THEN
+        PRINT "PASS:"; label
+    ELSE
+        PRINT "FAIL:"; label
+    END IF
+END SUB


### PR DESCRIPTION
Previously variable-length STRING arrays were stored in uint64-slots on 64-bit and 32-bit, which was necessary as the generated code in ./internal/source has to compile as both (and offsets into the array are calculated by the QB64-PE compiler and inserted into the C++ code directly).

Now that ./internal/source is only treated as 64-bit this restriction no longer exists and we can simply generate different array offsets for each platform, storing both as arrays of `qbs *` based on the size of `qbs *` for that platform.

The benefit of this is in simplifying the memory-layout - arrays of STRINGs were the only type where the size of their entries in an array were different than the size of that variable declared alone. This is important in preparation for the `mem_layout` stuff I'm working on as it unifies the definition of a STRING inside of arrays vs. outside of arrays, otherwise the difference would have to be part of the layout and exposed to callers.